### PR TITLE
chore: remove ts-node dependency for server, use tsc + node (#107)

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "scripts": {
     "start": "concurrently -k \"npm run server\" \"npm run client\"",
-    "server": "cross-env NODE_OPTIONS='--max-old-space-size=8000' nodemon server/src/server.ts",
+    "server": "cross-env NODE_OPTIONS='--max-old-space-size=8000' nodemon server/dist/server.js",
     "client": "vite",
     "build": "vite build",
     "build:server": "tsc -p server/tsconfig.json",
@@ -130,6 +130,7 @@
     "ajv": "^8.8.2",
     "concurrently": "^7.0.0",
     "cross-env": "^7.0.3",
+    "esbuild": "^0.25.10",
     "js-cookie": "^3.0.5",
     "nodemon": "^2.0.15",
     "sequelize-cli": "^6.6.2",


### PR DESCRIPTION
This PR removes ts-node from the backend workflow. The server now uses:

- TypeScript compiler (tsc) for compiling server code
- nodemon to run compiled JS (server/dist/server.js)

This improves startup speed, avoids runtime dependency on ts-node, and keeps the project compatible with all Node.js dependencies.

All scripts (client, migrations, linting) remain unchanged.

Addresses issue #107.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated server startup configuration to run the compiled production build.
  - Aligned build tooling by adding required entries to both runtime and development dependencies.
  - Deployment and start commands have been adjusted accordingly.
  - No user-facing changes expected; application behavior remains the same in normal use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->