### PR TITLE
feat: auto add capture fields for list selection

### DIFF
--- a/src/components/browser/BrowserWindow.tsx
+++ b/src/components/browser/BrowserWindow.tsx
@@ -935,7 +935,7 @@ export const BrowserWindow = () => {
         element: HTMLElement;
         isLeaf: boolean;
         depth: number;
-        position: { x: number; y: number }; // Add position property
+        position: { x: number; y: number };
       }>
     ): Array<{
       id: number;
@@ -943,7 +943,7 @@ export const BrowserWindow = () => {
       element: HTMLElement;
       isLeaf: boolean;
       depth: number;
-      position: { x: number; y: number }; // Add position property
+      position: { x: number; y: number };
     }> => {
       const filtered: Array<{
         id: number;
@@ -977,8 +977,6 @@ export const BrowserWindow = () => {
         }
       }
 
-      // Remove the sorting here since we want to maintain position-based order
-      // The candidates are already sorted by position before this function is called
       return filtered;
     };
 
@@ -989,7 +987,7 @@ export const BrowserWindow = () => {
         element: HTMLElement;
         isLeaf: boolean;
         depth: number;
-        position: { x: number; y: number }; // Add position property
+        position: { x: number; y: number };
       }>
     ): Record<string, TextStep> => {
       const finalFields: Record<string, TextStep> = {};

--- a/src/components/browser/BrowserWindow.tsx
+++ b/src/components/browser/BrowserWindow.tsx
@@ -324,6 +324,7 @@ export const BrowserWindow = () => {
           element: HTMLElement;
           isLeaf: boolean;
           depth: number;
+          position: { x: number; y: number };
         }> = [];
 
         const uniqueChildSelectors = [...new Set(childSelectors)];
@@ -704,6 +705,9 @@ export const BrowserWindow = () => {
             ) as HTMLElement;
 
             if (element && isElementVisible(element)) {
+              const rect = element.getBoundingClientRect();
+              const position = { x: rect.left, y: rect.top };
+
               const tagName = element.tagName.toLowerCase();
               const isShadow = element.getRootNode() instanceof ShadowRoot;
 
@@ -726,6 +730,7 @@ export const BrowserWindow = () => {
                     element: element,
                     isLeaf: true,
                     depth: 0,
+                    position: position,
                     field: {
                       id: fieldIdHref,
                       type: "text",
@@ -749,6 +754,7 @@ export const BrowserWindow = () => {
                     element: element,
                     isLeaf: true,
                     depth: 0,
+                    position: position,
                     field: {
                       id: fieldIdText,
                       type: "text",
@@ -776,6 +782,7 @@ export const BrowserWindow = () => {
                     element: element,
                     isLeaf: true,
                     depth: 0,
+                    position: position,
                     field: {
                       id: fieldId,
                       type: "text",
@@ -799,6 +806,7 @@ export const BrowserWindow = () => {
                     element: element,
                     isLeaf: true,
                     depth: 0,
+                    position: position,
                     field: {
                       id: fieldId,
                       type: "text",
@@ -832,6 +840,7 @@ export const BrowserWindow = () => {
                     element: deepestElement,
                     isLeaf: isLeaf,
                     depth: depth,
+                    position: position,
                     field: {
                       id: fieldId,
                       type: "text",
@@ -854,6 +863,16 @@ export const BrowserWindow = () => {
               error
             );
           }
+        });
+
+        candidateFields.sort((a, b) => {
+          const yDiff = a.position.y - b.position.y;
+          
+          if (Math.abs(yDiff) <= 5) {
+            return a.position.x - b.position.x;
+          }
+          
+          return yDiff;
         });
 
         const filteredCandidates = removeParentChildDuplicates(candidateFields);
@@ -916,6 +935,7 @@ export const BrowserWindow = () => {
         element: HTMLElement;
         isLeaf: boolean;
         depth: number;
+        position: { x: number; y: number }; // Add position property
       }>
     ): Array<{
       id: number;
@@ -923,6 +943,7 @@ export const BrowserWindow = () => {
       element: HTMLElement;
       isLeaf: boolean;
       depth: number;
+      position: { x: number; y: number }; // Add position property
     }> => {
       const filtered: Array<{
         id: number;
@@ -930,6 +951,7 @@ export const BrowserWindow = () => {
         element: HTMLElement;
         isLeaf: boolean;
         depth: number;
+        position: { x: number; y: number };
       }> = [];
 
       for (const candidate of candidates) {
@@ -955,13 +977,8 @@ export const BrowserWindow = () => {
         }
       }
 
-      filtered.sort((a, b) => {
-        if (a.isLeaf !== b.isLeaf) {
-          return a.isLeaf ? -1 : 1;
-        }
-        return b.depth - a.depth;
-      });
-
+      // Remove the sorting here since we want to maintain position-based order
+      // The candidates are already sorted by position before this function is called
       return filtered;
     };
 
@@ -972,6 +989,7 @@ export const BrowserWindow = () => {
         element: HTMLElement;
         isLeaf: boolean;
         depth: number;
+        position: { x: number; y: number }; // Add position property
       }>
     ): Record<string, TextStep> => {
       const finalFields: Record<string, TextStep> = {};

--- a/src/components/recorder/DOMBrowserRenderer.tsx
+++ b/src/components/recorder/DOMBrowserRenderer.tsx
@@ -667,6 +667,12 @@ export const DOMBrowserRenderer: React.FC<RRWebDOMBrowserRendererProps> = ({
           return;
         }
 
+        if (isCachingChildSelectors) {
+          e.preventDefault();
+          e.stopPropagation();
+          return;
+        }
+
         e.preventDefault();
 
         if (!isInCaptureMode) {
@@ -1009,7 +1015,8 @@ export const DOMBrowserRenderer: React.FC<RRWebDOMBrowserRendererProps> = ({
           height: "100%",
           border: "none",
           display: "block",
-          overflow: "hidden !important",
+          overflow: isCachingChildSelectors ? "hidden !important" : "hidden !important",
+          pointerEvents: isCachingChildSelectors ? "none" : "auto",
         }}
         sandbox="allow-same-origin allow-forms allow-scripts"
         title="DOM Browser Content"


### PR DESCRIPTION
What this PR does?

1. Alters the UI for the selection of list element
2. Auto adds the fields of the captured list element

https://github.com/user-attachments/assets/5c279e54-7ae9-42d9-89a9-6c932d51236f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a visual scanning animation overlay with highlights and labels during list selector caching for clearer feedback.
  * Added automatic creation of candidate fields from child selectors to streamline data extraction.
* **Enhancements**
  * Improved the loading overlay by replacing the spinner with a semi-transparent background and animated highlights of group elements.
  * Disabled user interactions (scrolling, clicking) on the iframe during list selector caching to prevent interference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->