### PR TITLE
fix: stop option not available when robot is running

### DIFF
--- a/src/components/run/RunContent.tsx
+++ b/src/components/run/RunContent.tsx
@@ -617,10 +617,15 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
       <TabContext value={tab}>
         <TabPanel value='output' sx={{ width: '100%', maxWidth: '900px' }}>
           {row.status === 'running' || row.status === 'queued' ? (
-            <Box sx={{ display: 'flex', alignItems: 'center' }}>
-              <CircularProgress size={22} sx={{ marginRight: '10px' }} />
-              {t('run_content.loading')}
-            </Box>
+            <>
+              <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                <CircularProgress size={22} sx={{ marginRight: '10px' }} />
+                {t('run_content.loading')}
+              </Box>
+              <Button color="error" onClick={abortRunHandler} sx={{ mt: 1 }}>
+                {t('run_content.buttons.stop')}
+              </Button>
+            </>
           ) : (!hasData && !hasScreenshots
             ? <Typography>{t('run_content.empty_output')}</Typography>
             : null)}


### PR DESCRIPTION
What this PR does?

Adds the stop button for running robots allowing the functionality to abort running robots.

Fixes: #867 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now stop or cancel runs while they are in progress or queued for execution. A stop button is displayed alongside the loading indicator for easy access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->