### PR TITLE
feat: change pagination selector used for scrape list 

### DIFF
--- a/src/components/organisms/BrowserWindow.tsx
+++ b/src/components/organisms/BrowserWindow.tsx
@@ -212,6 +212,7 @@ export const BrowserWindow = () => {
                         notify(`info`, t('browser_window.attribute_modal.notifications.pagination_select_success'));
                         addListStep(listSelector!, fields, currentListId || 0, { type: paginationType, selector: highlighterData.selector });
                     }
+                    socket?.emit('setPaginationMode', { paginationMode: false });
                     return;
                 }
 

--- a/src/context/browserActions.tsx
+++ b/src/context/browserActions.tsx
@@ -54,6 +54,7 @@ export const ActionProvider = ({ children }: { children: ReactNode }) => {
         setPaginationMode(true);
         setCaptureStage('pagination');
         socket?.emit('setGetList', { getList: false });
+        socket?.emit('setPaginationMode', { paginationMode: true });
     };
 
     const stopPaginationMode = () => setPaginationMode(false);


### PR DESCRIPTION
Check if the pagination selector is over specific and use other selectors based on pagination mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced pagination mode functionality for workflow generation
	- Added socket event handling for setting pagination mode
	- Enhanced selector generation logic to handle paginated content more robustly

- **Improvements**
	- Implemented mechanism to toggle pagination mode on and off
	- Improved element selection process during pagination

<!-- end of auto-generated comment: release notes by coderabbit.ai -->