### PR TITLE
fix: swagger api routes display

### DIFF
--- a/server/src/swagger/config.ts
+++ b/server/src/swagger/config.ts
@@ -2,14 +2,26 @@ import swaggerJSDoc from 'swagger-jsdoc';
 import path from 'path';
 import fs from 'fs';
 
-// Dynamically determine API file paths
-const jsFiles = [path.join(__dirname, '../api/*.js')]
-const tsFiles = [path.join(__dirname, '../api/*.ts')]
+const apiDir = path.join(__dirname, '../api');
+const jsGlobPattern = path.join(__dirname, '../api/*.js');
+const tsGlobPattern = path.join(__dirname, '../api/*.ts');
 
-let apis = fs.existsSync(jsFiles[0]) ? jsFiles : tsFiles;
+let apis: string[];
 
-if (!apis) {
-  throw new Error('No valid API files found! Ensure either .js or .ts files exist in the ../api/ directory.');
+if (fs.existsSync(apiDir)) {
+  const files = fs.readdirSync(apiDir);
+  const hasJsFiles = files.some(file => file.endsWith('.js'));
+  const hasTsFiles = files.some(file => file.endsWith('.ts'));
+  
+  if (hasJsFiles) {
+    apis = [jsGlobPattern];
+  } else if (hasTsFiles) {
+    apis = [tsGlobPattern];
+  } else {
+    throw new Error('No valid API files found! Ensure either .js or .ts files exist in the ../api/ directory.');
+  }
+} else {
+  throw new Error('API directory not found! Ensure the ../api/ directory exists.');
 }
 
 const options = {


### PR DESCRIPTION
What this PR does?

Fixes the spec not defined error for the swagger routes page. This issue occurred when server files were build and used.

<img width="1920" height="706" alt="Screenshot 2026-01-19 at 12 54 18 AM" src="https://github.com/user-attachments/assets/8ac3b5dd-00f2-4064-b65c-b2d86db5ec61" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved API configuration detection with enhanced error messages for better setup troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->