### PR TITLE
fix: remove menu width adjustment on tab selection

### DIFF
--- a/src/components/dashboard/MainMenu.tsx
+++ b/src/components/dashboard/MainMenu.tsx
@@ -44,7 +44,7 @@ export const MainMenu = ({ value = 'robots', handleChangeContent }: MainMenuProp
   return (
     <Paper
       sx={{
-        height: 'auto',
+        height: '100%',
         width: '250px',
         backgroundColor: theme.palette.background.paper,
         paddingTop: '0.5rem',

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -171,7 +171,9 @@ export const MainPage = ({ handleEditRecording, initialContent }: MainPageProps)
 
   return (
     <Stack direction='row' spacing={0} sx={{ minHeight: '900px' }}>
+      <Stack sx={{ width: 240, flexShrink: 0 }}>
       <MainMenu value={content} handleChangeContent={setContent} />
+      </Stack>
       {DisplayContent()}
     </Stack>
   );

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -171,7 +171,7 @@ export const MainPage = ({ handleEditRecording, initialContent }: MainPageProps)
 
   return (
     <Stack direction='row' spacing={0} sx={{ minHeight: '900px' }}>
-      <Stack sx={{ width: 240, flexShrink: 0 }}>
+      <Stack sx={{ width: 250, flexShrink: 0 }}>
       <MainMenu value={content} handleChangeContent={setContent} />
       </Stack>
       {DisplayContent()}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated main menu container to occupy full height of its parent for improved layout consistency.
  - Main menu is now displayed within a fixed-width sidebar that does not shrink when resizing the window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->