### PR TITLE
fix: capture text highlighting on discard

### DIFF
--- a/src/components/recorder/RightSidePanel.tsx
+++ b/src/components/recorder/RightSidePanel.tsx
@@ -423,6 +423,8 @@ export const RightSidePanel: React.FC<RightSidePanelProps> = ({ onFinishCapture 
       }
     });
     resetListState();
+    stopPaginationMode();
+    stopLimitMode();
     setShowPaginationOptions(false);
     setShowLimitOptions(false);
     setCaptureStage('initial');

--- a/src/context/browserActions.tsx
+++ b/src/context/browserActions.tsx
@@ -68,7 +68,10 @@ export const ActionProvider = ({ children }: { children: ReactNode }) => {
         socket?.emit('setPaginationMode', { pagination: true });
     };
 
-    const stopPaginationMode = () => setPaginationMode(false);
+    const stopPaginationMode = () => {
+        setPaginationMode(false);
+        socket?.emit('setPaginationMode', { pagination: false });
+    };
 
     const startLimitMode = () => {
         setLimitMode(true);

--- a/src/context/browserActions.tsx
+++ b/src/context/browserActions.tsx
@@ -88,6 +88,7 @@ export const ActionProvider = ({ children }: { children: ReactNode }) => {
 
     const stopGetList = () => {
         setGetList(false);
+        socket?.emit('setGetList', { getList: false });
         setPaginationType('');
         setLimitType('');
         setCustomLimit('');


### PR DESCRIPTION
What this PR does?

Fixes the issue where the highlighter displays selection for Capture List instead of Capture Text on discarding Capture List action

Fixes: #555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization between local and socket states when stopping pagination and "get list" actions for consistent behavior.
  - Enhanced cleanup when discarding a list capture by explicitly stopping pagination and limit modes, ensuring better UI state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->