### PR TITLE
fix: href selector revamp

### DIFF
--- a/src/helpers/clientSelectorGenerator.ts
+++ b/src/helpers/clientSelectorGenerator.ts
@@ -1553,15 +1553,29 @@ class ClientSelectorGenerator {
         );
 
         return attrs.map(
-          (attr): Node => ({
-            name:
-              "[" +
-              cssesc(attr.name, { isIdentifier: true }) +
-              '="' +
-              cssesc(attr.value) +
-              '"]',
-            penalty: 0.5,
-          })
+          (attr): Node => {
+            let attrValue = attr.value;
+            
+            if (attr.name === "href" && attr.value.includes("://")) {
+              try {
+                const url = new URL(attr.value);
+                const siteOrigin = `${url.protocol}//${url.host}`;
+                attrValue = attr.value.replace(siteOrigin, "");
+              } catch (e) {
+                // Keep original if URL parsing fails
+              }
+            }
+            
+            return {
+              name:
+                "[" +
+                cssesc(attr.name, { isIdentifier: true }) +
+                '="' +
+                cssesc(attrValue) +
+                '"]',
+              penalty: 0.5,
+            };
+          }
         );
       }
 
@@ -3526,8 +3540,8 @@ class ClientSelectorGenerator {
     const elementInfo = this.getElementInformation(
       iframeDocument,
       coordinates,
-      this.listSelector,
-      this.getList
+      '',
+      false
     );
 
     const selectorBasedOnCustomAction = this.getSelectors(iframeDocument, coordinates);


### PR DESCRIPTION
What this PR does?

Solves the issue where few URLs were not being scraped. Had observed the behaviour for header links for the YC site.

![image](https://github.com/user-attachments/assets/95577f2b-28cb-42b6-a669-83723bb55b0f)

![image](https://github.com/user-attachments/assets/53a5f0ce-4884-4429-a9fb-a012345ade88)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved generation of CSS selectors for elements with href attributes by stripping the URL origin, resulting in more concise selectors.

* **Refactor**
  * Adjusted how element information is retrieved during selector generation to ensure consistent context, regardless of list-related state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->