### PR TITLE
fix: notifies run finished prematurely

### DIFF
--- a/server/src/routes/record.ts
+++ b/server/src/routes/record.ts
@@ -234,7 +234,7 @@ router.get('/interpret', requireSignIn, async (req: AuthenticatedRequest, res) =
         logger.log('info', `Queued interpret workflow job: ${jobId}, waiting for completion...`);
 
         try {
-            const result = await waitForJobCompletion(jobId, 'interpret-workflow', 15000);
+            const result = await waitForJobCompletion(jobId, 'interpret-workflow', 1000000);
             
             if (result) {
                 return res.send('interpretation done');


### PR DESCRIPTION
What this PR does?

Increases the execution timeout for the output preview run so that run is not notified as completed prematurely.

Fixes: #531 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Extended the wait time for task completion, allowing the system to accommodate longer-running processes without prematurely timing out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->