### PR TITLE
feat: add robot duplication

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -436,7 +436,7 @@
       "title": "Duplicate Robot",
       "descriptions": {
         "purpose": "Robot duplication is useful to extract data from pages with the same structure.",
-        "example": "Example: If you've created a robot for {{url1}}, you can duplicate it to scrape similar pages like {{url2}} without training a robot from scratch.",
+        "example": "Example: If you've created a robot for <0>{{url1}}</0>, you can duplicate it to scrape similar pages like <1>{{url2}}</1> without training a robot from scratch.",
         "warning": "⚠️ Ensure the new page has the same structure as the original page."
       },
       "fields": {

--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -1451,6 +1451,23 @@ router.post("/robots/:id/duplicate", requireAPIKey, async (req: Request, res: Re
             });
         }
 
+        try {
+            const parsed = new URL(targetUrl);
+            if (!['http:', 'https:'].includes(parsed.protocol)) {
+                return res.status(400).json({
+                    statusCode: 400,
+                    messageCode: "bad_request",
+                    message: 'The "targetUrl" must use http or https protocol.',
+                });
+            }
+        } catch {
+            return res.status(400).json({
+                statusCode: 400,
+                messageCode: "bad_request",
+                message: 'The "targetUrl" must be a valid URL.',
+            });
+        }
+
         const originalRobot = await Robot.findOne({
             where: { 'recording_meta.id': id },
         });

