### PR TITLE
feat: unified run creation and execution

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -61,7 +61,8 @@
         "notifications": {
             "delete_warning": "Der Roboter hat zugehörige Ausführungen. Löschen Sie zuerst die Ausführungen, um den Roboter zu löschen",
             "delete_success": "Roboter erfolgreich gelöscht",
-            "auth_success": "Roboter erfolgreich authentifiziert"
+            "auth_success": "Roboter erfolgreich authentifiziert",
+            "browser_limit_warning": "Remote-Browser sind derzeit ausgelastet. Bitte warten Sie einige Minuten und versuchen Sie es erneut"
         }
     },
     "mainmenu": {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -68,7 +68,8 @@
       "notifications": {
         "delete_warning": "The robot has associated runs. First delete runs to delete the robot",
         "delete_success": "Robot deleted successfully",
-        "auth_success": "Robot successfully authenticated"
+        "auth_success": "Robot successfully authenticated",
+        "browser_limit_warning": "Remote browsers are currently busy. Please wait for a few minutes and try again"
       }
     },
     "mainmenu":{

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -62,7 +62,8 @@
     "notifications": {
       "delete_warning": "El robot tiene ejecuciones asociadas. Primero elimine las ejecuciones para eliminar el robot",
       "delete_success": "Robot eliminado exitosamente",
-      "auth_success": "Robot autenticado exitosamente"
+      "auth_success": "Robot autenticado exitosamente",
+      "browser_limit_warning": "Los navegadores remotos están ocupados actualmente. Por favor, espere unos minutos e inténtelo de nuevo"
     }
   },
   "mainmenu": {

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -62,7 +62,8 @@
         "notifications": {
             "delete_warning": "ロボットには関連する実行があります。ロボットを削除するには、まず実行を削除してください",
             "delete_success": "ロボットが正常に削除されました",
-            "auth_success": "ロボットの認証に成功しました"
+            "auth_success": "ロボットの認証に成功しました",
+            "browser_limit_warning": "リモートブラウザは現在ビジー状態です。数分お待ちいただいてから再度お試しください"
         }
   },
   "mainmenu": {

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -62,7 +62,8 @@
     "notifications": {
       "delete_warning": "该机器人有关联的运行记录。请先删除运行记录才能删除机器人",
       "delete_success": "机器人删除成功",
-      "auth_success": "机器人认证成功"
+      "auth_success": "机器人认证成功",
+      "browser_limit_warning": "远程浏览器当前繁忙。请稍等几分钟后重试"
     }
   },
   "mainmenu": {

--- a/server/src/browser-management/classes/BrowserPool.ts
+++ b/server/src/browser-management/classes/BrowserPool.ts
@@ -507,6 +507,29 @@ export class BrowserPool {
     };
 
     /**
+     * Checks if there are available browser slots for a user.
+     * Returns true if user has available slots AND none of their active browsers are in "recording" state.
+     * @param userId the user ID to check browser slots for
+     * @returns {boolean} true if user has available slots and no recording browsers, false otherwise
+     */
+    public hasAvailableBrowserSlots = (userId: string, state?: BrowserState): boolean => {
+        const userBrowserIds = this.userToBrowserMap.get(userId) || [];
+        
+        if (userBrowserIds.length >= 2) {
+            return false;
+        }
+        
+        if (state === "recording") {
+            const hasBrowserInState = userBrowserIds.some(browserId => 
+                this.pool[browserId] && this.pool[browserId].state === "recording"
+            );
+            return !hasBrowserInState;
+        }
+        
+        return true;
+    };
+
+    /**
      * Returns the first active browser's instance id from the pool.
      * If there is no active browser, it returns null.
      * If there are multiple active browsers, it returns the first one.

--- a/server/src/browser-management/controller.ts
+++ b/server/src/browser-management/controller.ts
@@ -136,6 +136,19 @@ export const getActiveBrowserIdByState = (userId: string, state: "recording" | "
 };
 
 /**
+ * Checks if there are available browser slots for a user.
+ * Wrapper around {@link browserPool.hasAvailableBrowserSlots()} function.
+ * If state is provided, also checks that none of their active browsers are in that state.
+ * @param userId the user ID to check browser slots for
+ * @param state optional state to check - if provided, ensures no browser is in this state
+ * @returns {boolean} true if user has available slots (and no browsers in specified state if state is provided)
+ * @category BrowserManagement-Controller
+ */
+export const canCreateBrowserInState = (userId: string, state?: "recording" | "run"): boolean => {
+  return browserPool.hasAvailableBrowserSlots(userId, state);
+};
+
+/**
  * Returns the url string from a remote browser if exists in the browser pool.
  * @param id instance id of the remote browser
  * @returns {string | undefined}

--- a/server/src/browser-management/controller.ts
+++ b/server/src/browser-management/controller.ts
@@ -54,20 +54,23 @@ export const initializeRemoteBrowserForRecording = (userId: string): string => {
  * @category BrowserManagement-Controller
  */
 export const createRemoteBrowserForRun = (userId: string): string => {
-  const id = uuid();
+  if (!userId) {
+    logger.log('error', 'createRemoteBrowserForRun: Missing required parameter userId');
+    throw new Error('userId is required');
+  }
   
-  createSocketConnectionForRun(
-    io.of(id), 
-    async (socket: Socket) => {
-      try {
-        const browserSession = new RemoteBrowser(socket, userId, id);
-        await browserSession.initialize(userId);
-        browserPool.addRemoteBrowser(id, browserSession, userId, false, "run");
-        socket.emit('ready-for-run');
-      } catch (error: any) {
-        logger.error(`Error initializing browser: ${error.message}`);
-      }
-    });
+  const id = uuid();
+
+  const slotReserved = browserPool.reserveBrowserSlot(id, userId, "run");
+  if (!slotReserved) {
+    logger.log('warn', `Cannot create browser for user ${userId}: no available slots`);
+    throw new Error('User has reached maximum browser limit');
+  }
+
+  logger.log('info', `createRemoteBrowserForRun: Reserved slot ${id} for user ${userId}`);
+
+  initializeBrowserAsync(id, userId);
+  
   return id;
 };
 
@@ -209,5 +212,89 @@ export const stopRunningInterpretation = async (userId: string) => {
     await browser?.stopCurrentInterpretation();
   } else {
     logger.log('error', 'Cannot stop interpretation: No active browser or generator.');
+  }
+};
+
+const initializeBrowserAsync = async (id: string, userId: string) => {
+  try {
+    const namespace = io.of(id);
+    let clientConnected = false;
+    let connectionTimeout: NodeJS.Timeout;
+    
+    const waitForConnection = new Promise<Socket | null>((resolve) => {
+      namespace.on('connection', (socket: Socket) => {
+        clientConnected = true;
+        clearTimeout(connectionTimeout);
+        logger.log('info', `Frontend connected to browser ${id} via socket ${socket.id}`);
+        resolve(socket);
+      });
+      
+      connectionTimeout = setTimeout(() => {
+        if (!clientConnected) {
+          logger.log('warn', `No client connected to browser ${id} within timeout, proceeding with dummy socket`);
+          resolve(null);
+        }
+      }, 10000); 
+    });
+
+    namespace.on('error', (error: any) => {
+      logger.log('error', `Socket namespace error for browser ${id}: ${error.message}`);
+      clearTimeout(connectionTimeout);
+      browserPool.failBrowserSlot(id);
+    });
+
+    const socket = await waitForConnection;
+    
+    try {
+      let browserSession: RemoteBrowser;
+      
+      if (socket) {
+        logger.log('info', `Using real socket for browser ${id}`);
+        browserSession = new RemoteBrowser(socket, userId, id);
+      } else {
+        logger.log('info', `Using dummy socket for browser ${id}`);
+        const dummySocket = {
+          emit: (event: string, data?: any) => {
+            logger.log('debug', `Browser ${id} dummy socket emitted ${event}:`, data);
+          },
+          on: () => {},
+          id: `dummy-${id}`,
+        } as any;
+        
+        browserSession = new RemoteBrowser(dummySocket, userId, id);
+      }
+
+      await browserSession.initialize(userId);
+      
+      const upgraded = browserPool.upgradeBrowserSlot(id, browserSession);
+      if (!upgraded) {
+        throw new Error('Failed to upgrade reserved browser slot');
+      }
+      
+      if (socket) {
+        socket.emit('ready-for-run');
+      } else {
+        setTimeout(async () => {
+          try {
+            logger.log('info', `Starting execution for browser ${id} with dummy socket`);
+          } catch (error: any) {
+            logger.log('error', `Error executing run for browser ${id}: ${error.message}`);
+          }
+        }, 100); 
+      }
+      
+      logger.log('info', `Browser ${id} successfully initialized for run with ${socket ? 'real' : 'dummy'} socket`);
+      
+    } catch (error: any) {
+      logger.log('error', `Error initializing browser ${id}: ${error.message}`);
+      browserPool.failBrowserSlot(id);
+      if (socket) {
+        socket.emit('error', { message: error.message });
+      }
+    }
+    
+  } catch (error: any) {
+    logger.log('error', `Error setting up browser ${id}: ${error.message}`);
+    browserPool.failBrowserSlot(id);
   }
 };

