### PR TITLE
fix: Rendered browser image stretches for some sites

### DIFF
--- a/server/src/browser-management/classes/RemoteBrowser.ts
+++ b/server/src/browser-management/classes/RemoteBrowser.ts
@@ -318,7 +318,6 @@ export class RemoteBrowser {
                     isMobile: false,
                     hasTouch: false,
                     userAgent: this.getUserAgent(),
-                    deviceScaleFactor: 2,
                 };
     
                 if (proxyOptions.server) {


### PR DESCRIPTION
What this PR does?

Removes the device scale factor that was responsible to browser image stretching.

Fixes: #539 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the browser's rendering configuration by removing a fixed scaling factor, allowing display behavior to more naturally adapt to various devices, including high-DPI screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->