### PR TITLE
fix: images do not load in recorder

### DIFF
--- a/server/src/browser-management/classes/RemoteBrowser.ts
+++ b/server/src/browser-management/classes/RemoteBrowser.ts
@@ -380,6 +380,7 @@ export class RemoteBrowser {
             );
 
             await this.currentPage.mouse.wheel(data.deltaX, data.deltaY);
+            await this.currentPage.waitForLoadState("networkidle", { timeout: 5000 });
 
             const scrollInfo = await this.currentPage.evaluate(() => ({
               x: window.scrollX,
@@ -1590,7 +1591,7 @@ export class RemoteBrowser {
           }
 
           return window.rrwebSnapshot.snapshot(document, {
-            inlineImages: true,
+            inlineImages: false,
             collectFonts: true,
           });
         });


### PR DESCRIPTION
What this PR does?

It fixes the issue with the images not loading in the remote browser environment for certain sites.

Fixes: #780 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability after scroll actions by waiting for the page to stabilize, reducing flicker and missed updates.

* **Performance**
  * Reduced session recording payload sizes by no longer inlining images in snapshots, improving upload speeds and bandwidth usage. Fonts remain captured for consistent rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->