### PR TITLE
fix: display proxy config immediately after submission w/o hard refresh

### DIFF
--- a/src/components/proxy/ProxyForm.tsx
+++ b/src/components/proxy/ProxyForm.tsx
@@ -103,6 +103,7 @@ const ProxyForm: React.FC = () => {
                 setIsProxyConfigured(true);
                 setProxy({ proxy_url: proxyConfigForm.server_url, auth: requiresAuth });
                 notify('success', t('proxy.notifications.config_success'));
+                fetchProxyConfig();
             } else {
                 notify('error', t('proxy.notifications.config_error'));
                 console.log(`${t('proxy.notifications.config_error')} ${response}`)

--- a/src/components/proxy/ProxyForm.tsx
+++ b/src/components/proxy/ProxyForm.tsx
@@ -100,6 +100,7 @@ const ProxyForm: React.FC = () => {
         try {
             const response = await sendProxyConfig(proxyConfigForm);
             if (response) {
+                setIsProxyConfigured(true);
                 notify('success', t('proxy.notifications.config_success'));
             } else {
                 notify('error', t('proxy.notifications.config_error'));

--- a/src/components/proxy/ProxyForm.tsx
+++ b/src/components/proxy/ProxyForm.tsx
@@ -101,6 +101,7 @@ const ProxyForm: React.FC = () => {
             const response = await sendProxyConfig(proxyConfigForm);
             if (response) {
                 setIsProxyConfigured(true);
+                setProxy({ proxy_url: proxyConfigForm.server_url, auth: requiresAuth });
                 notify('success', t('proxy.notifications.config_success'));
             } else {
                 notify('error', t('proxy.notifications.config_error'));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the proxy configuration form so that after a successful submission, the interface immediately reflects the updated proxy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->