### PR TITLE
fix: display the latest run name for each robot run

### DIFF
--- a/src/components/run/RunsTable.tsx
+++ b/src/components/run/RunsTable.tsx
@@ -390,7 +390,7 @@ export const RunsTable: React.FC<RunsTableProps> = ({
               TransitionProps={{ unmountOnExit: true }} // Optimize accordion rendering
             >
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Typography variant="h6">{data[data.length - 1].name}</Typography>
+                <Typography variant="h6">{data[0].name}</Typography>
               </AccordionSummary>
               <AccordionDetails>
                 <Table stickyHeader aria-label="sticky table">


### PR DESCRIPTION
What this PR does?
Display the latest updated run name for the Runs of each robot.

Fixes: #524 

![image](https://github.com/user-attachments/assets/525ab1e7-2555-4e42-b037-78873f2803cb)

![image](https://github.com/user-attachments/assets/e933e9e9-93b8-45fb-a1bc-361ce621e8ef)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the run summary display so that the run name now reflects the first entry in the list instead of the last, ensuring the correct information is shown to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->