### PR TITLE
fix: settings show only one limit for robots with multiple list actions

### DIFF
--- a/src/components/robot/pages/RobotSettingsPage.tsx
+++ b/src/components/robot/pages/RobotSettingsPage.tsx
@@ -152,20 +152,36 @@ export const RobotSettingsPage = ({ handleStart }: RobotSettingsProps) => {
                 }}
                 style={{ marginBottom: "20px" }}
               />
-              {robot.recording.workflow?.[0]?.what?.[0]?.args?.[0]?.limit !==
-                undefined && (
-                <TextField
-                  label={t("robot_settings.robot_limit")}
-                  type="number"
-                  value={
-                    robot.recording.workflow[0].what[0].args[0].limit || ""
-                  }
-                  InputProps={{
-                    readOnly: true,
-                  }}
-                  style={{ marginBottom: "20px" }}
-                />
-              )}
+              {(() => {
+                let listCounter = 1;
+
+                return robot.recording.workflow.flatMap((wf, wfIndex) =>
+                  wf.what.flatMap((action, actionIndex) => {
+                    const argsWithLimit = action.args?.filter(
+                      (arg: any) => arg && typeof arg === "object" && arg.limit !== undefined
+                    );
+
+                    if (!argsWithLimit?.length) return [];
+
+                    return argsWithLimit.map((arg, limitIndex) => {
+                      const labelName = action.name || `List ${listCounter++}`;
+                      return (
+                        <TextField
+                          key={`limit-${wfIndex}-${actionIndex}-${limitIndex}`}
+                          label={`${t("robot_settings.robot_limit")} (${labelName})`}
+                          type="number"
+                          value={arg.limit || ""}
+                          InputProps={{
+                            readOnly: true,
+                          }}
+                          style={{ marginBottom: "20px" }}
+                        />
+                      );
+                    });
+                  })
+                );
+              })()}
+
               <TextField
                 label={t("robot_settings.created_by_user")}
                 key="Created By User"


### PR DESCRIPTION
What this PR does?

Fixes the issue with the robot settings displaying the limit of only a single capture list action even if multiple actions are present.

<img width="999" height="559" alt="Screenshot 2025-11-12 at 11 14 03 PM" src="https://github.com/user-attachments/assets/ccd6cbbc-54da-4ae8-906d-3fd7abfb2ab3" />

Fixes #870 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Robot settings page now dynamically renders limit fields for all available workflows and actions, replacing the previous single hard-coded field. Each read-only numeric field is labeled with its corresponding action name for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->