### PR TITLE
fix: remove `onCancel` button from robot config page

### DIFF
--- a/src/components/robot/pages/RobotConfigPage.tsx
+++ b/src/components/robot/pages/RobotConfigPage.tsx
@@ -154,7 +154,7 @@ export const RobotConfigPage: React.FC<RobotConfigPageProps> = ({
           )}
 
           <Box sx={{ display: 'flex', gap: 2 }}>
-            {showCancelButton && (
+            /* {showCancelButton && (
               <Button
                 variant="outlined"
                 onClick={handleBack}
@@ -164,7 +164,7 @@ export const RobotConfigPage: React.FC<RobotConfigPageProps> = ({
                 }} >
                 {cancelButtonText || t("buttons.cancel")}
               </Button>
-            )}
+            )} */
             {showSaveButton && onSave && (
               <Button
                 variant="contained"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the cancel button from the Robot Config Page. Users can now only save their configuration or return to the selection screen.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->