### PR TITLE
fix: xpath validation check

### DIFF
--- a/src/helpers/clientSelectorGenerator.ts
+++ b/src/helpers/clientSelectorGenerator.ts
@@ -2820,6 +2820,11 @@ class ClientSelectorGenerator {
     contextNode: Document | ShadowRoot
   ): HTMLElement[] {
     try {
+      if (!this.isXPathSelector(xpath)) {
+        console.warn("Selector doesn't appear to be XPath:", xpath);
+        return [];
+      }
+
       const document =
         contextNode instanceof ShadowRoot
           ? (contextNode.host as HTMLElement).ownerDocument
@@ -2847,11 +2852,28 @@ class ClientSelectorGenerator {
     }
   }
 
+  private isXPathSelector(selector: string): boolean {
+    return selector.startsWith('//') || 
+      selector.startsWith('/') || 
+      selector.startsWith('./') ||
+      selector.includes('contains(@') ||
+      selector.includes('[count(') ||
+      selector.includes('@class=') ||
+      selector.includes('@id=') ||
+      selector.includes(' and ') ||
+      selector.includes(' or ');
+  }
+
   private fallbackXPathEvaluation(
     xpath: string,
     contextNode: Document | ShadowRoot
   ): HTMLElement[] {
     try {
+      if (this.isXPathSelector(xpath)) {
+        console.warn("⚠️ Complex XPath not supported in fallback:", xpath);
+        return [];
+      }
+
       const simpleTagMatch = xpath.match(/^\/\/(\w+)$/);
       if (simpleTagMatch) {
         const tagName = simpleTagMatch[1];


### PR DESCRIPTION
Fixes the xpath child elements evaluation error by adding validation checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of selector inputs by adding early validation for XPath selectors, preventing unsupported or unnecessary XPath evaluations.
  * Enhanced warning messages for unsupported or invalid XPath selectors to provide clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->