### PR TITLE
fix: use `window.location.origin` as baseUrl for scrapeList

### DIFF
--- a/maxun-core/src/browserSide/scraper.js
+++ b/maxun-core/src/browserSide/scraper.js
@@ -283,9 +283,9 @@ function scrapableHeuristics(maxCountPerPage = 50, minArea = 20000, scrolls = 3,
             } else if (attribute === 'innerHTML') {
               record[label] = fieldElement.innerHTML.trim();
             } else if (attribute === 'src') {
-               // Handle relative 'src' URLs
-               const src = fieldElement.getAttribute('src');
-               record[label] = src ? new URL(src, window.location.origin).href : null;
+              // Handle relative 'src' URLs
+              const src = fieldElement.getAttribute('src');
+              record[label] = src ? new URL(src, window.location.origin).href : null;
             } else if (attribute === 'href') {
               // Handle relative 'href' URLs
               const href = fieldElement.getAttribute('href');
@@ -346,5 +346,5 @@ function scrapableHeuristics(maxCountPerPage = 50, minArea = 20000, scrolls = 3,
 
     return results;
   };
-  
+
 })(window);

--- a/maxun-core/src/browserSide/scraper.js
+++ b/maxun-core/src/browserSide/scraper.js
@@ -285,7 +285,7 @@ function scrapableHeuristics(maxCountPerPage = 50, minArea = 20000, scrolls = 3,
             } else if (attribute === 'src') {
                // Handle relative 'src' URLs
                const src = fieldElement.getAttribute('src');
-               record[label] = src ? new URL(src, baseUrl).href : null;
+               record[label] = src ? new URL(src, window.location.origin).href : null;
             } else if (attribute === 'href') {
               // Handle relative 'href' URLs
               const href = fieldElement.getAttribute('href');

--- a/maxun-core/src/browserSide/scraper.js
+++ b/maxun-core/src/browserSide/scraper.js
@@ -289,7 +289,7 @@ function scrapableHeuristics(maxCountPerPage = 50, minArea = 20000, scrolls = 3,
             } else if (attribute === 'href') {
               // Handle relative 'href' URLs
               const href = fieldElement.getAttribute('href');
-              record[label] = href ? new URL(href, baseUrl).href : null;
+              record[label] = href ? new URL(href, window.location.origin).href : null;
             } else {
               record[label] = fieldElement.getAttribute(attribute);
             }


### PR DESCRIPTION
fixes #227 