### PR TITLE
feat: add output preview data reset functionality 

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -250,6 +250,7 @@
     "interpretation_buttons": {
         "buttons": {
             "preview": "Vorschau der Ausgabedaten anzeigen",
+            "reset": "Zurücksetzen",
             "yes": "Ja",
             "no": "Nein"
         },

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -245,6 +245,9 @@
             "mimetype": "Medientyp: ",
             "image_below": "Bild wird unten angezeigt:",
             "separator": "--------------------------------------------------"
+        },
+        "notifications": {
+            "reset_success": "Vorschau erfolgreich zurückgesetzt"
         }
     },
     "interpretation_buttons": {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -251,6 +251,7 @@
     "interpretation_buttons": {
       "buttons": {
         "preview": "Get Preview of Output Data",
+        "reset": "Reset",
         "yes": "Yes",
         "no": "No"
       },

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -246,6 +246,9 @@
         "mimetype": "mimetype: ",
         "image_below": "Image is rendered below:",
         "separator": "--------------------------------------------------"
+      }, 
+      "notifications": {
+        "reset_success": "Output Preview reset successfully"
       }
     },
     "interpretation_buttons": {

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -251,6 +251,7 @@
   "interpretation_buttons": {
     "buttons": {
       "preview": "Obtener Vista Previa de Datos de Salida",
+      "reset": "Restablecer",
       "yes": "Sí",
       "no": "No"
     },

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -265,6 +265,9 @@
       "use_previous": "¿Desea usar su selección anterior como condición para realizar esta acción?",
       "previous_action": "Su acción anterior fue: ",
       "element_text": "en un elemento con texto "
+    },
+    "notifications": {
+      "reset_success": "Vista previa restablecida correctamente"
     }
   },
   "recording_page": {

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -251,6 +251,7 @@
     "interpretation_buttons": {
         "buttons": {
             "preview": "出力データのプレビューを取得",
+            "reset": "リセット",
             "yes": "はい",
             "no": "いいえ"
         },

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -246,6 +246,9 @@
             "mimetype": "MIMEタイプ: ",
             "image_below": "画像は以下に表示されます：",
             "separator": "--------------------------------------------------"
+        },
+        "notifications": {
+            "reset_success": "出力プレビューが正常にリセットされました"
         }
     },
     "interpretation_buttons": {

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -246,6 +246,9 @@
       "mimetype": "MIME类型：",
       "image_below": "图片显示如下：",
       "separator": "--------------------------------------------------"
+    },
+    "notifications": {
+      "reset_success": "输出预览已成功重置"
     }
   },
   "interpretation_buttons": {

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -251,6 +251,7 @@
   "interpretation_buttons": {
     "buttons": {
       "preview": "获取输出数据预览",
+      "reset": "重置",
       "yes": "是",
       "no": "否"
     },

--- a/src/components/molecules/InterpretationLog.tsx
+++ b/src/components/molecules/InterpretationLog.tsx
@@ -35,7 +35,7 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
 
   const { width } = useBrowserDimensionsStore();
   const { socket } = useSocketStore();
-  const { currentWorkflowActionsState, notify } = useGlobalInfoStore();
+  const { currentWorkflowActionsState, shouldResetInterpretationLog, notify } = useGlobalInfoStore();
 
   const toggleDrawer = (newOpen: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {
     if (
@@ -94,12 +94,13 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
     setCustomValue(event.target.value);
   };
 
-  const handleReset = () => {
-    setLog('');
-    setTableData([]);
-    setBinaryData(null);
-    notify("success", t('interpretation_log.notifications.reset_success'));
-  };
+  useEffect(() => {
+    if (shouldResetInterpretationLog) {
+      setLog('');
+      setTableData([]);
+      setBinaryData(null);
+    }
+  }, [shouldResetInterpretationLog]);
 
   useEffect(() => {
     socket?.on('log', handleLog);

--- a/src/components/molecules/InterpretationLog.tsx
+++ b/src/components/molecules/InterpretationLog.tsx
@@ -179,34 +179,12 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
           >
             {
               binaryData ? (
-                <>
-                  <div style={{ marginBottom: '20px' }}>
-                    <Typography variant="body1" gutterBottom>
-                      {t('interpretation_log.titles.screenshot')}
-                    </Typography>
-                    <img src={binaryData} alt={t('interpretation_log.titles.screenshot')} style={{ maxWidth: '100%' }} />
-                  </div>
-                  <Button
-                  variant="contained"
-                  color="primary"
-                  onClick={handleReset}
-                  sx={{
-                    position: 'absolute',
-                    color: 'white',
-                    bottom: '20px',
-                    right: '20px',
-                    backgroundColor: '#ff00c3',
-                    overflow: 'hidden',
-                    textAlign: 'left',
-                    '&:hover': {
-                      backgroundColor: '#ff00c3',
-                    },
-                  }}
-                  >
-                  Reset
-                  {/* {t('interpretation_log.buttons.reset')} */}
-                </Button>
-              </>
+                <div style={{ marginBottom: '20px' }}>
+                  <Typography variant="body1" gutterBottom>
+                    {t('interpretation_log.titles.screenshot')}
+                  </Typography>
+                  <img src={binaryData} alt={t('interpretation_log.titles.screenshot')} style={{ maxWidth: '100%' }} />
+                </div>
               ) : tableData.length > 0 ? (
                 <>
                   <TableContainer component={Paper}>
@@ -232,25 +210,6 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
                   <span style={{ marginLeft: '15px', marginTop: '10px', fontSize: '12px' }}>
                     {t('interpretation_log.messages.additional_rows')}
                   </span>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={handleReset}
-                    sx={{
-                      position: 'absolute',
-                      color: 'white',
-                      bottom: '20px',
-                      right: '20px',
-                      backgroundColor: '#ff00c3',
-                      overflow: 'hidden',
-                      textAlign: 'left',
-                      '&:hover': {
-                        backgroundColor: '#ff00c3',
-                      },
-                    }}
-                    >
-                    {t('interpretation_buttons.buttons.reset')}
-                  </Button>
                 </>
               ) : (
                 <Grid container justifyContent="center" alignItems="center" style={{ height: '100%' }}>

--- a/src/components/molecules/InterpretationLog.tsx
+++ b/src/components/molecules/InterpretationLog.tsx
@@ -35,7 +35,7 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
 
   const { width } = useBrowserDimensionsStore();
   const { socket } = useSocketStore();
-  const { currentWorkflowActionsState } = useGlobalInfoStore();
+  const { currentWorkflowActionsState, notify } = useGlobalInfoStore();
 
   const toggleDrawer = (newOpen: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {
     if (
@@ -98,6 +98,7 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
     setLog('');
     setTableData([]);
     setBinaryData(null);
+    notify("success", t('interpretation_log.notifications.reset_success'));
   };
 
   useEffect(() => {

--- a/src/components/molecules/InterpretationLog.tsx
+++ b/src/components/molecules/InterpretationLog.tsx
@@ -94,6 +94,12 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
     setCustomValue(event.target.value);
   };
 
+  const handleReset = () => {
+    setLog('');
+    setTableData([]);
+    setBinaryData(null);
+  };
+
   useEffect(() => {
     socket?.on('log', handleLog);
     socket?.on('serializableCallback', handleSerializableCallback);
@@ -172,12 +178,34 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
           >
             {
               binaryData ? (
-                <div style={{ marginBottom: '20px' }}>
-                  <Typography variant="body1" gutterBottom>
-                    {t('interpretation_log.titles.screenshot')}
-                  </Typography>
-                  <img src={binaryData} alt={t('interpretation_log.titles.screenshot')} style={{ maxWidth: '100%' }} />
-                </div>
+                <>
+                  <div style={{ marginBottom: '20px' }}>
+                    <Typography variant="body1" gutterBottom>
+                      {t('interpretation_log.titles.screenshot')}
+                    </Typography>
+                    <img src={binaryData} alt={t('interpretation_log.titles.screenshot')} style={{ maxWidth: '100%' }} />
+                  </div>
+                  <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={handleReset}
+                  sx={{
+                    position: 'absolute',
+                    color: 'white',
+                    bottom: '20px',
+                    right: '20px',
+                    backgroundColor: '#ff00c3',
+                    overflow: 'hidden',
+                    textAlign: 'left',
+                    '&:hover': {
+                      backgroundColor: '#ff00c3',
+                    },
+                  }}
+                  >
+                  Reset
+                  {/* {t('interpretation_log.buttons.reset')} */}
+                </Button>
+              </>
               ) : tableData.length > 0 ? (
                 <>
                   <TableContainer component={Paper}>
@@ -203,6 +231,25 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
                   <span style={{ marginLeft: '15px', marginTop: '10px', fontSize: '12px' }}>
                     {t('interpretation_log.messages.additional_rows')}
                   </span>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleReset}
+                    sx={{
+                      position: 'absolute',
+                      color: 'white',
+                      bottom: '20px',
+                      right: '20px',
+                      backgroundColor: '#ff00c3',
+                      overflow: 'hidden',
+                      textAlign: 'left',
+                      '&:hover': {
+                        backgroundColor: '#ff00c3',
+                      },
+                    }}
+                    >
+                    {t('interpretation_buttons.buttons.reset')}
+                  </Button>
                 </>
               ) : (
                 <Grid container justifyContent="center" alignItems="center" style={{ height: '100%' }}>

--- a/src/components/organisms/RightSidePanel.tsx
+++ b/src/components/organisms/RightSidePanel.tsx
@@ -57,7 +57,7 @@ export const RightSidePanel: React.FC<RightSidePanelProps> = ({ onFinishCapture 
   const [hoverStates, setHoverStates] = useState<{ [id: string]: boolean }>({});
   const [browserStepIdList, setBrowserStepIdList] = useState<number[]>([]);
 
-  const { lastAction, notify, currentWorkflowActionsState, setCurrentWorkflowActionsState } = useGlobalInfoStore();
+  const { lastAction, notify, currentWorkflowActionsState, setCurrentWorkflowActionsState, resetInterpretationLog } = useGlobalInfoStore();
   const { getText, startGetText, stopGetText, getScreenshot, startGetScreenshot, stopGetScreenshot, getList, startGetList, stopGetList, startPaginationMode, stopPaginationMode, paginationType, updatePaginationType, limitType, customLimit, updateLimitType, updateCustomLimit, stopLimitMode, startLimitMode, captureStage, setCaptureStage } = useActionContext();
   const { browserSteps, updateBrowserTextStepLabel, deleteBrowserStep, addScreenshotStep, updateListTextFieldLabel, removeListTextField } = useBrowserSteps();
   const { id, socket } = useSocketStore();
@@ -225,8 +225,9 @@ export const RightSidePanel: React.FC<RightSidePanelProps> = ({ onFinishCapture 
     if (hasTextSteps) {
       socket?.emit('action', { action: 'scrapeSchema', settings });
     }
+    resetInterpretationLog();
     onFinishCapture();
-  }, [stopGetText, getTextSettingsObject, socket, browserSteps, confirmedTextSteps]);
+  }, [stopGetText, getTextSettingsObject, socket, browserSteps, confirmedTextSteps, resetInterpretationLog]);
 
   const getListSettingsObject = useCallback(() => {
     let settings: {

--- a/src/context/globalInfo.tsx
+++ b/src/context/globalInfo.tsx
@@ -32,6 +32,8 @@ interface GlobalInfo {
     hasScreenshotAction: boolean;
     hasScrapeSchemaAction: boolean;
   }) => void;
+  shouldResetInterpretationLog: boolean;
+  resetInterpretationLog: () => void;
 };
 
 class GlobalInfoStore implements Partial<GlobalInfo> {
@@ -53,6 +55,7 @@ class GlobalInfoStore implements Partial<GlobalInfo> {
     hasScreenshotAction: false,
     hasScrapeSchemaAction: false,
   };
+  shouldResetInterpretationLog = false;
 };
 
 const globalInfoStore = new GlobalInfoStore();
@@ -71,6 +74,7 @@ export const GlobalInfoProvider = ({ children }: { children: JSX.Element }) => {
   const [recordingName, setRecordingName] = useState<string>(globalInfoStore.recordingName);
   const [recordingUrl, setRecordingUrl] = useState<string>(globalInfoStore.recordingUrl);
   const [currentWorkflowActionsState, setCurrentWorkflowActionsState] = useState(globalInfoStore.currentWorkflowActionsState);
+  const [shouldResetInterpretationLog, setShouldResetInterpretationLog] = useState<boolean>(globalInfoStore.shouldResetInterpretationLog);
 
   const notify = (severity: 'error' | 'warning' | 'info' | 'success', message: string) => {
     setNotification({ severity, message, isOpen: true });
@@ -85,6 +89,14 @@ export const GlobalInfoProvider = ({ children }: { children: JSX.Element }) => {
     if (!browserId) {
       setRecordingLength(0);
     }
+  }
+
+  const resetInterpretationLog = () => {
+    setShouldResetInterpretationLog(true);
+    // Reset the flag after a short delay to allow components to respond
+    setTimeout(() => {
+      setShouldResetInterpretationLog(false);
+    }, 100);
   }
 
   return (
@@ -111,6 +123,8 @@ export const GlobalInfoProvider = ({ children }: { children: JSX.Element }) => {
         setRecordingUrl,
         currentWorkflowActionsState,
         setCurrentWorkflowActionsState,
+        shouldResetInterpretationLog,
+        resetInterpretationLog,
       }}
     >
       {children}


### PR DESCRIPTION
Added functionality to reset the output preview data after the user adds and confirms additional data fields.
fix: #218 


https://github.com/user-attachments/assets/d4c1fba0-07bd-48a3-914c-d7c1af1bcb26




