### PR TITLE
fix: display abort status for aborted run

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -513,7 +513,8 @@
             "running": "Läuft",
             "scheduled": "Geplant",
             "queued": "In Warteschlange",
-            "failed": "Fehlgeschlagen"
+            "failed": "Fehlgeschlagen",
+            "aborted": "Abgebrochen"
         },
         "run_settings_modal": {
             "title": "Ausführungseinstellungen",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -521,7 +521,8 @@
         "running": "Running",
         "scheduled": "Scheduled",
         "queued": "Queued",
-        "failed": "Failed"
+        "failed": "Failed",
+        "aborted": "Aborted"
       },
       "run_settings_modal": {
         "title": "Run Settings",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -514,7 +514,8 @@
       "running": "Ejecutando",
       "scheduled": "Programado",
       "queued": "En cola",
-      "failed": "Fallido"
+      "failed": "Fallido",
+      "aborted": "Abortado"
     },
     "run_settings_modal": {
       "title": "Configuración de Ejecución",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -514,7 +514,8 @@
             "running": "実行中",
             "scheduled": "スケジュール済み",
             "queued": "キューに入れました",
-            "failed": "失敗"
+            "failed": "失敗",
+            "aborted": "中止されました"
         },
         "run_settings_modal": {
             "title": "実行設定",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -514,7 +514,8 @@
       "running": "运行中",
       "scheduled": "已计划",
       "queued": "排队",
-      "failed": "失败"
+      "failed": "失败",
+      "aborted": "已中止"
     },
     "run_settings_modal": {
       "title": "运行设置",

--- a/src/components/run/ColapsibleRow.tsx
+++ b/src/components/run/ColapsibleRow.tsx
@@ -125,6 +125,7 @@ export const CollapsibleRow = ({ row, handleDelete, isOpen, currentLog, abortRun
                     {row.status === 'scheduled' && <Chip label={t('runs_table.run_status_chips.scheduled')} variant="outlined" />}
                     {row.status === 'queued' && <Chip label={t('runs_table.run_status_chips.queued')} variant="outlined" />}
                     {row.status === 'failed' && <Chip label={t('runs_table.run_status_chips.failed')} color="error" variant="outlined" />}
+                    {row.status === 'aborted' && <Chip label={t('runs_table.run_status_chips.aborted')} color="error" variant="outlined" />}
                   </TableCell>
                 )
               case 'delete':


### PR DESCRIPTION
What this PR does?
It displays the abort status for the run that is aborted.

Fixes: #526 

![image](https://github.com/user-attachments/assets/602941b6-296a-4231-bc97-9c4e506eb1f9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new “aborted” run status that enhances feedback across the app with clear, localized labels in German, English, Spanish, Japanese, and Chinese.
  - The update enhances the visual display of run statuses, ensuring users can easily distinguish an intentionally halted run from other outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->