### PR TITLE
fix: browser crashes due to scroll input event

### DIFF
--- a/server/src/browser-management/inputHandlers.ts
+++ b/server/src/browser-management/inputHandlers.ts
@@ -185,8 +185,19 @@ const onWheel = async (socket: AuthenticatedSocket, scrollDeltas: ScrollDeltas) 
  * @category BrowserManagement
  */
 const handleWheel = async (generator: WorkflowGenerator, page: Page, { deltaX, deltaY }: ScrollDeltas) => {
-    await page.mouse.wheel(deltaX, deltaY);
-    logger.log('debug', `Scrolled horizontally ${deltaX} pixels and vertically ${deltaY} pixels`);
+    try {
+        if (page.isClosed()) {
+            return;
+        }
+        
+        await page.mouse.wheel(deltaX, deltaY).catch(error => {
+            logger.log('warn', `Wheel event failed: ${error.message}`);
+        });    
+        logger.log('debug', `Scrolled horizontally ${deltaX} pixels and vertically ${deltaY} pixels`);    
+    } catch (e) {
+        const { message } = e as Error;
+        logger.log('warn', `Error handling wheel event: ${message}`);
+    }
 };
 
 /**


### PR DESCRIPTION
What this PR does?
Solves the issue that occurs when remote browser crashes when discarded while performing an input action.

Fixes: #372 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for scroll actions, ensuring a smoother and more reliable scrolling experience under various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->