### PR TITLE
minio bucket name was fixed to 'maxun-test', added option to use custom name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@
 /server/logs
 
 /build
+/start
 
 package-lock.json

--- a/server/src/storage/mino.ts
+++ b/server/src/storage/mino.ts
@@ -9,7 +9,7 @@ const minioClient = new Client({
   secretKey: process.env.MINIO_SECRET_KEY || 'minio-secret-key',
 });
 
-minioClient.bucketExists('maxun-test')
+minioClient.bucketExists(process.env.MINIO_BUCKET || 'maxun-test')
   .then((exists) => {
     if (exists) {
       console.log('MinIO was connected successfully.');
@@ -19,7 +19,8 @@ minioClient.bucketExists('maxun-test')
   })
   .catch((err) => {
     console.error('Error connecting to MinIO:', err);
-  })
+  });
+
 
 async function createBucketWithPolicy(bucketName: string, policy?: 'public-read' | 'private') {
   try {


### PR DESCRIPTION
- In the terminal it was showing Error "Bucket does not exist, but MinIO was connected" (Setting up without docker)
- sample env file did not had a field for adding MinIO bucket name as a parameter, fixed this