### PR TITLE
fix: rm recorder script injection

### DIFF
--- a/server/src/browser-management/controller.ts
+++ b/server/src/browser-management/controller.ts
@@ -32,7 +32,7 @@ export const initializeRemoteBrowserForRecording = (userId: string, mode: string
         const remoteBrowser = browserPool.getRemoteBrowser(activeId);
         remoteBrowser?.updateSocket(socket);
       } else {
-        const browserSession = new RemoteBrowser(socket, userId, id);
+        const browserSession = new RemoteBrowser(socket, userId, id, true);
         browserSession.interpreter.subscribeToPausing();
         
         try {


### PR DESCRIPTION
What this PR does?

During the recording session dont inject the script to record replay live DOM changes. This ensures that there is no performance overhead due to script injection during robot run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized browser session handling to improve performance by conditionally managing initialization overhead based on session type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->