### PR TITLE
feat(ui): match theme of standard & outlined alerts

### DIFF
--- a/src/components/ui/AlertSnackbar.tsx
+++ b/src/components/ui/AlertSnackbar.tsx
@@ -7,7 +7,7 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert(
   props,
   ref,
 ) {
-  return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
+  return <MuiAlert elevation={6} ref={ref} variant="outlined" {...props} />;
 });
 
 export interface AlertSnackbarProps {

--- a/src/context/theme-provider.tsx
+++ b/src/context/theme-provider.tsx
@@ -193,10 +193,10 @@ const darkTheme = createTheme({
           },
         },
         outlinedInfo: {
-          color: '#ff00c3',
-          borderColor: '#ff00c3',
+          color: '#ffffff',
+          borderColor: '#ffffff',
           "& .MuiAlert-icon": {
-            color: "#ff00c3",
+            color: "#ffffff",
           },
         },
       },

--- a/src/context/theme-provider.tsx
+++ b/src/context/theme-provider.tsx
@@ -210,7 +210,6 @@ const darkTheme = createTheme({
         },
       },
     },
-    // Additional dark mode specific components
     MuiPaper: {
       styleOverrides: {
         root: {
@@ -247,14 +246,6 @@ const darkTheme = createTheme({
         },
       },
     },
-    //   MuiTextField:{
-    //     styleOverrides: {
-    //       root: {
-    //         '& .MuiInputBase-root': {
-    //           backgroundColor: '#1d1c1cff',
-    //         },
-    //   }
-    // }}
   },
 });
 

--- a/src/context/theme-provider.tsx
+++ b/src/context/theme-provider.tsx
@@ -66,10 +66,10 @@ const lightTheme = createTheme({
           },
         },
         outlinedInfo: {
-          color: '#ff00c3',
-          borderColor: '#ff00c3',
+          color: '#000000ff',
+          borderColor: '#000000ff',
           "& .MuiAlert-icon": {
-            color: "#ff00c3",
+            color: "#000000ff",
           },
         },
       },

--- a/src/context/theme-provider.tsx
+++ b/src/context/theme-provider.tsx
@@ -65,6 +65,13 @@ const lightTheme = createTheme({
             color: "#ff00c3",
           },
         },
+        outlinedInfo: {
+          color: '#ff00c3',
+          borderColor: '#ff00c3',
+          "& .MuiAlert-icon": {
+            color: "#ff00c3",
+          },
+        },
       },
     },
     MuiAlertTitle: {

--- a/src/context/theme-provider.tsx
+++ b/src/context/theme-provider.tsx
@@ -192,6 +192,13 @@ const darkTheme = createTheme({
             color: "#ff66d9",
           },
         },
+        outlinedInfo: {
+          color: '#ff00c3',
+          borderColor: '#ff00c3',
+          "& .MuiAlert-icon": {
+            color: "#ff00c3",
+          },
+        },
       },
     },
     MuiAlertTitle: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Alert notifications now use an outlined visual style instead of filled.
  * Added a new "outlined info" alert variant (bright magenta — #ff00c3) with matching icon color, applied across light and dark themes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->