### PR TITLE
feat: do not show recording url before browser is available

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -305,7 +305,7 @@
     },
     "recording_page": {
         "loader": {
-            "browser_startup": "Browser wird gestartet...Navigation zu {{url}}"
+            "browser_startup": "Browser wird gestartet...Festhalten"
         }
     },
     "integration_settings": {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -318,7 +318,7 @@
     },
     "recording_page": {
       "loader": {
-        "browser_startup": "Spinning up a browser...Navigating to {{url}}"
+        "browser_startup": "Spinning up a browser...Hold tight"
       }
     },
     "integration_settings": {

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -306,7 +306,7 @@
   },
   "recording_page": {
     "loader": {
-      "browser_startup": "Iniciando el navegador...Navegando a {{url}}"
+      "browser_startup": "Iniciando el navegador...Mantener apretado"
     }
   },
   "integration_settings": {

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -306,7 +306,7 @@
     },
     "recording_page": {
         "loader": {
-            "browser_startup": "ブラウザを起動中...{{url}}に移動中"
+            "browser_startup": "ブラウザを起動中...しっかり握って"
         }
     },
     "integration_settings": {

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -306,7 +306,7 @@
   },
   "recording_page": {
     "loader": {
-      "browser_startup": "正在启动浏览器...正在导航至{{url}}"
+      "browser_startup": "正在启动浏览器...抓紧"
     }
   },
   "integration_settings": {


### PR DESCRIPTION
closes #649 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the browser startup loading message on the recording page across all supported languages to use a shorter, static phrase instead of referencing a specific URL. This change provides a more concise and consistent user experience during browser startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->