### PR TITLE
fix(maxun-core): add multiple scroll approach

### DIFF
--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -734,10 +734,22 @@ export default class Interpreter extends EventEmitter {
               return allResults;
             }
 
-            await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+            await page.evaluate(() => {
+              const scrollHeight = Math.max(
+                document.body.scrollHeight,
+                document.documentElement.scrollHeight
+              );
+
+              window.scrollTo(0, scrollHeight);
+            });
             await page.waitForTimeout(2000);
 
-            const currentHeight = await page.evaluate(() => document.body.scrollHeight);
+            const currentHeight = await page.evaluate(() => {
+              return Math.max(
+                document.body.scrollHeight,
+                document.documentElement.scrollHeight
+              );
+            });
             const currentResultCount = allResults.length;
             
             if (currentResultCount === previousResultCount) {
@@ -1024,10 +1036,22 @@ export default class Interpreter extends EventEmitter {
           
               // Wait for content to load and check scroll height
               await page.waitForTimeout(2000);
-              await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+              await page.evaluate(() => {
+                const scrollHeight = Math.max(
+                  document.body.scrollHeight,
+                  document.documentElement.scrollHeight
+                );
+
+                window.scrollTo(0, scrollHeight);
+              });
               await page.waitForTimeout(2000);
-          
-              const currentHeight = await page.evaluate(() => document.body.scrollHeight);
+
+              const currentHeight = await page.evaluate(() => {
+                return Math.max(
+                  document.body.scrollHeight,
+                  document.documentElement.scrollHeight
+                );
+              });
               const heightChanged = currentHeight !== previousHeight;
               previousHeight = currentHeight;
               


### PR DESCRIPTION
What this PR does?

Brings in support for one more scroll approach just in case the original one fails as it seems to be not supported for certain sites like [www.youtube.com](http://www.youtube.com/)

Fixes: #759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-scroll now consistently reaches the true bottom of pages, reducing missed content.
  * Improved handling of pages with complex or dynamically changing layouts.
  * More reliable behavior when navigating paginated content, minimizing stalls or partial loads.
  * Smoother end-of-page detection for long documents and feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->