### PR TITLE
fix: destroy browser fallback

### DIFF
--- a/server/src/routes/record.ts
+++ b/server/src/routes/record.ts
@@ -147,7 +147,7 @@ router.get('/stop/:browserId', requireSignIn, async (req: AuthenticatedRequest, 
         });
 
         if (!jobId) {
-            await destroyRemoteBrowser(req.user.id, req.user.id);
+            await destroyRemoteBrowser(req.params.browserId, req.user.id);
             return res.send(false);
         }
 

--- a/server/src/routes/record.ts
+++ b/server/src/routes/record.ts
@@ -10,6 +10,7 @@ import {
     getRemoteBrowserCurrentUrl,
     getRemoteBrowserCurrentTabs,
     getActiveBrowserIdByState,
+    destroyRemoteBrowser,
 } from '../browser-management/controller';
 import { chromium } from 'playwright-extra';
 import stealthPlugin from 'puppeteer-extra-plugin-stealth';
@@ -146,8 +147,8 @@ router.get('/stop/:browserId', requireSignIn, async (req: AuthenticatedRequest, 
         });
 
         if (!jobId) {
-            const browserId = initializeRemoteBrowserForRecording(req.user.id);
-            return res.send( browserId );
+            await destroyRemoteBrowser(req.user.id, req.user.id);
+            return res.send(false);
         }
 
         logger.log('info', `Queued browser destruction job: ${jobId}, waiting for completion...`);


### PR DESCRIPTION
What this PR does?

Executes destroy browser fallback function if queueing fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the behavior of the stop recording endpoint to handle edge cases more reliably, ensuring browsers are properly destroyed if stopping fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->