### PR TITLE
feat: discard only current active action

### DIFF
--- a/src/components/browser/BrowserWindow.tsx
+++ b/src/components/browser/BrowserWindow.tsx
@@ -327,7 +327,7 @@ export const BrowserWindow = () => {
                             tag: highlighterData.elementInfo?.tagName,
                             shadow: highlighterData.elementInfo?.isShadowRoot,
                             attribute,
-                        }, currentTextActionId || `text-${Date.now()}`);
+                        }, currentTextActionId || `text-${crypto.randomUUID()}`);
                     } else {
                         // Show the modal if there are multiple options
                         setAttributeOptions(options);
@@ -344,7 +344,7 @@ export const BrowserWindow = () => {
                     if (paginationType !== '' && paginationType !== 'scrollDown' && paginationType !== 'scrollUp' && paginationType !== 'none') {
                         setPaginationSelector(highlighterData.selector);
                         notify(`info`, t('browser_window.attribute_modal.notifications.pagination_select_success'));
-                        addListStep(listSelector!, fields, currentListId || 0, currentListActionId || `list-${Date.now()}`, { type: paginationType, selector: highlighterData.selector });
+                        addListStep(listSelector!, fields, currentListId || 0, currentListActionId || `list-${crypto.randomUUID()}`, { type: paginationType, selector: highlighterData.selector });
                         socket?.emit('setPaginationMode', { pagination: false });
                     }
                     return;
@@ -412,7 +412,7 @@ export const BrowserWindow = () => {
                                 listSelector, 
                                 updatedFields, 
                                 currentListId, 
-                                currentListActionId || `list-${Date.now()}`,
+                                currentListActionId || `list-${crypto.randomUUID()}`,
                                 { type: '', selector: paginationSelector }
                             );
                         }
@@ -450,7 +450,7 @@ export const BrowserWindow = () => {
                         tag: selectedElement.info?.tagName,
                         shadow: selectedElement.info?.isShadowRoot,
                         attribute: attribute
-                    }, currentTextActionId || `text-${Date.now()}`);
+                    }, currentTextActionId || `text-${crypto.randomUUID()}`);
                 }
                 if (getList === true && listSelector && currentListId) {
                     const newField: TextStep = {
@@ -485,7 +485,7 @@ export const BrowserWindow = () => {
                             listSelector, 
                             updatedFields, 
                             currentListId, 
-                            currentListActionId || `list-${Date.now()}`,
+                            currentListActionId || `list-${crypto.randomUUID()}`,
                             { type: '', selector: paginationSelector }
                         );
                     }

--- a/src/components/browser/BrowserWindow.tsx
+++ b/src/components/browser/BrowserWindow.tsx
@@ -85,7 +85,7 @@ export const BrowserWindow = () => {
     const [paginationSelector, setPaginationSelector] = useState<string>('');
 
     const { socket } = useSocketStore();
-    const { notify } = useGlobalInfoStore();
+    const { notify, currentTextActionId, currentListActionId } = useGlobalInfoStore();
     const { getText, getList, paginationMode, paginationType, limitMode, captureStage } = useActionContext();
     const { addTextStep, addListStep, updateListStepData } = useBrowserSteps();
   
@@ -326,8 +326,8 @@ export const BrowserWindow = () => {
                             selector: highlighterData.selector,
                             tag: highlighterData.elementInfo?.tagName,
                             shadow: highlighterData.elementInfo?.isShadowRoot,
-                            attribute
-                        });
+                            attribute,
+                        }, currentTextActionId || `text-${Date.now()}`);
                     } else {
                         // Show the modal if there are multiple options
                         setAttributeOptions(options);
@@ -344,7 +344,7 @@ export const BrowserWindow = () => {
                     if (paginationType !== '' && paginationType !== 'scrollDown' && paginationType !== 'scrollUp' && paginationType !== 'none') {
                         setPaginationSelector(highlighterData.selector);
                         notify(`info`, t('browser_window.attribute_modal.notifications.pagination_select_success'));
-                        addListStep(listSelector!, fields, currentListId || 0, { type: paginationType, selector: highlighterData.selector });
+                        addListStep(listSelector!, fields, currentListId || 0, currentListActionId || `list-${Date.now()}`, { type: paginationType, selector: highlighterData.selector });
                         socket?.emit('setPaginationMode', { pagination: false });
                     }
                     return;
@@ -412,6 +412,7 @@ export const BrowserWindow = () => {
                                 listSelector, 
                                 updatedFields, 
                                 currentListId, 
+                                currentListActionId || `list-${Date.now()}`,
                                 { type: '', selector: paginationSelector }
                             );
                         }
@@ -449,7 +450,7 @@ export const BrowserWindow = () => {
                         tag: selectedElement.info?.tagName,
                         shadow: selectedElement.info?.isShadowRoot,
                         attribute: attribute
-                    });
+                    }, currentTextActionId || `text-${Date.now()}`);
                 }
                 if (getList === true && listSelector && currentListId) {
                     const newField: TextStep = {
@@ -484,6 +485,7 @@ export const BrowserWindow = () => {
                             listSelector, 
                             updatedFields, 
                             currentListId, 
+                            currentListActionId || `list-${Date.now()}`,
                             { type: '', selector: paginationSelector }
                         );
                     }

--- a/src/components/recorder/RightSidePanel.tsx
+++ b/src/components/recorder/RightSidePanel.tsx
@@ -139,20 +139,20 @@ export const RightSidePanel: React.FC<RightSidePanelProps> = ({ onFinishCapture 
 
   const handleStartGetText = () => {
     setIsCaptureTextConfirmed(false);
-    const newActionId = `text-${Date.now()}`;
+    const newActionId = `text-${crypto.randomUUID()}`;
     setCurrentTextActionId(newActionId);
     startGetText();
   }
 
   const handleStartGetList = () => {
     setIsCaptureListConfirmed(false);
-    const newActionId = `list-${Date.now()}`;
+    const newActionId = `list-${crypto.randomUUID()}`;
     setCurrentListActionId(newActionId);
     startGetList();
   }
 
   const handleStartGetScreenshot = () => {
-    const newActionId = `screenshot-${Date.now()}`;
+    const newActionId = `screenshot-${crypto.randomUUID()}`;
     setCurrentScreenshotActionId(newActionId);
     startGetScreenshot();
   };

--- a/src/context/globalInfo.tsx
+++ b/src/context/globalInfo.tsx
@@ -80,6 +80,12 @@ interface GlobalInfo {
   }) => void;
   shouldResetInterpretationLog: boolean;
   resetInterpretationLog: () => void;
+  currentTextActionId: string;
+  setCurrentTextActionId: (actionId: string) => void;
+  currentListActionId: string;
+  setCurrentListActionId: (actionId: string) => void;
+  currentScreenshotActionId: string;
+  setCurrentScreenshotActionId: (actionId: string) => void;
 };
 
 class GlobalInfoStore implements Partial<GlobalInfo> {
@@ -106,6 +112,9 @@ class GlobalInfoStore implements Partial<GlobalInfo> {
     hasScrapeSchemaAction: false,
   };
   shouldResetInterpretationLog = false;
+  currentTextActionId = '';
+  currentListActionId = '';
+  currentScreenshotActionId = '';
 };
 
 const globalInfoStore = new GlobalInfoStore();
@@ -129,6 +138,9 @@ export const GlobalInfoProvider = ({ children }: { children: JSX.Element }) => {
   const [recordingUrl, setRecordingUrl] = useState<string>(globalInfoStore.recordingUrl);
   const [currentWorkflowActionsState, setCurrentWorkflowActionsState] = useState(globalInfoStore.currentWorkflowActionsState);
   const [shouldResetInterpretationLog, setShouldResetInterpretationLog] = useState<boolean>(globalInfoStore.shouldResetInterpretationLog);
+  const [currentTextActionId, setCurrentTextActionId] = useState<string>('');
+  const [currentListActionId, setCurrentListActionId] = useState<string>('');
+  const [currentScreenshotActionId, setCurrentScreenshotActionId] = useState<string>('');
 
   const notify = (severity: 'error' | 'warning' | 'info' | 'success', message: string) => {
     setNotification({ severity, message, isOpen: true });
@@ -187,6 +199,12 @@ export const GlobalInfoProvider = ({ children }: { children: JSX.Element }) => {
         setCurrentWorkflowActionsState,
         shouldResetInterpretationLog,
         resetInterpretationLog,
+        currentTextActionId,
+        setCurrentTextActionId,
+        currentListActionId,
+        setCurrentListActionId,
+        currentScreenshotActionId,
+        setCurrentScreenshotActionId,
       }}
     >
       {children}


### PR DESCRIPTION
What this PR does?

Functionality to discard only the current active actions on clicking discard.


https://github.com/user-attachments/assets/7de80805-bd60-44c6-97eb-6264f87961ad


Closes: #586 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added the ability to group and track steps by an associated action.
  - Introduced a new option to remove all steps linked to a specific action.

- **Improvements**
  - Enhanced step management by allowing steps to be added with an action reference for better organization.
  - Extended global state to manage current action identifiers for text, list, and screenshot steps, improving tracking and association.
  - Enabled selective deletion of steps associated with a specific action when discarding captures, improving cleanup precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->