### PR TITLE
chore(docker): !copy `maxun-core` during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app
 
 # Copy package files
 COPY package*.json ./
-COPY maxun-core ./maxun-core
 
 # Install dependencies
 RUN npm install --legacy-peer-deps

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /app
 
 # Install node dependencies
 COPY package*.json ./
-COPY maxun-core ./maxun-core
 COPY src ./src
 COPY public ./public 
 COPY server ./server


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the container build process to streamline the image creation by omitting an internal resource directory. The overall functionality remains unchanged for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->