### PR TITLE
fix: remove page timeout for pagination 

### DIFF
--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -663,10 +663,7 @@ export default class Interpreter extends EventEmitter {
     let availableSelectors = config.pagination.selector.split(',');
 
     try {
-      while (true) {
-        // Reduced timeout for faster performance
-        await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
-        
+      while (true) {    
         switch (config.pagination.type) {
           case 'scrollDown': {
             await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));


### PR DESCRIPTION
Why this?
Output preview does not get data during scroll down for certain sites due to timeout issues. This PR fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the responsiveness of content navigation by streamlining transitions during paging. These refinements reduce unnecessary waiting times, resulting in a faster and smoother browsing experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->