### PR TITLE
feat: execute abort operation using queue

### DIFF
--- a/server/src/pgboss-worker.ts
+++ b/server/src/pgboss-worker.ts
@@ -393,19 +393,15 @@ async function abortRun(runId: string, userId: string): Promise<boolean> {
     }
 
     const currentLog = browser.interpreter.debugMessages.join('\n');
-    const serializableOutput = browser.interpreter.serializableData.reduce((reducedObject, item, index) => {
-      return {
-        [`item-${index}`]: item,
-        ...reducedObject,
-      }
-    }, {});
+    const serializableOutput: Record<string, any> = {};
+    browser.interpreter.serializableData.forEach((item, index) => {
+      serializableOutput[`item-${index}`] = item;
+    });
     
-    const binaryOutput = browser.interpreter.binaryData.reduce((reducedObject, item, index) => {
-      return {
-        [`item-${index}`]: item,
-        ...reducedObject,
-      }
-    }, {});
+    const binaryOutput: Record<string, any> = {};
+    browser.interpreter.binaryData.forEach((item, index) => {
+      binaryOutput[`item-${index}`] = item;
+    });
 
     await run.update({
       status: 'aborted',

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -71,7 +71,7 @@ export const MainPage = ({ handleEditRecording, initialContent }: MainPageProps)
     interpretStoredRecording(runId).then(async (interpretation: boolean) => {
       if (!aborted) {
         if (interpretation) {
-          notify('success', t('main_page.notifications.interpretation_success', { name: runningRecordingName }));
+          // notify('success', t('main_page.notifications.interpretation_success', { name: runningRecordingName }));
         } else {
           notify('success', t('main_page.notifications.interpretation_failed', { name: runningRecordingName }));
           // destroy the created browser
@@ -112,6 +112,14 @@ export const MainPage = ({ handleEditRecording, initialContent }: MainPageProps)
           notify('error', t('main_page.notifications.interpretation_failed', { name: robotName }));
         }
       });
+
+      socket.on('run-aborted', (data) => {
+        setRerenderRuns(true);
+        
+        const abortedRobotName = data.robotName;
+        notify('success', t('main_page.notifications.abort_success', { name: abortedRobotName }));
+      });
+
       setContent('runs');
       if (browserId) {
         notify('info', t('main_page.notifications.run_started', { name: runningRecordingName }));


### PR DESCRIPTION
What this PR does?

Shifts execution of abort run operations to separate user specific queues. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated cancellation service that processes abort requests for running tasks, providing faster and more consistent status updates when canceling operations.
  - Added real-time notifications to inform users when a run has been successfully aborted.

- **Refactor**
  - Streamlined the cancellation workflow by simplifying abort request handling and improving error logging, resulting in a more reliable and smoother user experience during task aborts.
  - Enhanced browser session termination with improved error handling and logging to ensure robust cleanup during task aborts.

- **Bug Fixes**
  - Prevented status conflicts by ensuring aborted runs are not overwritten during execution or failure updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->