--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -23,7 +23,7 @@ const router = Router();
 const formatRecording = (recordingData: any) => {
     const recordingMeta = recordingData.recording_meta;
     const workflow = recordingData.recording.workflow || [];
-    const firstWorkflowStep = workflow[0]?.where?.url || '';
+    const firstWorkflowStep = recordingMeta.url || workflow[workflow.length - 1]?.where?.url || '';
 
     const inputParameters = [
         {
@@ -128,7 +128,7 @@ router.get("/robots", requireAPIKey, async (req: Request, res: Response) => {
 const formatRecordingById = (recordingData: any) => {
     const recordingMeta = recordingData.recording_meta;
     const workflow = recordingData.recording.workflow || [];
-    const firstWorkflowStep = workflow[0]?.where?.url || '';
+    const firstWorkflowStep = recordingMeta.url || workflow[workflow.length - 1]?.where?.url || '';
 
     const inputParameters = [
         {
@@ -1396,6 +1396,148 @@ router.post("/robots/:id/runs", requireAPIKey, async (req: AuthenticatedRequest,
             statusCode: 500,
             messageCode: "error",
             message: "Failed to run robot",
+        });
+    }
+});
+
+/**
+ * @swagger
+ * /api/robots/{id}/duplicate:
+ *   post:
+ *     summary: Duplicate a robot with a new target URL
+ *     description: Duplicate an existing robot to run it on a different URL with the same structure.
+ *     security:
+ *       - api_key: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: The ID of the robot to duplicate.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - targetUrl
+ *             properties:
+ *               targetUrl:
+ *                 type: string
+ *                 example: "https://www.ycombinator.com/companies/airbnb"
+ *                 description: The new URL to target in the duplicated robot.
+ *     responses:
+ *       201:
+ *         description: Robot duplicated successfully.
+ *       400:
+ *         description: Missing required field.
+ *       404:
+ *         description: Robot not found.
+ *       500:
+ *         description: Internal server error.
+ */
+router.post("/robots/:id/duplicate", requireAPIKey, async (req: Request, res: Response) => {
+    try {
+        const { id } = req.params;
+        const { targetUrl } = req.body;
+
+        if (!targetUrl) {
+            return res.status(400).json({
+                statusCode: 400,
+                messageCode: "bad_request",
+                message: 'The "targetUrl" field is required.',
+            });
+        }
+
+        const originalRobot = await Robot.findOne({
+            where: { 'recording_meta.id': id },
+        });
+
+        if (!originalRobot) {
+            return res.status(404).json({
+                statusCode: 404,
+                messageCode: "not_found",
+                message: `Robot with ID "${id}" not found.`,
+            });
+        }
+
+        const lastWord = targetUrl.split('/').filter(Boolean).pop() || 'Unnamed';
+
+        const steps: any[] = originalRobot.recording.workflow;
+        const entryStep = steps.findLast((step: any) => step.where?.url === 'about:blank');
+        const originalEntryUrl: string | null = entryStep?.what?.find(
+            (action: any) => action.action === 'goto' && action.args?.length
+        )?.args?.[0] ?? null;
+
+        let gotoUpdated = false;
+        let whereUpdateStopped = false;
+
+        const workflow = [...steps].reverse().map((step: any) => {
+            let updatedWhere = step.where;
+
+            if (originalEntryUrl && step.where?.url !== 'about:blank' && !whereUpdateStopped) {
+                if (step.where?.url === originalEntryUrl) {
+                    updatedWhere = { ...step.where, url: targetUrl };
+                } else {
+                    whereUpdateStopped = true;
+                }
+            }
+
+            const updatedWhat = step.what.map((action: any) => {
+                if (!gotoUpdated && action.action === 'goto' && action.args?.[0] === originalEntryUrl) {
+                    gotoUpdated = true;
+                    return { ...action, args: [targetUrl, ...action.args.slice(1)] };
+                }
+                return action;
+            });
+
+            return { ...step, where: updatedWhere, what: updatedWhat };
+        }).reverse();
+
+        const currentTimestamp = new Date().toLocaleString();
+
+        const newRobot = await Robot.create({
+            id: uuid(),
+            userId: originalRobot.userId,
+            recording_meta: {
+                ...originalRobot.recording_meta,
+                id: uuid(),
+                name: `${originalRobot.recording_meta.name} (${lastWord})`,
+                url: targetUrl,
+                createdAt: currentTimestamp,
+                updatedAt: currentTimestamp,
+            },
+            recording: { ...originalRobot.recording, workflow },
+            google_sheet_email: null,
+            google_sheet_name: null,
+            google_sheet_id: null,
+            google_access_token: null,
+            google_refresh_token: null,
+            airtable_base_id: null,
+            airtable_base_name: null,
+            airtable_table_name: null,
+            airtable_table_id: null,
+            airtable_access_token: null,
+            airtable_refresh_token: null,
+            webhooks: null,
+            schedule: null,
+        });
+
+        logger.log('info', `Robot with ID ${id} duplicated successfully as ${newRobot.id}.`);
+
+        return res.status(201).json({
+            statusCode: 201,
+            messageCode: "success",
+            robot: formatRecordingById(newRobot.toJSON()),
+        });
+    } catch (error) {
+        logger.log('error', `Error duplicating robot with ID ${req.params.id}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        return res.status(500).json({
+            statusCode: 500,
+            messageCode: "error",
+            message: error instanceof Error ? error.message : 'An unknown error occurred.',
         });
     }
 });

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -586,6 +586,15 @@ router.post('/recordings/:id/duplicate', requireSignIn, async (req: Authenticate
       return res.status(400).json({ error: 'The "targetUrl" field is required.' });
     }
 
+    try {
+      const parsed = new URL(targetUrl);
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        return res.status(400).json({ error: 'The "targetUrl" must use http or https protocol.' });
+      }
+    } catch {
+      return res.status(400).json({ error: 'The "targetUrl" must be a valid URL.' });
+    }
+
     const originalRobot = await Robot.findOne({
       where: { 'recording_meta.id': id },
     });

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -575,6 +575,105 @@ router.delete('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest
 });
 
 /**
+ * POST endpoint to duplicate a robot with a new target URL.
+ */
+router.post('/recordings/:id/duplicate', requireSignIn, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { id } = req.params;
+    const { targetUrl } = req.body;
+
+    if (!targetUrl) {
+      return res.status(400).json({ error: 'The "targetUrl" field is required.' });
+    }
+
+    const originalRobot = await Robot.findOne({
+      where: { 'recording_meta.id': id },
+    });
+
+    if (!originalRobot) {
+      return res.status(404).json({ error: 'Original robot not found.' });
+    }
+
+    const lastWord = targetUrl.split('/').filter(Boolean).pop() || 'Unnamed';
+
+    const steps: any[] = originalRobot.recording.workflow;
+    const entryStep = steps.findLast((step: any) => step.where?.url === 'about:blank');
+    const originalEntryUrl: string | null = entryStep?.what?.find(
+      (action: any) => action.action === 'goto' && action.args?.length
+    )?.args?.[0] ?? null;
+
+    let gotoUpdated = false;
+    let whereUpdateStopped = false;
+
+    const workflow = [...steps].reverse().map((step: any) => {
+      let updatedWhere = step.where;
+
+      if (originalEntryUrl && step.where?.url !== 'about:blank' && !whereUpdateStopped) {
+        if (step.where?.url === originalEntryUrl) {
+          updatedWhere = { ...step.where, url: targetUrl };
+        } else {
+          whereUpdateStopped = true;
+        }
+      }
+
+      const updatedWhat = step.what.map((action: any) => {
+        if (!gotoUpdated && action.action === 'goto' && action.args?.[0] === originalEntryUrl) {
+          gotoUpdated = true;
+          return { ...action, args: [targetUrl, ...action.args.slice(1)] };
+        }
+        return action;
+      });
+
+      return { ...step, where: updatedWhere, what: updatedWhat };
+    }).reverse();
+
+    const currentTimestamp = new Date().toLocaleString();
+
+    const newRobot = await Robot.create({
+      id: uuid(),
+      userId: originalRobot.userId,
+      recording_meta: {
+        ...originalRobot.recording_meta,
+        id: uuid(),
+        name: `${originalRobot.recording_meta.name} (${lastWord})`,
+        url: targetUrl,
+        createdAt: currentTimestamp,
+        updatedAt: currentTimestamp,
+      },
+      recording: { ...originalRobot.recording, workflow },
+      google_sheet_email: null,
+      google_sheet_name: null,
+      google_sheet_id: null,
+      google_access_token: null,
+      google_refresh_token: null,
+      airtable_base_id: null,
+      airtable_base_name: null,
+      airtable_table_name: null,
+      airtable_table_id: null,
+      airtable_access_token: null,
+      airtable_refresh_token: null,
+      webhooks: null,
+      schedule: null,
+    });
+
+    logger.log('info', `Robot with ID ${id} duplicated successfully as ${newRobot.id}.`);
+
+    return res.status(201).json({
+      message: 'Robot duplicated and target URL updated successfully.',
+      robot: newRobot,
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      logger.log('error', `Error duplicating robot with ID ${req.params.id}: ${error.message}`);
+      return res.status(500).json({ error: error.message });
+    } else {
+      logger.log('error', `Unknown error duplicating robot with ID ${req.params.id}`);
+      return res.status(500).json({ error: 'An unknown error occurred.' });
+    }
+  }
+});
+
+/**
  * GET endpoint for getting an array of runs from the storage.
  */
 router.get('/runs', requireSignIn, async (req, res) => {

--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -131,6 +131,22 @@ export const getStoredRuns = async (): Promise<string[] | null> => {
   }
 };
 
+export const duplicateRecording = async (id: string, targetUrl: string): Promise<any> => {
+  try {
+    const response = await axios.post(`${apiUrl}/storage/recordings/${id}/duplicate`, {
+      targetUrl,
+    }, { withCredentials: true });
+    if (response.status === 201) {
+      return response.data;
+    } else {
+      throw new Error(`Couldn't duplicate recording with id ${id}`);
+    }
+  } catch (error: any) {
+    console.error(`Error duplicating recording: ${error.message}`);
+    return null;
+  }
+};
+
 export const getStoredRecording = async (id: string) => {
   try {
     const response = await axios.get(`${apiUrl}/storage/recordings/${id}`);

--- a/src/components/robot/Recordings.tsx
+++ b/src/components/robot/Recordings.tsx
@@ -9,6 +9,7 @@ import {
 import { RobotIntegrationPage } from "./pages/RobotIntegrationPage";
 import { RobotSettingsPage } from "./pages/RobotSettingsPage";
 import { RobotEditPage } from "./pages/RobotEditPage";
+import { RobotDuplicatePage } from "./pages/RobotDuplicatePage";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { useGlobalInfoStore } from "../../context/globalInfo";
 import { useTranslation } from "react-i18next";
@@ -105,6 +106,8 @@ export const Recordings = ({
       return <RobotSettingsPage handleStart={() => {}} />;
     } else if (currentPath.endsWith("/edit")) {
       return <RobotEditPage handleStart={() => {}} />;
+    } else if (currentPath.endsWith("/duplicate")) {
+      return <RobotDuplicatePage handleStart={() => {}} />;
     }
     return null;
   };
@@ -115,6 +118,7 @@ export const Recordings = ({
     currentPath.includes("/integrate") ||
     currentPath.includes("/settings") ||
     currentPath.includes("/edit") ||
+    currentPath.includes("/duplicate") ||
     currentPath.includes("/run");
 
   if (isConfigPage) {
@@ -141,6 +145,9 @@ export const Recordings = ({
             }
             handleEditRobot={(id, name, params) =>
               handleNavigate(`/robots/${id}/edit`, id, name, params)
+            }
+            handleDuplicateRobot={(id, name, params) =>
+              handleNavigate(`/robots/${id}/duplicate`, id, name, params)
             }
           />
         </Grid>

--- a/src/components/robot/RecordingsTable.tsx
+++ b/src/components/robot/RecordingsTable.tsx
@@ -32,7 +32,8 @@ import {
   Settings,
   Power,
   MoreHoriz,
-  Refresh
+  Refresh,
+  ContentCopy,
 } from "@mui/icons-material";
 import { useGlobalInfoStore, useCachedRecordings } from "../../context/globalInfo";
 import { checkRunsForRecording, deleteRecordingFromStorage } from "../../api/storage";
@@ -72,6 +73,7 @@ interface RecordingsTableProps {
   handleIntegrateRecording: (id: string, fileName: string, params: string[]) => void;
   handleSettingsRecording: (id: string, fileName: string, params: string[]) => void;
   handleEditRobot: (id: string, name: string, params: string[]) => void;
+  handleDuplicateRobot: (id: string, name: string, params: string[]) => void;
 }
 
 const LoadingRobotRow = memo(({ row, columns }: any) => {
@@ -147,8 +149,9 @@ const TableRowMemoized = memo(({ row, columns, handlers }: any) => {
               return (
                 <MemoizedTableCell key={column.id} align={column.align}>
                   <MemoizedOptionsButton
-                    handleRetrain={() =>handlers.handleRetrainRobot(row.id, row.name)}
+                    handleRetrain={() => handlers.handleRetrainRobot(row.id, row.name)}
                     handleEdit={() => handlers.handleEditRobot(row.id, row.name, row.params || [])}
+                    handleDuplicate={() => handlers.handleDuplicateRobot(row.id, row.name, row.params || [])}
                     handleDelete={() => handlers.handleDelete(row.id)}
                     robotType={row.type}
                   />
@@ -177,6 +180,7 @@ export const RecordingsTable = ({
   handleIntegrateRecording,
   handleSettingsRecording,
   handleEditRobot,
+  handleDuplicateRobot,
   }: RecordingsTableProps) => {
   const { t } = useTranslation();
   const theme = useTheme();
@@ -499,9 +503,10 @@ export const RecordingsTable = ({
     handleIntegrateRecording,
     handleSettingsRecording,
     handleEditRobot,
+    handleDuplicateRobot,
     handleRetrainRobot,
     handleDelete: async (id: string) => openDeleteConfirm(id)
-  }), [handleRunRecording, handleScheduleRecording, handleIntegrateRecording, handleSettingsRecording, handleEditRobot, handleRetrainRobot, notify, t, refetch]);
+  }), [handleRunRecording, handleScheduleRecording, handleIntegrateRecording, handleSettingsRecording, handleEditRobot, handleDuplicateRobot, handleRetrainRobot, notify, t, refetch]);
 
   return (
     <React.Fragment>
@@ -768,11 +773,12 @@ const SettingsButton = ({ handleSettings }: SettingsButtonProps) => {
 interface OptionsButtonProps {
   handleRetrain: () => void;
   handleEdit: () => void;
+  handleDuplicate: () => void;
   handleDelete: () => void;
   robotType: string;
 }
 
-const OptionsButton = ({ handleRetrain, handleEdit, handleDelete, robotType }: OptionsButtonProps) => {
+const OptionsButton = ({ handleRetrain, handleEdit, handleDuplicate, handleDelete, robotType }: OptionsButtonProps) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -812,6 +818,13 @@ const OptionsButton = ({ handleRetrain, handleEdit, handleDelete, robotType }: O
           <ListItemIcon><Edit fontSize="small" /></ListItemIcon>
           <ListItemText>Edit</ListItemText>
         </MenuItem>
+
+        {robotType === 'extract' && (
+          <MenuItem onClick={() => { handleDuplicate(); handleClose(); }}>
+            <ListItemIcon><ContentCopy fontSize="small" /></ListItemIcon>
+            <ListItemText>Duplicate</ListItemText>
+          </MenuItem>
+        )}
 
         <MenuItem onClick={() => { handleDelete(); handleClose(); }}>
           <ListItemIcon><DeleteForever fontSize="small" /></ListItemIcon>

--- a/src/components/robot/pages/RobotDuplicatePage.tsx
+++ b/src/components/robot/pages/RobotDuplicatePage.tsx
@@ -1,0 +1,115 @@
+import React, { useState, useEffect } from "react";
+import { TextField, Typography, Box } from "@mui/material";
+import { useGlobalInfoStore } from "../../../context/globalInfo";
+import { duplicateRecording, getStoredRecording } from "../../../api/storage";
+import { useTranslation } from "react-i18next";
+import { RobotConfigPage } from "./RobotConfigPage";
+import { useNavigate } from "react-router-dom";
+
+interface RobotDuplicatePageProps {
+  handleStart: (settings: any) => void;
+}
+
+export const RobotDuplicatePage = ({ handleStart }: RobotDuplicatePageProps) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [targetUrl, setTargetUrl] = useState<string>("");
+  const [robot, setRobot] = useState<any>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const { recordingId, notify, setRerenderRobots } = useGlobalInfoStore();
+
+  useEffect(() => {
+    getRobot();
+  }, []);
+
+  useEffect(() => {
+    if (robot) {
+      let url = robot.recording_meta?.url;
+
+      if (!url && robot.recording?.workflow?.length) {
+        const lastPair = robot.recording.workflow[robot.recording.workflow.length - 1];
+        url = lastPair?.what?.find((action: any) => action.action === "goto")?.args?.[0];
+      }
+
+      if (url) setTargetUrl(url);
+    }
+  }, [robot]);
+
+  const getRobot = async () => {
+    if (recordingId) {
+      try {
+        const data = await getStoredRecording(recordingId);
+        setRobot(data);
+      } catch (error) {
+        notify("error", t("robot_duplication.notifications.robot_not_found"));
+      }
+    } else {
+      notify("error", t("robot_duplication.notifications.robot_not_found"));
+    }
+  };
+
+  const handleSave = async () => {
+    if (!robot || !targetUrl) {
+      notify("error", t("robot_duplication.notifications.url_required"));
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const result = await duplicateRecording(robot.recording_meta.id, targetUrl);
+
+      if (result) {
+        setRerenderRobots(true);
+        notify("success", t("robot_duplication.notifications.duplicate_success"));
+        handleStart(robot);
+        navigate("/robots");
+      } else {
+        notify("error", t("robot_duplication.notifications.duplicate_error"));
+      }
+    } catch (error) {
+      notify("error", t("robot_duplication.notifications.unknown_error"));
+      console.error("Error duplicating robot:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <RobotConfigPage
+      title={t("robot_duplication.title")}
+      onSave={handleSave}
+      saveButtonText={t("robot_duplication.buttons.duplicate")}
+      isLoading={isLoading}
+      showCancelButton={false}
+    >
+      <>
+        <Box style={{ display: "flex", flexDirection: "column" }}>
+          {robot && (
+            <>
+              <span>{t("robot_duplication.descriptions.purpose")}</span>
+              <br />
+              <span
+                dangerouslySetInnerHTML={{
+                  __html: t("robot_duplication.descriptions.example", {
+                    url1: "<code>producthunt.com/topics/api</code>",
+                    url2: "<code>producthunt.com/topics/database</code>",
+                  }),
+                }}
+              />
+              <br />
+              <span>
+                <b>{t("robot_duplication.descriptions.warning")}</b>
+              </span>
+              <TextField
+                label={t("robot_duplication.fields.target_url")}
+                value={targetUrl}
+                onChange={(e) => setTargetUrl(e.target.value)}
+                style={{ marginBottom: "20px", marginTop: "30px" }}
+              />
+            </>
+          )}
+        </Box>
+      </>
+    </RobotConfigPage>
+  );
+};

--- a/src/components/robot/pages/RobotDuplicatePage.tsx
+++ b/src/components/robot/pages/RobotDuplicatePage.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from "react";
-import { TextField, Typography, Box } from "@mui/material";
+import { TextField, Box } from "@mui/material";
 import { useGlobalInfoStore } from "../../../context/globalInfo";
 import { duplicateRecording, getStoredRecording } from "../../../api/storage";
-import { useTranslation } from "react-i18next";
+import { useTranslation, Trans } from "react-i18next";
 import { RobotConfigPage } from "./RobotConfigPage";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 
 interface RobotDuplicatePageProps {
   handleStart: (settings: any) => void;
@@ -13,10 +13,13 @@ interface RobotDuplicatePageProps {
 export const RobotDuplicatePage = ({ handleStart }: RobotDuplicatePageProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
   const [targetUrl, setTargetUrl] = useState<string>("");
   const [robot, setRobot] = useState<any>(null);
   const [isLoading, setIsLoading] = useState(false);
   const { recordingId, notify, setRerenderRobots } = useGlobalInfoStore();
+  const robotIdFromUrl = location.pathname.split('/').filter(Boolean)[1] ?? null;
+  const effectiveId = recordingId || robotIdFromUrl;
 
   useEffect(() => {
     getRobot();
@@ -36,16 +39,16 @@ export const RobotDuplicatePage = ({ handleStart }: RobotDuplicatePageProps) => 
   }, [robot]);
 
   const getRobot = async () => {
-    if (recordingId) {
-      try {
-        const data = await getStoredRecording(recordingId);
-        setRobot(data);
-      } catch (error) {
-        notify("error", t("robot_duplication.notifications.robot_not_found"));
-      }
-    } else {
+    if (!effectiveId) {
       notify("error", t("robot_duplication.notifications.robot_not_found"));
+      return;
     }
+    const data = await getStoredRecording(effectiveId);
+    if (!data) {
+      notify("error", t("robot_duplication.notifications.robot_not_found"));
+      return;
+    }
+    setRobot(data);
   };
 
   const handleSave = async () => {
@@ -88,14 +91,13 @@ export const RobotDuplicatePage = ({ handleStart }: RobotDuplicatePageProps) => 
             <>
               <span>{t("robot_duplication.descriptions.purpose")}</span>
               <br />
-              <span
-                dangerouslySetInnerHTML={{
-                  __html: t("robot_duplication.descriptions.example", {
-                    url1: "<code>producthunt.com/topics/api</code>",
-                    url2: "<code>producthunt.com/topics/database</code>",
-                  }),
-                }}
-              />
+              <span>
+                <Trans
+                  i18nKey="robot_duplication.descriptions.example"
+                  values={{ url1: "producthunt.com/topics/api", url2: "producthunt.com/topics/database" }}
+                  components={[<code key="0" />, <code key="1" />]}
+                />
+              </span>
               <br />
               <span>
                 <b>{t("robot_duplication.descriptions.warning")}</b>


### PR DESCRIPTION
What this PR does?

1. bring back robot duplication
2. add robot duplication to website to API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate robots with a configurable target URL via a new duplicate flow (UI and API), including a dedicated duplication page and table action to start the flow.
* **Bug Fixes**
  * Improved entry URL selection: displayed entry URL now prefers stored recording metadata and falls back to workflow-derived URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->