### PR TITLE
fix: main menu tab spacing

### DIFF
--- a/src/components/dashboard/MainMenu.tsx
+++ b/src/components/dashboard/MainMenu.tsx
@@ -31,7 +31,7 @@ export const MainMenu = ({ value = 'robots', handleChangeContent }: MainMenuProp
     textAlign: 'left',
     fontSize: '17px',
     letterSpacing: '0.02857em',
-    padding: '20px 16px 6px 22px',
+    padding: '20px 16px 20px 22px',
     minHeight: '48px',
     minWidth: '100%',
     display: 'flex',

--- a/src/components/dashboard/MainMenu.tsx
+++ b/src/components/dashboard/MainMenu.tsx
@@ -112,7 +112,7 @@ export const MainMenu = ({ value = 'robots', handleChangeContent }: MainMenuProp
           />
         </Tabs>
         <hr />
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem', textAlign: 'left' }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', textAlign: 'left' }}>
           {/* <Button href={`${apiUrl}/api-docs/`} target="_blank" rel="noopener noreferrer" sx={buttonStyles} startIcon={<Code />}>
             {t('mainmenu.apidocs')}
           </Button> */}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the vertical padding of main menu buttons for a more balanced appearance.
  * Removed extra vertical spacing between buttons to create a more compact layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->