### PR TITLE
fix: output preview for capture text action

### DIFF
--- a/src/components/run/InterpretationLog.tsx
+++ b/src/components/run/InterpretationLog.tsx
@@ -306,6 +306,8 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
         shouldOpenDrawer = true;
       }
       lastListDataLength.current = captureListData.length;
+    } else if (hasScrapeListAction && captureListData.length === 0) {
+      lastListDataLength.current = 0;
     }
 
     if (hasScrapeSchemaAction && captureTextData.length > 0 && !getText) {
@@ -315,6 +317,8 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
         shouldOpenDrawer = true;
       }
       lastTextDataLength.current = captureTextData.length;
+    } else if (hasScrapeSchemaAction && captureTextData.length === 0) {
+      lastTextDataLength.current = 0;
     }
 
     if (hasScreenshotAction && screenshotData.length > 0) {
@@ -324,6 +328,8 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
         shouldOpenDrawer = true;
       }
       lastScreenshotDataLength.current = screenshotData.length;
+    } else if (hasScreenshotAction && screenshotData.length === 0) {
+      lastScreenshotDataLength.current = 0;
     }
 
     const getLatestCaptureType = () => {
@@ -466,7 +472,7 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
             {t('interpretation_log.titles.output_preview')}
           </Typography>
 
-          {!(hasScrapeListAction || hasScrapeSchemaAction || hasScreenshotAction) && (
+          {!(hasScrapeListAction || hasScrapeSchemaAction || hasScreenshotAction) && !showPreviewData && availableTabs.length === 0 && (
             <Grid container justifyContent="center" alignItems="center" style={{ height: '100%' }}>
               <Grid item>
                 <Typography variant="h6" gutterBottom align="left">


### PR DESCRIPTION
What this PR does?

1. Fixes the output preview issue occurring mid capture text action.
2. Fixes the issue wherein the output preview does not automatically open if capture performed the second time immediately after discard operation.

<img width="1347" height="663" alt="Screenshot 2025-11-10 at 10 02 59 AM" src="https://github.com/user-attachments/assets/87c7dfa8-7a01-4331-ae18-04901b403829" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preview drawer behavior to properly handle empty data states and prevent unexpected opening/closing sequences.
  * Improved display logic for the no-selection message to account for available preview data and tabs, ensuring the message only appears when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->