### PR TITLE
feat: support for editing multiple capture list limits

### DIFF
--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -254,11 +254,11 @@ function handleWorkflowActions(workflow: any[], credentials: Credentials) {
 router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
-    const { name, limit, credentials, targetUrl } = req.body;
+    const { name, limits, credentials, targetUrl } = req.body;
 
     // Validate input
-    if (!name && limit === undefined && !targetUrl) {
-      return res.status(400).json({ error: 'Either "name", "limit" or "target_url" must be provided.' });
+    if (!name && !limits && !credentials && !targetUrl) {
+      return res.status(400).json({ error: 'Either "name", "limits", "credentials" or "target_url" must be provided.' });
     }
 
     // Fetch the robot by ID
@@ -274,22 +274,26 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
     }
 
     if (targetUrl) {
-      const updatedWorkflow = robot.recording.workflow.map((step) => {
-        if (step.where?.url && step.where.url !== "about:blank") {
-          step.where.url = targetUrl;
-        }
-
-        step.what.forEach((action) => {
+      const updatedWorkflow = [...robot.recording.workflow];
+      
+      for (let i = updatedWorkflow.length - 1; i >= 0; i--) {
+        const step = updatedWorkflow[i];
+        for (let j = 0; j < step.what.length; j++) {
+          const action = step.what[j];
           if (action.action === "goto" && action.args?.length) {
-            action.args[0] = targetUrl; 
+
+            action.args[0] = targetUrl;
+            if (step.where?.url && step.where.url !== "about:blank") {
+              step.where.url = targetUrl;
+            }
+            
+            robot.set('recording', { ...robot.recording, workflow: updatedWorkflow });
+            robot.changed('recording', true);
+            i = -1;
+            break;
           }
-        });
-
-        return step;
-      });
-
-      robot.set('recording', { ...robot.recording, workflow: updatedWorkflow });
-      robot.changed('recording', true);
+        }
+      }
     }
 
     await robot.save();
@@ -300,38 +304,20 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
       workflow = handleWorkflowActions(workflow, credentials);
     }
 
-    // Update the limit
-    if (limit !== undefined) {
-      // Ensure the workflow structure is valid before updating
-      if (
-        workflow.length > 0 &&
-        workflow[0]?.what?.[0]
-      ) {
-        // Create a new workflow object with the updated limit
-        workflow = workflow.map((step, index) => {
-          if (index === 0) { // Assuming you want to update the first step
-            return {
-              ...step,
-              what: step.what.map((action, actionIndex) => {
-                if (actionIndex === 0) { // Assuming the first action needs updating
-                  return {
-                    ...action,
-                    args: (action.args ?? []).map((arg, argIndex) => {
-                      if (argIndex === 0) { // Assuming the first argument needs updating
-                        return { ...arg, limit };
-                      }
-                      return arg;
-                    }),
-                  };
-                }
-                return action;
-              }),
-            };
-          }
-          return step;
-        });
-      } else {
-        return res.status(400).json({ error: 'Invalid workflow structure for updating limit.' });
+    if (limits && Array.isArray(limits) && limits.length > 0) {
+      for (const limitInfo of limits) {
+        const { pairIndex, actionIndex, argIndex, limit } = limitInfo;
+        
+        const pair = workflow[pairIndex];
+        if (!pair || !pair.what) continue;
+        
+        const action = pair.what[actionIndex];
+        if (!action || !action.args) continue;
+        
+        const arg = action.args[argIndex];
+        if (!arg || typeof arg !== 'object') continue;
+        
+        (arg as { limit: number }).limit = limit;
       }
     }
 

--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -28,7 +28,12 @@ export const getStoredRecordings = async (): Promise<string[] | null> => {
   }
 };
 
-export const updateRecording = async (id: string, data: { name?: string; limit?: number, credentials?: Credentials, targetUrl?: string }): Promise<boolean> => {
+export const updateRecording = async (id: string, data: { 
+  name?: string; 
+  limits?: Array<{pairIndex: number, actionIndex: number, argIndex: number, limit: number}>;
+  credentials?: Credentials; 
+  targetUrl?: string 
+}): Promise<boolean> => {
   try {
     const response = await axios.put(`${apiUrl}/storage/recordings/${id}`, data);
     if (response.status === 200) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled editing and saving of multiple scrape list limits within a robot workflow.
  - The interface now dynamically detects and displays input fields for all scrape list limits, allowing users to modify each individually.

- **Bug Fixes**
  - Improved validation when updating recordings to ensure at least one relevant field is present.

- **Refactor**
  - Streamlined the process for updating target URLs and batch updating limits in workflows for better reliability and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->