### PR TITLE
fix: attribute selection window closes

### DIFF
--- a/src/components/browser/BrowserWindow.tsx
+++ b/src/components/browser/BrowserWindow.tsx
@@ -1159,10 +1159,6 @@ export const BrowserWindow = () => {
         setShowAttributeModal(false);
         setSelectedElement(null);
         setAttributeOptions([]);
-
-        setTimeout(() => {
-        setShowAttributeModal(false);
-        }, 0);
     };
 
     const resetPaginationSelector = useCallback(() => {

--- a/src/components/ui/GenericModal.tsx
+++ b/src/components/ui/GenericModal.tsx
@@ -15,7 +15,7 @@ export const GenericModal: FC<ModalProps> = (
 
   return (
     <Modal open={isOpen} onClose={canBeClosed ? onClose : () => { }} >
-      <Box sx={modalStyle ? { ...modalStyle, boxShadow: 24, position: 'absolute', borderRadius: 5 } : defaultModalStyle}>
+      <Box sx={modalStyle ? { ...modalStyle, boxShadow: 24, position: 'absolute', borderRadius: 5 } : defaultModalStyle} onClick={(e) => e.stopPropagation()}>
         {canBeClosed ?
           <IconButton onClick={onClose} sx={{ float: "right" }}>
             <Clear sx={{ fontSize: 20 }} />


### PR DESCRIPTION
What this PR does?

Solves the issue where the attribute selection modal wont close on clicking close button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal behavior to prevent unintended closing when clicking inside the modal content area.
  * Streamlined attribute selection process in the browser window for more consistent and predictable user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->