### PR TITLE
fix: remove `version` from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:13


### PR DESCRIPTION
the attribute `version` is obsolete

