### PR TITLE
fix: skip click action if selector not visible

### DIFF
--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -506,7 +506,11 @@ export default class Interpreter extends EventEmitter {
           try {
             await executeAction(invokee, methodName, step.args);
           } catch (error) {
-            await executeAction(invokee, methodName, [step.args[0], { force: true }]);
+            try{
+              await executeAction(invokee, methodName, [step.args[0], { force: true }]);
+            } catch (error) {
+              continue
+            }
           }
         } else {
           await executeAction(invokee, methodName, step.args);


### PR DESCRIPTION
Popups visible only for a certain duration on the page can not be clicked on. If click and force click actions fail then continue as the selector is not visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for action execution, allowing workflows to continue despite failures.
	- Improved resilience in the `click` action with a retry mechanism.
	- Updated handling in the `getSelectors` method to return an empty array for empty workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->