### PR TITLE
Revert "fix: recorder ui bug "

### DIFF
--- a/src/components/recorder/RightSidePanel.tsx
+++ b/src/components/recorder/RightSidePanel.tsx
@@ -534,24 +534,9 @@ export const RightSidePanel: React.FC<RightSidePanelProps> = ({ onFinishCapture 
   const isDarkMode = theme.darkMode;
 
   return (
-    <Paper sx={{ height: panelHeight, width: 'auto', alignItems: "center", background: 'inherit', overflow: 'hidden' }} id="browser-actions" elevation={0}>
+    <Paper sx={{ height: panelHeight, width: 'auto', alignItems: "center", background: 'inherit' }} id="browser-actions" elevation={0}>
       <ActionDescriptionBox isDarkMode={isDarkMode} />
-      <Box
-        display="flex"
-        flexDirection="column"
-        gap={2}
-        style={{ margin: '13px' }}
-        sx={{
-          height: 'calc(100% - 26px)',
-          overflowY: 'auto',
-          overflowX: 'hidden',
-          '&::-webkit-scrollbar': {
-            display: 'none'
-          },
-          msOverflowStyle: 'none',
-          scrollbarWidth: 'none'
-        }}
-      >
+      <Box display="flex" flexDirection="column" gap={2} style={{ margin: '13px' }}>
         {!isAnyActionActive && (
           <>
             {showCaptureList && (

--- a/src/pages/RecordingPage.tsx
+++ b/src/pages/RecordingPage.tsx
@@ -157,7 +157,7 @@ export const RecordingPage = ({ recordingName }: RecordingPageProps) => {
             <>
               <Grid container direction="row" style={{ flexGrow: 1, height: '100%' }}>
                 <Grid item xs={12} md={9} lg={9} style={{ height: '100%', overflow: 'hidden', position: 'relative' }}>
-                  <div style={{ height: '100%', overflow: 'hidden' }}>
+                  <div style={{ height: '100%', overflow: 'auto' }}>
                     <BrowserContent />
                     <InterpretationLog isOpen={showOutputData} setIsOpen={setShowOutputData} />
                   </div>


### PR DESCRIPTION
Reverts getmaxun/maxun#853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modified scrolling behavior in the recording interface: the right-side panel now displays content without explicit scroll constraints, and the main recording page area now shows scrollbars when content overflows instead of hiding them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->