### PR TITLE
feat: increase job execution duration

### DIFF
--- a/server/src/pgboss-worker.ts
+++ b/server/src/pgboss-worker.ts
@@ -56,7 +56,10 @@ interface AbortRunData {
   runId: string;
 }
 
-const pgBoss = new PgBoss({connectionString: pgBossConnectionString });
+const pgBoss = new PgBoss({
+  connectionString: pgBossConnectionString,
+  expireInHours: 23
+});
 
 /**
  * Extract data safely from a job (single job or job array)


### PR DESCRIPTION
What this PR does?

Increases the duration of job execution from default 15 minutes to 23 hours ensuring the run does not get interrupted due to job expiration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal job processing configuration to improve background task handling reliability. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->