### PR TITLE
feat: option to remove authentication for integration

### DIFF
--- a/src/components/integration/IntegrationSettings.tsx
+++ b/src/components/integration/IntegrationSettings.tsx
@@ -815,14 +815,24 @@ export const IntegrationSettingsModal = ({
                     ) : error ? (
                       <Typography color="error">{error}</Typography>
                     ) : spreadsheets.length === 0 ? (
-                      <Button
-                        variant="outlined"
-                        color="primary"
-                        onClick={fetchSpreadsheetFiles}
-                        disabled={loading}
-                      >
-                        {t("integration_settings.google.buttons.fetch_sheets")}
-                      </Button>
+                      <Box sx={{ display: "flex", gap: "15px", alignItems: "center", marginBottom: "20px" }}>
+                        <Button
+                          variant="outlined"
+                          color="primary"
+                          onClick={fetchSpreadsheetFiles}
+                          disabled={loading}
+                        >
+                          {t("integration_settings.google.buttons.fetch_sheets")}
+                        </Button>
+                        <Button
+                          variant="outlined"
+                          color="error"
+                          onClick={removeGoogleSheetsIntegration}
+                          disabled={loading}
+                        >
+                          {loading ? <CircularProgress size={24} /> : t("integration_settings.google.buttons.remove_integration")}
+                        </Button>
+                      </Box>
                     ) : (
                       <>
                         <TextField
@@ -915,14 +925,24 @@ export const IntegrationSettingsModal = ({
                     ) : error ? (
                       <Typography color="error">{error}</Typography>
                     ) : airtableBases.length === 0 ? (
-                      <Button
-                        variant="outlined"
-                        color="primary"
-                        onClick={fetchAirtableBases}
-                        disabled={loading}
-                      >
-                        {t("integration_settings.airtable.buttons.fetch_bases")}
-                      </Button>
+                      <Box sx={{ display: "flex", gap: "15px", alignItems: "center", marginBottom: "20px" }}>
+                        <Button
+                          variant="outlined"
+                          color="primary"
+                          onClick={fetchAirtableBases}
+                          disabled={loading}
+                        >
+                          {t("integration_settings.airtable.buttons.fetch_bases")}
+                        </Button>
+                        <Button
+                          variant="outlined"
+                          color="error"
+                          onClick={removeAirtableIntegration}
+                          disabled={loading}
+                        >
+                          {loading ? <CircularProgress size={24} /> : t("integration_settings.airtable.buttons.remove_integration")}
+                        </Button>
+                      </Box>
                     ) : (
                       <>
                         <TextField


### PR DESCRIPTION
What this PR does?

Provides an option to remove authentication during sheet or base selection for google sheets and airtable integrations

Closes: #692

<img width="1411" height="695" alt="image" src="https://github.com/user-attachments/assets/45946ed4-ffd2-4a30-97cf-c4e894b6a32d" />

<img width="1411" height="698" alt="image" src="https://github.com/user-attachments/assets/b346c056-0ea7-4bb4-94cc-392a246c086c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


## Summary by CodeRabbit

* **New Features**
  * Added a "Remove Integration" button to the Google Sheets and Airtable integration UIs when no data is loaded, allowing users to remove integrations directly from the fetch state.
  * The new buttons display a loading indicator when an action is in progress and are styled for clear visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->