### PR TITLE
feat: re-render robot list on retrain

### DIFF
--- a/src/components/robot/RecordingsTable.tsx
+++ b/src/components/robot/RecordingsTable.tsx
@@ -193,7 +193,7 @@ export const RecordingsTable = ({
           notify(notificationData.type, notificationData.message);
           
           if ((notificationData.type === 'success' && 
-               notificationData.message.includes('saved')) ||
+               (notificationData.message.includes('saved') || notificationData.message.includes('retrained'))) ||
               (notificationData.type === 'warning' && 
                notificationData.message.includes('terminated'))) {
             setRerenderRobots(true);
@@ -253,7 +253,7 @@ export const RecordingsTable = ({
         const parsedRows = recordings
         .map((recording: any, index: number) => {
           if (recording?.recording_meta) {
-            const parsedDate = parseDateString(recording.recording_meta.createdAt);
+            const parsedDate = parseDateString(recording.recording_meta.updatedAt);
             
             return {
               id: index,


### PR DESCRIPTION
What this PR does?

1. It orders the robots displayed based on their updated datetime instead of creation datetime
2. Rerenders robot list on retrain

Closes: #571 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved table updates to reflect additional recording notifications, ensuring more accurate and timely rerendering.
  - Changed recording sorting to use the last updated date, so the most recently updated recordings now appear first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->