### PR TITLE
fix(core): normalize scrape schema

### DIFF
--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -498,7 +498,16 @@ export default class Interpreter extends EventEmitter {
       
         await this.ensureScriptsLoaded(page);
       
-        const scrapeResult = await page.evaluate((schemaObj) => window.scrapeSchema(schemaObj), schema);
+      const normalizedSchema = Object.fromEntries(
+          Object.entries(schema).map(([key, value]) => [
+            key,
+            typeof value === 'string'
+              ? { selector: value, tag: '', attribute: 'innerText', shadow: '' }
+              : value,
+          ])
+        );
+
+        const scrapeResult = await page.evaluate((schemaObj) => window.scrapeSchema(schemaObj), normalizedSchema);
       
         if (!this.cumulativeResults || !Array.isArray(this.cumulativeResults)) {
           this.cumulativeResults = [];


### PR DESCRIPTION
Fixes the below error occurring when running capture text run

<img width="1016" height="630" alt="Screenshot 2026-02-24 at 7 57 55 PM" src="https://github.com/user-attachments/assets/5bf822cb-2b66-4c5f-91df-26356d84002e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced schema support for web scraping to handle additional content extraction scenarios.

* **Bug Fixes**
  * Improved data extraction accuracy by normalizing schema input handling and supporting extended field configurations in the scraping workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->