### PR TITLE
feat: faster remote browser loading

### DIFF
--- a/src/components/browser/BrowserContent.tsx
+++ b/src/components/browser/BrowserContent.tsx
@@ -13,7 +13,7 @@ import {
 export const BrowserContent = () => {
   const { socket } = useSocketStore();
 
-  const [tabs, setTabs] = useState<string[]>(["current"]);
+  const [tabs, setTabs] = useState<string[]>(["Loading..."]);
   const [tabIndex, setTabIndex] = React.useState(0);
   const [showOutputData, setShowOutputData] = useState(false);
   const { browserWidth } = useBrowserDimensionsStore();
@@ -125,7 +125,7 @@ export const BrowserContent = () => {
   useEffect(() => {
     getCurrentTabs()
       .then((response) => {
-        if (response) {
+        if (response && response.length > 0) {
           setTabs(response);
         }
       })

--- a/src/pages/PageWrapper.tsx
+++ b/src/pages/PageWrapper.tsx
@@ -116,6 +116,10 @@ export const PageWrapper = () => {
                 path="/register"
                 element={<Register />}
               />
+              <Route
+                path="/recording-setup"
+                element={<div />}
+              />
               <Route path="*" element={<NotFoundPage />} />
             </Routes>
           </React.Fragment>

--- a/src/pages/RecordingPage.tsx
+++ b/src/pages/RecordingPage.tsx
@@ -43,7 +43,7 @@ export const RecordingPage = ({ recordingName }: RecordingPageProps) => {
 
   const { setId, socket } = useSocketStore();
   const { setWidth } = useBrowserDimensionsStore();
-  const { browserId, setBrowserId, recordingId, recordingUrl, setRecordingUrl, setRecordingName, setRetrainRobotId } = useGlobalInfoStore();
+  const { browserId, setBrowserId, recordingId, recordingUrl, setRecordingUrl, setRecordingName, setRetrainRobotId, setIsDOMMode } = useGlobalInfoStore();
 
   const handleShowOutputData = useCallback(() => {
     setShowOutputData(true);
@@ -77,6 +77,8 @@ export const RecordingPage = ({ recordingName }: RecordingPageProps) => {
   useEffect(() => {
     let isCancelled = false;
     const handleRecording = async () => {
+      setIsDOMMode(true);
+
       const storedUrl = window.sessionStorage.getItem('recordingUrl');
       if (storedUrl && !recordingUrl) {
         setRecordingUrl(storedUrl);
@@ -137,9 +139,12 @@ export const RecordingPage = ({ recordingName }: RecordingPageProps) => {
       if (browserId === 'new-recording') {
         socket?.emit('new-recording');
       }
+      if (recordingUrl && socket) {
+        socket.emit('input:url', recordingUrl);
+      }
       setIsLoaded(true);
     }
-  }, [socket, browserId, recordingName, recordingId, isLoaded]);
+  }, [socket, browserId, recordingName, recordingId, recordingUrl, isLoaded]);
 
   useEffect(() => {
     socket?.on('loaded', handleLoaded);
@@ -153,26 +158,20 @@ export const RecordingPage = ({ recordingName }: RecordingPageProps) => {
     <ActionProvider>
       <BrowserStepsProvider>
         <div id="browser-recorder">
-          {isLoaded ? (
-            <>
-              <Grid container direction="row" style={{ flexGrow: 1, height: '100%' }}>
-                <Grid item xs={12} md={9} lg={9} style={{ height: '100%', overflow: 'hidden', position: 'relative' }}>
-                  <div style={{ height: '100%', overflow: 'auto' }}>
-                    <BrowserContent />
-                    <InterpretationLog isOpen={showOutputData} setIsOpen={setShowOutputData} />
-                  </div>
-                </Grid>
-                <Grid item xs={12} md={3} lg={3} style={{ height: '100%', overflow: 'hidden' }}>
-                  <div className="right-side-panel" style={{ height: '100%' }}>
-                    <RightSidePanel onFinishCapture={handleShowOutputData} />
-                    <BrowserRecordingSave />
-                  </div>
-                </Grid>
-              </Grid>
-            </>
-          ) : (
-            <Loader text={t('recording_page.loader.browser_startup', { url: recordingUrl })} />
-          )}
+          <Grid container direction="row" style={{ flexGrow: 1, height: '100%' }}>
+            <Grid item xs={12} md={9} lg={9} style={{ height: '100%', overflow: 'hidden', position: 'relative' }}>
+              <div style={{ height: '100%', overflow: 'auto' }}>
+                <BrowserContent />
+                <InterpretationLog isOpen={showOutputData} setIsOpen={setShowOutputData} />
+              </div>
+            </Grid>
+            <Grid item xs={12} md={3} lg={3} style={{ height: '100%', overflow: 'hidden' }}>
+              <div className="right-side-panel" style={{ height: '100%' }}>
+                <RightSidePanel onFinishCapture={handleShowOutputData} />
+                <BrowserRecordingSave />
+              </div>
+            </Grid>
+          </Grid>
         </div>
       </BrowserStepsProvider>
     </ActionProvider>


### PR DESCRIPTION
What this PR does?

Sunsets the old spinning browser loader. Introduces inline loading progress indicator for browser spin up.


https://github.com/user-attachments/assets/60f78e7b-4116-4d01-9279-22c93af28aff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visible initial-load progress reporting during page loads and a DOM-driven rendering path for recordings.
  * New /recording-setup route.

* **UI/UX Improvements**
  * Persistent two-pane recording layout always shown.
  * DOM loading indicator plus refined element highlight/overlay for clearer interactions.
  * Simplified click handling and more consistent playback rendering.

* **Bug Fixes**
  * Tabs now initialize as "Loading..." and update only when fetched data is non-empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->