### PR TITLE
feat: disable mui tabs indicator animation

### DIFF
--- a/src/components/dashboard/MainMenu.tsx
+++ b/src/components/dashboard/MainMenu.tsx
@@ -87,7 +87,7 @@ export const MainMenu = ({ value = 'robots', handleChangeContent }: MainMenuProp
             textColor="primary"
             indicatorColor="primary"
             orientation="vertical"
-            sx={{ alignItems: 'flex-start' }}
+            sx={{ alignItems: 'flex-start', '& .MuiTabs-indicator': { display: 'none' }}
           >
             <Tab
               value="robots"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the visual tab indicator from the vertical menu navigation in the dashboard, providing a cleaner interface while preserving all existing menu functionality and navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->