### PR TITLE
fix: Return data even if single element exists

### DIFF
--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -286,6 +286,12 @@ export default class Interpreter extends EventEmitter {
             ? arrayToObject(<any>superset[key])
             : superset[key];
 
+          if (key === 'selectors' && Array.isArray(value) && Array.isArray(superset[key])) {
+            return value.some(selector => 
+              (superset[key] as any[]).includes(selector)
+            );
+          }
+
           // Every `subset` key must exist in the `superset` and
           // have the same value (strict equality), or subset[key] <= superset[key]
           return parsedSuperset[key]


### PR DESCRIPTION
For Capture List return data even if a single selector matches with the action state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the evaluation of workflow conditions so rules are applied more accurately, leading to more predictable execution of your automated actions.

- **Refactor**
  - Streamlined the process of consolidating unique workflow selectors, resulting in improved efficiency and clarity in how conditions are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->