### PR TITLE
fix: inherit bg in dark mode

### DIFF
--- a/src/components/dashboard/MainMenu.tsx
+++ b/src/components/dashboard/MainMenu.tsx
@@ -40,7 +40,7 @@ export const MainMenu = ({ value = 'robots', handleChangeContent }: MainMenuProp
     color: theme.palette.mode === 'light' ? '#6C6C6C' : 'inherit',
     '&:hover': {
       color: theme.palette.mode === 'light' ? '#6C6C6C' : 'inherit',
-      backgroundColor: theme.palette.mode === 'light' ? '#f5f5f5' : 'rgba(255, 255, 255, 0.08)',
+      backgroundColor: theme.palette.mode === 'light' ? '#f5f5f5' : 'inherit',
     },
   };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the hover background color for buttons in the MainMenu when using dark theme, ensuring it now inherits from parent or default styles for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->