### PR TITLE
fix: SSL certificate error on proxy configured browser launch

### DIFF
--- a/server/src/browser-management/classes/RemoteBrowser.ts
+++ b/server/src/browser-management/classes/RemoteBrowser.ts
@@ -284,6 +284,7 @@ export class RemoteBrowser {
                         "--disable-dev-shm-usage",
                         "--force-color-profile=srgb",
                         "--force-device-scale-factor=2",
+                        "--ignore-certificate-errors"
                     ],
                 }));
                 

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -89,6 +89,7 @@ router.get('/test', requireSignIn, async (req: Request, res: Response) => {
         const browser = await chromium.launch({
             headless: true,
             proxy: proxyOptions,
+            args:["--ignore-certificate-errors"]
         });
         const page = await browser.newPage();
         await page.goto('https://example.com');


### PR DESCRIPTION
What this PR does?

It sets parameters to ignore certificate errors on launching chromium browser instance. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved browser compatibility by allowing the browser to ignore SSL certificate errors during certain operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->