### PR TITLE
fix: use email instead of username

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -14,7 +14,7 @@
       },
       "error": {
         "user_not_found": "User does not exist",
-        "invalid_credentials": "Invalid username or password",
+        "invalid_credentials": "Invalid email or password",
         "server_error": "Login failed. Please try again later",
         "generic": "An error occurred. Please try again"
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the login error message to reference email instead of username, providing more accurate guidance during user authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->