### PR TITLE
fix: limit text overflows right side panel

### DIFF
--- a/src/components/recorder/RightSidePanel.tsx
+++ b/src/components/recorder/RightSidePanel.tsx
@@ -621,7 +621,15 @@ export const RightSidePanel: React.FC<RightSidePanelProps> = ({ onFinishCapture 
             {showLimitOptions && (
               <FormControl>
                 <FormLabel>
-                  <h4>{t('right_panel.limit.title')}</h4>
+                  <Typography variant="h6" sx={{ 
+                    fontSize: '16px', 
+                    fontWeight: 'bold',
+                    mb: 1,
+                    whiteSpace: 'normal', 
+                    wordBreak: 'break-word' 
+                  }}>
+                    {t('right_panel.limit.title')}
+                  </Typography>
                 </FormLabel>
                 <RadioGroup
                   value={limitType}
@@ -629,7 +637,7 @@ export const RightSidePanel: React.FC<RightSidePanelProps> = ({ onFinishCapture 
                   sx={{
                     display: 'flex',
                     flexDirection: 'column',
-                    width: '500px'
+                    width: '100%',
                   }}
                 >
                   <FormControlLabel value="10" control={<Radio />} label="10" />


### PR DESCRIPTION
What this PR does?

Fixes the text overflow for the right side panel limit window.

Closes: #576 

![image](https://github.com/user-attachments/assets/7d0ad37d-482b-44c9-b088-f9522dbdc22f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the appearance of the form label and limit options in the right side panel for improved consistency and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->