### PR TITLE
fix: conditionally render action names & list limits

### DIFF
--- a/src/components/robot/pages/RobotEditPage.tsx
+++ b/src/components/robot/pages/RobotEditPage.tsx
@@ -791,6 +791,9 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
     navigate(basePath);
   };
 
+  const scrapeListLimitFields = renderScrapeListLimitFields();
+  const actionNameFields = renderActionNameFields();
+
   return (
     <RobotConfigPage
       title={t("robot_edit.title")}

--- a/src/components/robot/pages/RobotEditPage.tsx
+++ b/src/components/robot/pages/RobotEditPage.tsx
@@ -791,9 +791,6 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
     navigate(basePath);
   };
 
-  const scrapeListLimitFields = renderScrapeListLimitFields();
-  const actionNameFields = renderActionNameFields();
-
   return (
     <RobotConfigPage
       title={t("robot_edit.title")}
@@ -824,10 +821,20 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
                 onChange={(e) => handleTargetUrlChange(e.target.value)}
                 style={{ marginBottom: "20px" }}
               />
-              <Divider />
-              {renderScrapeListLimitFields()}
-              <Divider />
-              {renderActionNameFields()}
+             {renderScrapeListLimitFields() && (
+  <>
+    <Divider />
+    {renderScrapeListLimitFields()}
+  </>
+)}
+
+{renderActionNameFields() && (
+  <>
+    <Divider />
+    {renderActionNameFields()}
+  </>
+)}
+
             </>
           )}
         </Box>

--- a/src/components/robot/pages/RobotEditPage.tsx
+++ b/src/components/robot/pages/RobotEditPage.tsx
@@ -500,7 +500,7 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
         {scrapeListLimits.map((limitInfo, index) => {
           // Get the corresponding scrapeList action to extract its name
           const scrapeListAction = robot?.recording?.workflow?.[limitInfo.pairIndex]?.what?.[limitInfo.actionIndex];
-          const actionName = 
+          const actionName =
             scrapeListAction?.name ||
             `List Limit ${index + 1}`;
 
@@ -821,20 +821,19 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
                 onChange={(e) => handleTargetUrlChange(e.target.value)}
                 style={{ marginBottom: "20px" }}
               />
-             {renderScrapeListLimitFields() && (
-  <>
-    <Divider />
-    {renderScrapeListLimitFields()}
-  </>
-)}
+              {renderScrapeListLimitFields() && (
+                <>
+                  <Divider />
+                  {renderScrapeListLimitFields()}
+                </>
+              )}
 
-{renderActionNameFields() && (
-  <>
-    <Divider />
-    {renderActionNameFields()}
-  </>
-)}
-
+              {renderActionNameFields() && (
+                <>
+                  <Divider />
+                  {renderActionNameFields()}
+                </>
+              )}
             </>
           )}
         </Box>


### PR DESCRIPTION
fixes duplicate dividers in case of scrape robots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conditional rendering of form sections in the robot edit page, ensuring "Scrape List Limits" and "Action Name" sections only display when applicable rather than always appearing.

* **Style**
  * Minor formatting adjustment to variable assignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->