### PR TITLE
fix: wrap symbol in `String()` for safe conversion

### DIFF
--- a/src/components/recorder/PairDetail.tsx
+++ b/src/components/recorder/PairDetail.tsx
@@ -252,7 +252,10 @@ export const PairDetail = ({ pair, index }: PairDetailProps) => {
                           sx={{ flexGrow: 1, overflowY: 'auto' }}
                           key={`tree-view-2-${key}-${index}`}
                         >
-                          <TreeItem nodeId={`${key}-${index}`} label={`${pair.what[index].action}`}>
+                                                    <TreeItem
+  nodeId={`${String(key)}-${index}`}
+  label={`${String(pair.what[index].action)}`}
+>
                             {
                               // @ts-ignore
                               DisplayValueContent(pair.what[key], [key], false)

--- a/src/components/recorder/PairDetail.tsx
+++ b/src/components/recorder/PairDetail.tsx
@@ -252,10 +252,10 @@ export const PairDetail = ({ pair, index }: PairDetailProps) => {
                           sx={{ flexGrow: 1, overflowY: 'auto' }}
                           key={`tree-view-2-${key}-${index}`}
                         >
-                                                    <TreeItem
-  nodeId={`${String(key)}-${index}`}
-  label={`${String(pair.what[index].action)}`}
->
+                          <TreeItem
+                            nodeId={`${String(key)}-${index}`}
+                            label={`${String(pair.what[index].action)}`}
+                          >
                             {
                               // @ts-ignore
                               DisplayValueContent(pair.what[key], [key], false)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability in the display of the "What" section within the detail view by ensuring item labels and identifiers are consistently handled as strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->