### PR TITLE
fix: back navigation for integrations

### DIFF
--- a/src/components/robot/pages/RobotIntegrationPage.tsx
+++ b/src/components/robot/pages/RobotIntegrationPage.tsx
@@ -694,7 +694,7 @@ export const RobotIntegrationPage = ({
     return (
       <RobotConfigPage
         title={getIntegrationTitle()}
-        // onCancel={handleCancel}
+        onCancel={handleCancel}
         cancelButtonText={t("buttons.cancel")}
         showSaveButton={false}
         // onBackToSelection={handleBack}

--- a/src/components/robot/pages/RobotIntegrationPage.tsx
+++ b/src/components/robot/pages/RobotIntegrationPage.tsx
@@ -698,7 +698,7 @@ export const RobotIntegrationPage = ({
         cancelButtonText={t("buttons.cancel")}
         showSaveButton={false}
         // onBackToSelection={handleBack}
-        onArrowBack={handleBack}
+        // onArrowBack={handleBack}
         showCancelButton={false}
         backToSelectionText={t("buttons.back_arrow")}
       >


### PR DESCRIPTION
closes #785 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated UI prop handling in RobotIntegrationPage to correctly pass onCancel and remove onArrowBack props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->