### PR TITLE
feat: prevent robot saving without capture actions

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -241,7 +241,15 @@
             "unable_create_settings": "Listeneinstellungen können nicht erstellt werden. Stellen Sie sicher, dass Sie ein Feld für die Liste definiert haben.",
             "capture_text_discarded": "Texterfassung verworfen",
             "capture_list_discarded": "Listenerfassung verworfen",
-            "label_required": "Beschriftung darf nicht leer sein"
+            "label_required": "Beschriftung darf nicht leer sein",
+            "duplicate_label": "Diese Beschriftung existiert bereits. Bitte verwenden Sie eine eindeutige Beschriftung.",
+            "no_text_captured": "Bitte markieren und wählen Sie Textelemente aus, bevor Sie bestätigen.",
+            "capture_list_first": "Bitte bewegen Sie die Maus über eine Liste und wählen Sie Textfelder darin aus",
+            "confirm_all_list_fields": "Bitte bestätigen Sie alle erfassten Listenfelder, bevor Sie fortfahren"
+        },
+        "tooltips": {
+            "capture_list_first": "Bewegen Sie die Maus über eine Liste und wählen Sie Textfelder darin aus",
+            "confirm_all_list_fields": "Bitte bestätigen Sie alle erfassten Listenfelder, bevor Sie fortfahren"
         }
     },
     "save_recording": {
@@ -258,7 +266,8 @@
         },
         "errors": {
             "user_not_logged": "Benutzer nicht angemeldet. Aufnahme kann nicht gespeichert werden.",
-            "exists_warning": "Ein Roboter mit diesem Namen existiert bereits, bitte bestätigen Sie das Überschreiben des Roboters."
+            "exists_warning": "Ein Roboter mit diesem Namen existiert bereits, bitte bestätigen Sie das Überschreiben des Roboters.",
+            "no_actions_performed": "Roboter kann nicht gespeichert werden. Bitte führen Sie mindestens eine Erfassungsaktion durch, bevor Sie speichern."
         },
         "tooltips": {
             "saving": "Workflow wird optimiert und gespeichert"

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -241,7 +241,15 @@
         "unable_create_settings": "Unable to create list settings. Make sure you have defined a field for the list.",
         "capture_text_discarded": "Capture Text Discarded",
         "capture_list_discarded": "Capture List Discarded",
-        "label_required": "Label cannot be empty"
+        "label_required": "Label cannot be empty",
+        "duplicate_label": "This label already exists. Please use a unique label.",
+        "no_text_captured": "Please highlight and select text elements before confirming.",
+        "capture_list_first": "Please hover over a list and select text fields inside it first",
+        "confirm_all_list_fields": "Please confirm all captured list fields before proceeding"
+      },
+      "tooltips": {
+        "capture_list_first": "Hover over a list and select text fields inside it first",
+        "confirm_all_list_fields": "Please confirm all captured list fields before proceeding"
       }
     },
     "save_recording": {
@@ -258,7 +266,8 @@
       },
       "errors": {
         "user_not_logged": "User not logged in. Cannot save recording.",
-        "exists_warning": "Robot with this name already exists, please confirm the Robot's overwrite."
+        "exists_warning": "Robot with this name already exists, please confirm the Robot's overwrite.",
+        "no_actions_performed": "Cannot save robot. Please perform at least one capture action before saving."
       },
       "tooltips": {
         "saving": "Optimizing and saving the workflow"

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -241,7 +241,15 @@
       "unable_create_settings": "No se pueden crear las configuraciones de la lista. Asegúrese de haber definido un campo para la lista.",
       "capture_text_discarded": "Captura de texto descartada",
       "capture_list_discarded": "Captura de lista descartada",
-      "label_required": "La etiqueta no puede estar vacía"
+      "label_required": "La etiqueta no puede estar vacía",
+      "duplicate_label": "Esta etiqueta ya existe. Por favor use una etiqueta única.",
+      "no_text_captured": "Por favor resalte y seleccione elementos de texto antes de confirmar.",
+      "capture_list_first": "Por favor posicione el cursor sobre una lista y seleccione campos de texto dentro de ella primero",
+      "confirm_all_list_fields": "Por favor confirme todos los campos de lista capturados antes de continuar"
+    },
+    "tooltips": {
+      "capture_list_first": "Posicione el cursor sobre una lista y seleccione campos de texto dentro de ella primero",
+      "confirm_all_list_fields": "Por favor confirme todos los campos de lista capturados antes de continuar"
     }
   },
   "save_recording": {
@@ -258,7 +266,8 @@
     },
     "errors": {
       "user_not_logged": "Usuario no conectado. No se puede guardar la grabación.",
-      "exists_warning": "Ya existe un robot con este nombre, por favor confirme la sobrescritura del robot."
+      "exists_warning": "Ya existe un robot con este nombre, por favor confirme la sobrescritura del robot.",
+      "no_actions_performed": "No se puede guardar el robot. Por favor realice al menos una acción de captura antes de guardar."
     },
     "tooltips": {
       "saving": "Optimizando y guardando el flujo de trabajo"

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -241,7 +241,15 @@
             "unable_create_settings": "リスト設定を作成できません。リストのフィールドを定義したことを確認してください。",
             "capture_text_discarded": "テキスト取得が破棄されました",
             "capture_list_discarded": "リスト取得が破棄されました",
-            "label_required": "ラベルは空にできません"
+            "label_required": "ラベルは空にできません",
+            "duplicate_label": "このラベルは既に存在します。固有のラベルを使用してください。",
+            "no_text_captured": "確認する前にテキスト要素をハイライトして選択してください。",
+            "capture_list_first": "まずリストの上にカーソルを置き、その中のテキストフィールドを選択してください",
+            "confirm_all_list_fields": "続行する前にすべてのキャプチャされたリストフィールドを確認してください"
+        },
+        "tooltips": {
+            "capture_list_first": "リストの上にカーソルを置き、その中のテキストフィールドを選択してください",
+            "confirm_all_list_fields": "すべてのキャプチャされたリストフィールドを確認してください"
         }
     },
     "save_recording": {
@@ -258,7 +266,8 @@
         },
         "errors": {
             "user_not_logged": "ユーザーがログインしていません。録画を保存できません。",
-            "exists_warning": "この名前のロボットは既に存在します。ロボットの上書きを確認してください。"
+            "exists_warning": "この名前のロボットは既に存在します。ロボットの上書きを確認してください。",
+            "no_actions_performed": "ロボットを保存できません。保存する前に少なくとも1つのキャプチャアクションを実行してください。"
         },
         "tooltips": {
             "saving": "ワークフローを最適化して保存中"

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -241,7 +241,14 @@
       "unable_create_settings": "Liste ayarları oluşturulamadı. Bir alan tanımladığınızdan emin olun.",
       "capture_text_discarded": "Metin Yakalama İptal Edildi",
       "capture_list_discarded": "Liste Yakalama İptal Edildi",
-      "label_required": "Etiket boş olamaz"
+      "label_required": "Etiket boş olamaz",
+      "no_text_captured": "Henüz metin yakalanmadı. Lütfen önce metin öğeleri seçin.",
+      "duplicate_label": "Bu etiket zaten mevcut. Lütfen benzersiz bir etiket kullanın.",
+      "capture_list_first": "Lütfen onaylamadan önce bir liste yakalayın ve alanlar seçin.",
+      "confirm_all_list_fields": "Lütfen devam etmeden önce tüm liste alanlarını onaylayın."
+    },
+    "tooltips": {
+      "confirm_all_list_fields": "Lütfen bir sonraki adıma geçmeden önce tüm liste alanlarını onaylayın"
     }
   },
   "save_recording": {
@@ -258,7 +265,8 @@
     },
     "errors": {
       "user_not_logged": "Kullanıcı girişi yok. Kaydedilemedi.",
-      "exists_warning": "Bu isimde robot zaten var; üzerine yazmayı onaylayın."
+      "exists_warning": "Bu isimde robot zaten var; üzerine yazmayı onaylayın.",
+      "no_actions_performed": "Robot kaydedilemez. Lütfen kaydetmeden önce en az bir yakalama eylemi gerçekleştirin."
     },
     "tooltips": {
       "saving": "Akış optimize ediliyor ve kaydediliyor"

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -241,7 +241,15 @@
       "unable_create_settings": "无法创建列表设置。请确保您已为列表定义了字段。",
       "capture_text_discarded": "文本捕获已放弃",
       "capture_list_discarded": "列表捕获已放弃",
-      "label_required": "标签不能为空"
+      "label_required": "标签不能为空",
+      "duplicate_label": "此标签已存在。请使用唯一的标签。",
+      "no_text_captured": "请在确认之前先高亮并选择文本元素。",
+      "capture_list_first": "请先将鼠标悬停在列表上并选择其中的文本字段",
+      "confirm_all_list_fields": "请在继续之前确认所有已捕获的列表字段"
+    },
+    "tooltips": {
+      "capture_list_first": "将鼠标悬停在列表上并选择其中的文本字段",
+      "confirm_all_list_fields": "请确认所有已捕获的列表字段"
     }
   },
   "save_recording": {
@@ -258,7 +266,8 @@
     },
     "errors": {
       "user_not_logged": "用户未登录。无法保存录制。",
-      "exists_warning": "已存在同名机器人，请确认是否覆盖机器人。"
+      "exists_warning": "已存在同名机器人，请确认是否覆盖机器人。",
+      "no_actions_performed": "无法保存机器人。请在保存之前至少执行一次捕获操作。"
     },
     "tooltips": {
       "saving": "正在优化并保存工作流程"


### PR DESCRIPTION
What this PR does?

1. Does not let the user save a robot without at least performing a single capture action.
2. Better notifications on confirm capture list without highlighting or without confirming all fields.

Closes: #766 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added per-action validations for list and text capture, including duplicate label detection and requiring all list fields to be confirmed before proceeding.
  - Confirm button now shows tooltips explaining outstanding requirements.
  - Prevent saving when no capture actions were performed, with clear error messaging.
  - Improved success/error notifications, preserved across app exit.

- Localization
  - Added new error and tooltip messages across German, English, Spanish, Japanese, Turkish, and Chinese to support the enhanced capture and save flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->