### PR TITLE
feat: display proper message for run exists notification

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -40,7 +40,7 @@
         "delete": "Löschen",
         "duplicate": "Duplizieren",
         "notifications": {
-            "delete_warning": "Roboter kann nicht gelöscht werden, da zugehörige Ausführungen vorhanden sind",
+            "delete_warning": "Der Roboter hat zugehörige Ausführungen. Löschen Sie zuerst die Ausführungen, um den Roboter zu löschen",
             "delete_success": "Roboter erfolgreich gelöscht",
             "auth_success": "Roboter erfolgreich authentifiziert"
         }

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -41,7 +41,7 @@
       "duplicate":"Duplicate",
       "search":"Search Robots...",
       "notifications": {
-        "delete_warning": "Cannot delete robot as it has associated runs",
+        "delete_warning": "The robot has associated runs. First delete runs to delete the robot",
         "delete_success": "Robot deleted successfully",
         "auth_success": "Robot successfully authenticated"
       }

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -41,7 +41,7 @@
     "duplicate": "Duplicar",
     "search": "Buscar robots...",
     "notifications": {
-      "delete_warning": "No se puede eliminar el robot ya que tiene ejecuciones asociadas",
+      "delete_warning": "El robot tiene ejecuciones asociadas. Primero elimine las ejecuciones para eliminar el robot",
       "delete_success": "Robot eliminado exitosamente",
       "auth_success": "Robot autenticado exitosamente"
     }

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -41,7 +41,7 @@
         "duplicate": "複製",
         "search": "ロボットを検索...",
         "notifications": {
-            "delete_warning": "関連する実行があるため、ロボットを削除できません",
+            "delete_warning": "ロボットには関連する実行があります。ロボットを削除するには、まず実行を削除してください",
             "delete_success": "ロボットが正常に削除されました",
             "auth_success": "ロボットの認証に成功しました"
         }

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -41,7 +41,7 @@
     "duplicate": "复制",
     "search": "搜索机器人...",
     "notifications": {
-      "delete_warning": "无法删除机器人，因为它有关联的运行记录",
+      "delete_warning": "该机器人有关联的运行记录。请先删除运行记录才能删除机器人",
       "delete_success": "机器人删除成功",
       "auth_success": "机器人认证成功"
     }


### PR DESCRIPTION
Closes: #371 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
	- Updated delete warning messages in multiple languages (German, English, Spanish, Japanese, Chinese) to provide clearer instructions about deleting robots with associated runs.
	- Enhanced user guidance by explicitly stating the need to delete associated runs before removing a robot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->