### PR TITLE
fix(maxun-core): run stuck in endless loop of clicking on pagination buttons

### DIFF
--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -1246,9 +1246,9 @@ export default class Interpreter extends EventEmitter {
             if (checkLimit()) return allResults;
             
             let loadMoreCounter = 0;
-            // let previousResultCount = allResults.length;
-            // let noNewItemsCounter = 0;
-            // const MAX_NO_NEW_ITEMS = 2;
+            let previousResultCount = allResults.length;
+            let noNewItemsCounter = 0;
+            const MAX_NO_NEW_ITEMS = 5;
             
             while (true) {
               if (this.isAborted) {
@@ -1332,21 +1332,21 @@ export default class Interpreter extends EventEmitter {
               
               await scrapeCurrentPage();
               
-              // const currentResultCount = allResults.length;
-              // const newItemsAdded = currentResultCount > previousResultCount;
+              const currentResultCount = allResults.length;
+              const newItemsAdded = currentResultCount > previousResultCount;
                           
-              // if (!newItemsAdded) {
-              //   noNewItemsCounter++;
-              //   debugLog(`No new items added after click (${noNewItemsCounter}/${MAX_NO_NEW_ITEMS})`);
+              if (!newItemsAdded) {
+                noNewItemsCounter++;
+                debugLog(`No new items added after click (${noNewItemsCounter}/${MAX_NO_NEW_ITEMS})`);
                 
-              //   if (noNewItemsCounter >= MAX_NO_NEW_ITEMS) {
-              //     debugLog(`Stopping after ${MAX_NO_NEW_ITEMS} clicks with no new items`);
-              //     return allResults;
-              //   }
-              // } else {
-              //   noNewItemsCounter = 0;
-              //   previousResultCount = currentResultCount;
-              // }
+                if (noNewItemsCounter >= MAX_NO_NEW_ITEMS) {
+                  debugLog(`Stopping after ${MAX_NO_NEW_ITEMS} clicks with no new items`);
+                  return allResults;
+                }
+              } else {
+                noNewItemsCounter = 0;
+                previousResultCount = currentResultCount;
+              }
               
               if (checkLimit()) return allResults;     
               


### PR DESCRIPTION
What this PR does?

1. Adds a no new items check to detect if new items are being added and accordingly exits if not for Load More.

Fixes: #868 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Pagination now terminates automatically after detecting no new items across multiple consecutive attempts, reducing unnecessary page loads and improving app responsiveness.
  * Termination logic enhanced and consistently applied across all pagination methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->