--- a/server/src/routes/record.ts
+++ b/server/src/routes/record.ts
@@ -11,6 +11,7 @@ import {
     getRemoteBrowserCurrentTabs,
     getActiveBrowserIdByState,
     destroyRemoteBrowser,
+    canCreateBrowserInState,
 } from '../browser-management/controller';
 import { chromium } from 'playwright-extra';
 import stealthPlugin from 'puppeteer-extra-plugin-stealth';
@@ -179,6 +180,18 @@ router.get('/active', requireSignIn, (req: AuthenticatedRequest, res) => {
     }
     const id = getActiveBrowserIdByState(req.user?.id, "recording");
     return res.send(id);
+});
+
+/**
+ * GET endpoint for checking if the user can create a new remote browser.
+ */
+router.get('/can-create/:state', requireSignIn, (req: AuthenticatedRequest, res) => {
+    if (!req.user) {
+        return res.status(401).send('User not authenticated');
+    }
+    const state = req.params.state as "recording" | "run";
+    const canCreate = canCreateBrowserInState(req.user.id, state);
+    return res.json({ canCreate });
 });
 
 /**

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import logger from "../logger";
-import { createRemoteBrowserForRun, getActiveBrowserIdByState } from "../browser-management/controller";
+import { createRemoteBrowserForRun, destroyRemoteBrowser, getActiveBrowserIdByState } from "../browser-management/controller";
 import { chromium } from 'playwright-extra';
 import stealthPlugin from 'puppeteer-extra-plugin-stealth';
 import { browserPool } from "../server";
@@ -517,98 +517,131 @@ router.put('/runs/:id', requireSignIn, async (req: AuthenticatedRequest, res) =>
       return res.status(401).send({ error: 'Unauthorized' });
     }
 
-    const proxyConfig = await getDecryptedProxyConfig(req.user.id);
-    let proxyOptions: any = {};
-
-    if (proxyConfig.proxy_url) {
-      proxyOptions = {
-        server: proxyConfig.proxy_url,
-        ...(proxyConfig.proxy_username && proxyConfig.proxy_password && {
-          username: proxyConfig.proxy_username,
-          password: proxyConfig.proxy_password,
-        }),
-      };
-    }
-
-    console.log(`Proxy config for run: ${JSON.stringify(proxyOptions)}`);
-
     // Generate runId first
     const runId = uuid();
     
-    // Check if user has reached browser limit
-    const userBrowserIds = browserPool.getAllBrowserIdsForUser(req.user.id);
-    const canCreateBrowser = userBrowserIds.length < 2;
-    
-    if (canCreateBrowser) {
-      // User has available browser slots, create it directly
-      const id = createRemoteBrowserForRun(req.user.id);
+    const canCreateBrowser = await browserPool.hasAvailableBrowserSlots(req.user.id, "run");
 
-      const run = await Run.create({
-        status: 'running',
+    if (canCreateBrowser) {
+      let browserId: string;
+      
+      try {
+        browserId = await createRemoteBrowserForRun(req.user.id);
+        
+        if (!browserId || browserId.trim() === '') {
+          throw new Error('Failed to generate valid browser ID');
+        }
+        
+        logger.log('info', `Created browser ${browserId} for run ${runId}`);
+        
+      } catch (browserError: any) {
+        logger.log('error', `Failed to create browser: ${browserError.message}`);
+        return res.status(500).send({ error: 'Failed to create browser instance' });
+      }
+
+      try {
+        await Run.create({
+          status: 'running',
+          name: recording.recording_meta.name,
+          robotId: recording.id,
+          robotMetaId: recording.recording_meta.id,
+          startedAt: new Date().toLocaleString(),
+          finishedAt: '',
+          browserId: browserId, 
+          interpreterSettings: req.body,
+          log: '',
+          runId,
+          runByUserId: req.user.id,
+          serializableOutput: {},
+          binaryOutput: {},
+        });
+
+        logger.log('info', `Created run ${runId} with browser ${browserId}`);
+
+      } catch (dbError: any) {
+        logger.log('error', `Database error creating run: ${dbError.message}`);
+        
+        try {
+          await destroyRemoteBrowser(browserId, req.user.id);
+        } catch (cleanupError: any) {
+          logger.log('warn', `Failed to cleanup browser after run creation failure: ${cleanupError.message}`);
+        }
+        
+        return res.status(500).send({ error: 'Failed to create run record' });
+      }
+
+      try {
+        const userQueueName = `execute-run-user-${req.user.id}`;
+        await pgBoss.createQueue(userQueueName);
+        
+        const jobId = await pgBoss.send(userQueueName, {
+          emailId: req.user.email,
+          userId: req.user.id,
+          runId: runId,
+          browserId: browserId, 
+          interpreterSettings: req.body
+        });
+        
+        logger.log('info', `Queued run execution job with ID: ${jobId} for run: ${runId}`);
+      } catch (queueError: any) {
+        logger.log('error', `Failed to queue run execution: ${queueError.message}`);
+        
+        try {
+          await Run.update({
+            status: 'failed',
+            finishedAt: new Date().toLocaleString(),
+            log: 'Failed to queue execution job'
+          }, { where: { runId: runId } });
+          
+          await destroyRemoteBrowser(browserId, req.user.id);
+        } catch (cleanupError: any) {
+          logger.log('warn', `Failed to cleanup after queue error: ${cleanupError.message}`);
+        }
+
+        return res.status(503).send({ error: 'Unable to queue run, please try again later' });
+      }
+
+      return res.send({
+        browserId: browserId, 
+        runId: runId,
+        robotMetaId: recording.recording_meta.id,
+        queued: false 
+      }); 
+    } else {
+      const browserId = uuid(); 
+
+      await Run.create({
+        status: 'queued',
         name: recording.recording_meta.name,
         robotId: recording.id,
         robotMetaId: recording.recording_meta.id,
         startedAt: new Date().toLocaleString(),
         finishedAt: '',
-        browserId: id,
+        browserId,
         interpreterSettings: req.body,
-        log: '',
+        log: 'Run queued - waiting for available browser slot',
         runId,
         runByUserId: req.user.id,
         serializableOutput: {},
         binaryOutput: {},
       });
-
-      const plainRun = run.toJSON();
-
+      
       return res.send({
-        browserId: id,
-        runId: plainRun.runId,
+        browserId: browserId,
+        runId: runId,
         robotMetaId: recording.recording_meta.id,
-        queued: false
+        queued: true 
       });
-    } else {
-      const browserId = getActiveBrowserIdByState(req.user.id, "run")
-
-      if (browserId) {
-        // User has reached the browser limit, queue the run
-        try {        
-          // Create the run record with 'queued' status
-          await Run.create({
-            status: 'queued',
-            name: recording.recording_meta.name,
-            robotId: recording.id,
-            robotMetaId: recording.recording_meta.id,
-            startedAt: new Date().toLocaleString(),
-            finishedAt: '',
-            browserId: browserId,  // Random will be updated later
-            interpreterSettings: req.body,
-            log: 'Run queued - waiting for available browser slot',
-            runId,
-            runByUserId: req.user.id,
-            serializableOutput: {},
-            binaryOutput: {},
-          });
-          
-          return res.send({
-            browserId: browserId,
-            runId: runId,
-            robotMetaId: recording.recording_meta.id,
-            queued: true,
-          });
-        } catch (queueError: any) {
-          logger.log('error', `Failed to queue run job: ${queueError.message}`);
-          return res.status(503).send({ error: 'Unable to queue run, please try again later' });
-        }
-      } else {
-        logger.log('info', "Browser id does not exist");
-        return res.send('');
-      }
     }
   } catch (e) {
     const { message } = e as Error;
-    logger.log('info', `Error while creating a run with robot id: ${req.params.id} - ${message}`);
-    return res.send('');
+    logger.log('error', `Error while creating a run with robot id: ${req.params.id} - ${message}`);
+    
+    if (message.includes('invalid input syntax for type uuid')) {
+      return res.status(400).send({ error: 'Invalid UUID format detected' });
+    }
+    
+    return res.status(500).send({ error: 'Internal server error' });
   }
 });
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -20,6 +20,7 @@ import connectPgSimple from 'connect-pg-simple';
 import pg from 'pg';
 import session from 'express-session';
 import Run from './models/Run';
+import { processQueuedRuns } from './routes/storage';
 
 const app = express();
 app.use(cors({
@@ -162,6 +163,10 @@ app.use((req, res, next) => {
   }
   next();
 });
+
+setInterval(() => {
+  processQueuedRuns();
+}, 5000);
 
 server.listen(SERVER_PORT, '0.0.0.0', async () => {
   try {

--- a/src/api/recording.ts
+++ b/src/api/recording.ts
@@ -35,6 +35,19 @@ export const getActiveBrowserId = async(): Promise<string> => {
     }
 };
 
+export const canCreateBrowserInState = async(state: "recording" | "run"): Promise<boolean> => {
+    try {
+        const response = await axios.get(`${apiUrl}/record/can-create/${state}`, { withCredentials: true });
+        if (response.status === 200) {
+            return response.data.canCreate;
+        } else {
+            return false;
+        }
+    } catch(error: any) {
+        return false;
+    }
+};
+
 export const interpretCurrentRecording = async(): Promise<boolean> => {
     try {
         const response = await axios.get(`${apiUrl}/record/interpret`);

--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -161,7 +161,7 @@ export interface CreateRunResponseWithQueue extends CreateRunResponse {
 export const createAndRunRecording = async (id: string, settings: RunSettings): Promise<CreateRunResponseWithQueue> => {
   try {
     const response = await axios.put(
-      `${apiUrl}/robot/runs/${id}`,
+      `${apiUrl}/storage/runs/${id}`,
       { ...settings, withCredentials: true }
     );
     if (response.status === 200) {

--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -154,6 +154,27 @@ export const editRecordingFromStorage = async (browserId: string, id: string): P
   }
 };
 
+export interface CreateRunResponseWithQueue extends CreateRunResponse {
+  queued?: boolean;
+}
+
+export const createAndRunRecording = async (id: string, settings: RunSettings): Promise<CreateRunResponseWithQueue> => {
+  try {
+    const response = await axios.put(
+      `${apiUrl}/robot/runs/${id}`,
+      { ...settings, withCredentials: true }
+    );
+    if (response.status === 200) {
+      return response.data;
+    } else {
+      throw new Error(`Couldn't create and run recording ${id}`);
+    }
+  } catch (error: any) {
+    console.log(error);
+    return { browserId: '', runId: '', robotMetaId: '', queued: false };
+  }
+}
+
 export const createRunForStoredRecording = async (id: string, settings: RunSettings): Promise<CreateRunResponse> => {
   try {
     const response = await axios.put(

--- a/src/components/robot/RecordingsTable.tsx
+++ b/src/components/robot/RecordingsTable.tsx
@@ -39,7 +39,7 @@ import { useGlobalInfoStore } from "../../context/globalInfo";
 import { checkRunsForRecording, deleteRecordingFromStorage, getStoredRecordings } from "../../api/storage";
 import { Add } from "@mui/icons-material";
 import { useNavigate } from 'react-router-dom';
-import { getActiveBrowserId, stopRecording } from "../../api/recording";
+import { canCreateBrowserInState, getActiveBrowserId, stopRecording } from "../../api/recording";
 import { GenericModal } from '../ui/GenericModal';
 
 declare global {
@@ -274,11 +274,16 @@ export const RecordingsTable = ({
   }, [setRecordings, notify, t]);
 
   const handleNewRecording = useCallback(async () => {
-    const activeBrowserId = await getActiveBrowserId();
+    const canCreateRecording = await canCreateBrowserInState("recording");
     
-    if (activeBrowserId) {
-      setActiveBrowserId(activeBrowserId);
-      setWarningModalOpen(true);
+    if (!canCreateRecording) {
+        const activeBrowserId = await getActiveBrowserId();
+        if (activeBrowserId) {
+          setActiveBrowserId(activeBrowserId);
+          setWarningModalOpen(true);
+        } else {
+          notify('warning', t('recordingtable.notifications.browser_limit_warning'));
+        }
     } else {
       setModalOpen(true);
     }
@@ -314,7 +319,6 @@ export const RecordingsTable = ({
   };
 
   const handleRetrainRobot = useCallback(async (id: string, name: string) => {
-    const activeBrowserId = await getActiveBrowserId();
     const robot = rows.find(row => row.id === id);
     let targetUrl;
     
@@ -340,11 +344,18 @@ export const RecordingsTable = ({
       window.sessionStorage.setItem('initialUrl', targetUrl);
     }
     
-    if (activeBrowserId) {
-      setActiveBrowserId(activeBrowserId);
-      setWarningModalOpen(true);
+    const canCreateRecording = await canCreateBrowserInState("recording");
+    
+    if (!canCreateRecording) {
+      const activeBrowserId = await getActiveBrowserId();
+      if (activeBrowserId) {
+        setActiveBrowserId(activeBrowserId);
+        setWarningModalOpen(true);
+      } else {
+        notify('warning', t('recordingtable.notifications.browser_limit_warning'));
+      }
     } else {
-      startRetrainRecording(id, name, targetUrl);
+        startRetrainRecording(id, name, targetUrl);
     }
   }, [rows, setInitialUrl, setRecordingUrl]);
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MainMenu } from "../components/dashboard/MainMenu";
 import { Stack } from "@mui/material";
@@ -7,13 +7,14 @@ import { Runs } from "../components/run/Runs";
 import ProxyForm from '../components/proxy/ProxyForm';
 import ApiKey from '../components/api/ApiKey';
 import { useGlobalInfoStore } from "../context/globalInfo";
-import { createRunForStoredRecording, interpretStoredRecording, notifyAboutAbort, scheduleStoredRecording } from "../api/storage";
+import { createAndRunRecording, createRunForStoredRecording, CreateRunResponseWithQueue, interpretStoredRecording, notifyAboutAbort, scheduleStoredRecording } from "../api/storage";
 import { io, Socket } from "socket.io-client";
 import { stopRecording } from "../api/recording";
 import { RunSettings } from "../components/run/RunSettings";
 import { ScheduleSettings } from "../components/robot/ScheduleSettings";
 import { apiUrl } from "../apiConfig";
 import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/auth';
 
 interface MainPageProps {
   handleEditRecording: (id: string, fileName: string) => void;
@@ -43,11 +44,15 @@ export const MainPage = ({ handleEditRecording, initialContent }: MainPageProps)
     runId: '',
     robotMetaId: ''
   });
+  const [queuedRuns, setQueuedRuns] = React.useState<Set<string>>(new Set());
 
   let aborted = false;
 
   const { notify, setRerenderRuns, setRecordingId } = useGlobalInfoStore();
   const navigate  = useNavigate();
+
+  const { state } = useContext(AuthContext);
+  const { user } = state;
 
   const abortRunHandler = (runId: string) => {
     aborted = true;
@@ -90,48 +95,109 @@ export const MainPage = ({ handleEditRecording, initialContent }: MainPageProps)
   }, [currentInterpretationLog])
 
   const handleRunRecording = useCallback((settings: RunSettings) => {
-    createRunForStoredRecording(runningRecordingId, settings).then(({ browserId, runId, robotMetaId }: CreateRunResponse) => {
+    createAndRunRecording(runningRecordingId, settings).then((response: CreateRunResponseWithQueue) => {
+      const { browserId, runId, robotMetaId, queued } = response;
+      
       setIds({ browserId, runId, robotMetaId });
       navigate(`/runs/${robotMetaId}/run/${runId}`);
-      const socket =
-        io(`${apiUrl}/${browserId}`, {
+            
+      if (queued) {
+        console.log('Creating queue socket for queued run:', runId); 
+        
+        setQueuedRuns(prev => new Set([...prev, runId]));
+        
+        const queueSocket = io(`${apiUrl}/queued-run`, {
+          transports: ["websocket"],
+          rejectUnauthorized: false,
+          query: { userId: user?.id }
+        });
+        
+        queueSocket.on('connect', () => {
+          console.log('Queue socket connected for user:', user?.id);
+        });
+        
+        queueSocket.on('connect_error', (error) => {
+          console.log('Queue socket connection error:', error);
+        });
+        
+        queueSocket.on('run-completed', (completionData) => {
+          if (completionData.runId === runId) {  
+            setRunningRecordingName('');
+            setCurrentInterpretationLog('');          
+            setRerenderRuns(true);
+            
+            setQueuedRuns(prev => {
+              const newSet = new Set(prev);
+              newSet.delete(runId);
+              return newSet;
+            });
+            
+            const robotName = completionData.robotName || runningRecordingName;
+            
+            if (completionData.status === 'success') {
+              notify('success', t('main_page.notifications.interpretation_success', { name: robotName }));
+            } else {
+              notify('error', t('main_page.notifications.interpretation_failed', { name: robotName }));
+            }
+            
+            queueSocket.disconnect();
+          }
+        });
+        
+        setSockets(sockets => [...sockets, queueSocket]);
+        
+        notify('info', `Run queued: ${runningRecordingName}`);
+      } else {
+        const socket = io(`${apiUrl}/${browserId}`, {
           transports: ["websocket"],
           rejectUnauthorized: false
         });
-      setSockets(sockets => [...sockets, socket]);
-      socket.on('ready-for-run', () => readyForRunHandler(browserId, runId));
-      socket.on('debugMessage', debugMessageHandler);
-      socket.on('run-completed', (data) => {
-        setRerenderRuns(true);
         
-        const robotName = data.robotName;
+        setSockets(sockets => [...sockets, socket]);
         
-        if (data.status === 'success') {
-          notify('success', t('main_page.notifications.interpretation_success', { name: robotName }));
+        socket.on('debugMessage', debugMessageHandler);
+        socket.on('run-completed', (data) => {
+          setRunningRecordingName('');
+          setCurrentInterpretationLog('');
+          setRerenderRuns(true);
+          
+          const robotName = data.robotName;
+          
+          if (data.status === 'success') {
+            notify('success', t('main_page.notifications.interpretation_success', { name: robotName }));
+          } else {
+            notify('error', t('main_page.notifications.interpretation_failed', { name: robotName }));
+          }
+        });
+        
+        socket.on('connect_error', (error) => {
+          console.log('error', `Failed to connect to browser ${browserId}: ${error}`);
+          notify('error', t('main_page.notifications.connection_failed', { name: runningRecordingName }));
+        });
+
+        socket.on('disconnect', (reason) => {
+          console.log('warn', `Disconnected from browser ${browserId}: ${reason}`);
+        });
+        
+        if (runId) {
+          notify('info', t('main_page.notifications.run_started', { name: runningRecordingName }));
         } else {
-          notify('error', t('main_page.notifications.interpretation_failed', { name: robotName }));
+          notify('error', t('main_page.notifications.run_start_failed', { name: runningRecordingName }));
         }
-      });
-
-      socket.on('run-aborted', (data) => {
-        setRerenderRuns(true);
-        
-        const abortedRobotName = data.robotName;
-        notify('success', t('main_page.notifications.abort_success', { name: abortedRobotName }));
-      });
-
-      setContent('runs');
-      if (browserId) {
-        notify('info', t('main_page.notifications.run_started', { name: runningRecordingName }));
-      } else {
-        notify('error', t('main_page.notifications.run_start_failed', { name: runningRecordingName }));
       }
-    })
-    return (socket: Socket, browserId: string, runId: string) => {
-      socket.off('ready-for-run', () => readyForRunHandler(browserId, runId));
+      
+      setContent('runs');
+    }).catch((error: any) => {
+      console.error('Error in createAndRunRecording:', error); // ✅ Debug log
+    });
+
+    return (socket: Socket) => {
       socket.off('debugMessage', debugMessageHandler);
+      socket.off('run-completed');
+      socket.off('connect_error');
+      socket.off('disconnect');
     }
-  }, [runningRecordingName, sockets, ids, readyForRunHandler, debugMessageHandler])
+  }, [runningRecordingName, sockets, ids, debugMessageHandler, user?.id, t, notify, setRerenderRuns, setQueuedRuns, navigate, setContent, setIds]);
 
   const handleScheduleRecording = (settings: ScheduleSettings) => {
     scheduleStoredRecording(runningRecordingId, settings)


### PR DESCRIPTION
1. Creating a run and executing it with a single API call
2. Removing frontend socket event reliance for backend to determine readiness of browser
3. Ensures all queued runs are executed if browser is available

Fixes: #624, #622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for handling queued runs alongside immediate runs, including real-time updates when queued runs are completed.
  - Introduced a new notification message informing users when remote browsers are busy and advising to wait before retrying.
  - Added an endpoint and client API to check if users can create new remote browsers in specific states.
- **Bug Fixes**
  - Improved error handling and user notifications for run creation, browser limits, and connection issues.
- **Refactor**
  - Enhanced state management and event handling for both queued and immediate runs to ensure smoother user experience.
  - Simplified browser lifecycle management by waiting for browser readiness and unconditionally destroying browsers after runs.
- **Chores**
  - Scheduled periodic processing of queued runs to automatically start them when resources become available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->