### PR TITLE
fix: redirect to /integrate/googleSheets on auth

### DIFF
--- a/src/components/robot/Recordings.tsx
+++ b/src/components/robot/Recordings.tsx
@@ -79,7 +79,7 @@ export const Recordings = ({
     } else if (authStatus === "success" && robotId) {
       console.log("Google Auth Status:", authStatus);
       notify(authStatus, t("recordingtable.notifications.auth_success"));
-      handleNavigate(`/robots/${robotId}/integrate/google`, robotId, "", []);
+      handleNavigate(`/robots/${robotId}/integrate/googleSheets`, robotId, "", []);
     }
   }, []);
 


### PR DESCRIPTION
closes #787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * After successful Google authentication, users are now redirected to the Google Sheets integration page for the selected robot (/robots/{id}/integrate/googleSheets) instead of the previous Google integration route. Navigation is consistent with the integration destination. Existing flows, notifications, and other navigation behaviors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->