### PR TITLE
⚠️ feat: deprecate redis dependency from v0.0.13 ⚠️ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ You can access the frontend at http://localhost:5173/ and backend at http://loca
 | `AIRTABLE_CLIENT_ID` | No       | Client ID for Airtable, used for Airtable integration authentication.                         | Airtable login will not work.  |
 | `AIRTABLE_REDIRECT_URI` | No    | Redirect URI for handling Airtable OAuth responses.                                           | Airtable login will not work.  |
 | `REDIS_HOST`          | Yes       | Host address of the Redis server, used by BullMQ for scheduling robots.                     | Redis connection will fail. |
-| `REDIS_PORT`          | Yes       | Port number for the Redis server.                                                           | Redis connection will fail. |
 
 | `MAXUN_TELEMETRY`     | No        | Disables telemetry to stop sending anonymous usage data. Keeping it enabled helps us understand how the product is used and assess the impact of any new changes. Please keep it enabled. | Telemetry data will not be collected. |
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ You can access the frontend at http://localhost:5173/ and backend at http://loca
 | `GOOGLE_REDIRECT_URI` | No       | Redirect URI for handling Google OAuth responses.                                            | Google login will not work.                                  |
 | `AIRTABLE_CLIENT_ID` | No       | Client ID for Airtable, used for Airtable integration authentication.                         | Airtable login will not work.  |
 | `AIRTABLE_REDIRECT_URI` | No    | Redirect URI for handling Airtable OAuth responses.                                           | Airtable login will not work.  |
-| `REDIS_HOST`          | Yes       | Host address of the Redis server, used by BullMQ for scheduling robots.                     | Redis connection will fail. |
 
 | `MAXUN_TELEMETRY`     | No        | Disables telemetry to stop sending anonymous usage data. Keeping it enabled helps us understand how the product is used and assess the impact of any new changes. Please keep it enabled. | Telemetry data will not be collected. |
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can access the frontend at http://localhost:5173/ and backend at http://loca
 | `AIRTABLE_REDIRECT_URI` | No    | Redirect URI for handling Airtable OAuth responses.                                           | Airtable login will not work.  |
 | `REDIS_HOST`          | Yes       | Host address of the Redis server, used by BullMQ for scheduling robots.                     | Redis connection will fail. |
 | `REDIS_PORT`          | Yes       | Port number for the Redis server.                                                           | Redis connection will fail. |
-| `REDIS_PASSWORD`          | No       | Password for Redis Authentication. Needed to authenticate with a password-protected Redis instance;                     | Redis will attempt to connect without authentication. |
+
 | `MAXUN_TELEMETRY`     | No        | Disables telemetry to stop sending anonymous usage data. Keeping it enabled helps us understand how the product is used and assess the impact of any new changes. Please keep it enabled. | Telemetry data will not be collected. |
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,6 @@ services:
     mem_limit: 2g   # Set a 2GB memory limit
     depends_on:
       - postgres
-      - redis
       - minio
     volumes:
       - /var/run/dbus:/var/run/dbus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,4 +72,3 @@ services:
 volumes:
   postgres_data:
   minio_data:
-  redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,16 +17,6 @@ services:
       timeout: 5s
       retries: 5
 
-  redis:
-    image: redis:6
-    environment:
-      REDIS_HOST: ${REDIS_HOST}
-      REDIS_PORT: ${REDIS_PORT}
-    ports:
-      - "${REDIS_PORT:-6379}:${REDIS_PORT:-6379}"
-    volumes:
-      - redis_data:/data
-
   minio:
     image: minio/minio
     environment:

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "react-router-dom": "^6.26.1",
     "react-simple-code-editor": "^0.11.2",
     "react-transition-group": "^4.4.2",
-    "redis": "^4.7.0",
     "sequelize": "^6.37.3",
     "sequelize-typescript": "^2.1.6",
     "sharp": "^0.33.5",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "body-parser": "^1.20.3",
     "buffer": "^6.0.3",
     "connect-pg-simple": "^10.0.0",
-    "connect-redis": "^8.0.1",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "cron-parser": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "bcrypt": "^5.1.1",
     "body-parser": "^1.20.3",
     "buffer": "^6.0.3",
-    "bullmq": "^5.12.15",
     "connect-pg-simple": "^10.0.0",
     "connect-redis": "^8.0.1",
     "cookie-parser": "^1.4.6",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "@types/prismjs": "^1.26.0",
     "@types/react-highlight": "^0.12.5",
     "@types/react-transition-group": "^4.4.4",
-    "@types/redis": "^4.0.11",
     "@types/styled-components": "^5.1.23",
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.6",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated configuration instructions by removing outdated settings for Redis.
  - Introduced a new optional setting for controlling telemetry data collection.
- **Chores**
  - Removed the Redis service configuration from the docker-compose setup, including associated volume definitions.
  - Removed the BullMQ dependency from the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->