### PR TITLE
fix: api key modal close

### DIFF
--- a/src/components/api/ApiKey.tsx
+++ b/src/components/api/ApiKey.tsx
@@ -111,6 +111,7 @@ const ApiKeyManager = () => {
   };
 
   const handleDeleteConfirm = () => {
+    setConfirmDeleteOpen(false);
     deleteApiKey();
   };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed the delete confirmation dialog behavior for API keys. When confirming the deletion of an API key, the confirmation dialog now properly closes at the right time. This resolves an issue that could cause confusion during API key management and provides a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->