### PR TITLE
fix: prevent page reload on run trigger to open remote browser

### DIFF
--- a/server/src/browser-management/classes/BrowserPool.ts
+++ b/server/src/browser-management/classes/BrowserPool.ts
@@ -15,6 +15,8 @@ interface BrowserPoolInfo {
      * @default false
      */
     active: boolean,
+
+    isRobotRun?: boolean;
 }
 
 /**
@@ -46,16 +48,28 @@ export class BrowserPool {
      * @param browser remote browser instance
      * @param active states if the browser's instance is being actively used
      */
-    public addRemoteBrowser = (id: string, browser: RemoteBrowser, active: boolean = false): void => {
+    public addRemoteBrowser = (id: string, browser: RemoteBrowser, active: boolean = false, isRobotRun: boolean = false): void => {
         this.pool = {
             ...this.pool,
             [id]: {
                 browser,
                 active,
+                isRobotRun
             },
         }
         logger.log('debug', `Remote browser with id: ${id} added to the pool`);
     };
+
+    public hasActiveRobotRun(): boolean {
+        return Object.values(this.pool).some(info => info.isRobotRun);
+    }
+
+    public clearRobotRunState(id: string): void {
+        if (this.pool[id]) {
+            this.pool[id].isRobotRun = false;
+            logger.log('debug', `Robot run state cleared for browser ${id}`);
+        }
+    }
 
     /**
      * Removes the remote browser instance from the pool.
@@ -67,6 +81,8 @@ export class BrowserPool {
             logger.log('warn', `Remote browser with id: ${id} does not exist in the pool`);
             return false;
         }
+
+        this.clearRobotRunState(id);
         delete (this.pool[id]);
         logger.log('debug', `Remote browser with id: ${id} deleted from the pool`);
         return true;

--- a/server/src/browser-management/controller.ts
+++ b/server/src/browser-management/controller.ts
@@ -59,7 +59,7 @@ export const createRemoteBrowserForRun = (userId: string): string => {
     async (socket: Socket) => {
       const browserSession = new RemoteBrowser(socket);
       await browserSession.initialize(userId);
-      browserPool.addRemoteBrowser(id, browserSession, true);
+      browserPool.addRemoteBrowser(id, browserSession, true, true);
       socket.emit('ready-for-run');
     });
   return id;

--- a/server/src/routes/record.ts
+++ b/server/src/routes/record.ts
@@ -16,6 +16,7 @@ import stealthPlugin from 'puppeteer-extra-plugin-stealth';
 import logger from "../logger";
 import { getDecryptedProxyConfig } from './proxy';
 import { requireSignIn } from '../middlewares/auth';
+import { browserPool } from '../server';
 
 export const router = Router();
 chromium.use(stealthPlugin());
@@ -32,6 +33,17 @@ router.all('/', requireSignIn, (req, res, next) => {
     logger.log('debug', `The record API was invoked: ${req.url}`)
     next() // pass control to the next handler
 })
+
+router.use('/', requireSignIn, (req: AuthenticatedRequest, res: Response, next) => {
+    if (browserPool.hasActiveRobotRun()) {
+        logger.log('debug', 'Preventing browser initialization - robot run in progress');
+        return res.status(403).json({
+            error: 'Cannot initialize recording browser while a robot run is in progress'
+        });
+    }
+    next();
+});
+
 
 /**
  * GET endpoint for starting the remote browser recording session.

--- a/server/src/workflow-management/classes/Interpreter.ts
+++ b/server/src/workflow-management/classes/Interpreter.ts
@@ -332,6 +332,8 @@ export class WorkflowInterpreter {
       }, {})
     }
 
+    this.socket.emit('run-completed', "success");
+
     logger.log('debug', `Interpretation finished`);
     this.clearState();
     return result;


### PR DESCRIPTION
Closes: #374 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tracking for robot run state in browser pool
  - Implemented middleware to prevent concurrent browser recording sessions
  - Enhanced socket communication for workflow interpretation completion

- **Bug Fixes**
  - Improved handling of browser recording session management
  - Updated local storage management for run information

- **Refactor**
  - Streamlined socket event handling in main page component
  - Improved browser pool state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->