### PR TITLE
fix: Empty label on recording shows error

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -205,7 +205,8 @@
             "confirm_text_fields": "Bitte bestätigen Sie alle Textfelder",
             "unable_create_settings": "Listeneinstellungen können nicht erstellt werden. Stellen Sie sicher, dass Sie ein Feld für die Liste definiert haben.",
             "capture_text_discarded": "Texterfassung verworfen",
-            "capture_list_discarded": "Listenerfassung verworfen"
+            "capture_list_discarded": "Listenerfassung verworfen",
+            "label_required": "Beschriftung darf nicht leer sein"
         }
     },
     "save_recording": {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -207,7 +207,8 @@
         "confirm_text_fields": "Please confirm all text fields",
         "unable_create_settings": "Unable to create list settings. Make sure you have defined a field for the list.",
         "capture_text_discarded": "Capture Text Discarded",
-        "capture_list_discarded": "Capture List Discarded"
+        "capture_list_discarded": "Capture List Discarded",
+        "label_required": "Label cannot be empty"
       }
     },
     "save_recording": {

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -206,7 +206,8 @@
       "confirm_text_fields": "Por favor confirme todos los campos de texto",
       "unable_create_settings": "No se pueden crear las configuraciones de la lista. Asegúrese de haber definido un campo para la lista.",
       "capture_text_discarded": "Captura de texto descartada",
-      "capture_list_discarded": "Captura de lista descartada"
+      "capture_list_discarded": "Captura de lista descartada",
+      "label_required": "La etiqueta no puede estar vacía"
     }
   },
   "save_recording": {

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -206,7 +206,8 @@
             "confirm_text_fields": "すべてのテキストフィールドを確認してください",
             "unable_create_settings": "リスト設定を作成できません。リストのフィールドを定義したことを確認してください。",
             "capture_text_discarded": "テキスト取得が破棄されました",
-            "capture_list_discarded": "リスト取得が破棄されました"
+            "capture_list_discarded": "リスト取得が破棄されました",
+            "label_required": "ラベルは空にできません"
         }
     },
     "save_recording": {

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -206,7 +206,8 @@
       "confirm_text_fields": "请确认所有文本字段",
       "unable_create_settings": "无法创建列表设置。请确保您已为列表定义了字段。",
       "capture_text_discarded": "文本捕获已放弃",
-      "capture_list_discarded": "列表捕获已放弃"
+      "capture_list_discarded": "列表捕获已放弃",
+      "label_required": "标签不能为空"
     }
   },
   "save_recording": {


### PR DESCRIPTION
Fixes: #369 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new localized error message for empty label validation across multiple languages (German, English, Spanish, Japanese, Chinese)
- **Documentation**
  - Updated localization files with consistent error messaging for label requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->