### PR TITLE
fix: enforce unique robot names across all creation flows and edit

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -279,6 +279,7 @@
         "errors": {
             "user_not_logged": "Benutzer nicht angemeldet. Aufnahme kann nicht gespeichert werden.",
             "exists_warning": "Ein Roboter mit diesem Namen existiert bereits, bitte bestätigen Sie das Überschreiben des Roboters.",
+            "name_exists": "Ein Roboter mit diesem Namen existiert bereits. Bitte wählen Sie einen anderen Namen.",
             "no_actions_performed": "Roboter kann nicht gespeichert werden. Bitte führen Sie mindestens eine Erfassungsaktion durch, bevor Sie speichern."
         },
         "tooltips": {
@@ -440,7 +441,8 @@
             "warning": "⚠️ Stellen Sie sicher, dass die neue Seite die gleiche Struktur wie die Originalseite hat."
         },
         "fields": {
-            "target_url": "Roboter Ziel-URL"
+            "target_url": "Roboter Ziel-URL",
+            "new_name": "Roboter-Name"
         },
         "buttons": {
             "duplicate": "Roboter duplizieren",
@@ -449,6 +451,7 @@
         "notifications": {
             "robot_not_found": "Roboterdetails konnten nicht gefunden werden. Bitte versuchen Sie es erneut.",
             "url_required": "Ziel-URL ist erforderlich.",
+            "name_required": "Roboter-Name ist erforderlich.",
             "duplicate_success": "Roboter erfolgreich dupliziert.",
             "duplicate_error": "Fehler beim Aktualisieren der Ziel-URL. Bitte versuchen Sie es erneut.",
             "unknown_error": "Beim Aktualisieren der Ziel-URL ist ein Fehler aufgetreten."

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -279,6 +279,7 @@
       "errors": {
         "user_not_logged": "User not logged in. Cannot save recording.",
         "exists_warning": "Robot with this name already exists, please confirm the Robot's overwrite.",
+        "name_exists": "A robot with this name already exists. Please choose a different name.",
         "no_actions_performed": "Cannot save robot. Please perform at least one capture action before saving."
       },
       "tooltips": {
@@ -440,7 +441,8 @@
         "warning": "⚠️ Ensure the new page has the same structure as the original page."
       },
       "fields": {
-        "target_url": "Target URL"
+        "target_url": "Target URL",
+        "new_name": "Robot Name"
       },
       "buttons": {
         "duplicate": "Duplicate Robot",
@@ -449,6 +451,7 @@
       "notifications": {
         "robot_not_found": "Could not find robot details. Please try again.",
         "url_required": "Target URL is required.",
+        "name_required": "Robot name is required.",
         "duplicate_success": "Robot duplicated successfully.",
         "duplicate_error": "Failed to update the Target URL. Please try again.",
         "unknown_error": "An error occurred while updating the Target URL."

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -279,6 +279,7 @@
     "errors": {
       "user_not_logged": "Usuario no conectado. No se puede guardar la grabación.",
       "exists_warning": "Ya existe un robot con este nombre, por favor confirme la sobrescritura del robot.",
+      "name_exists": "Ya existe un robot con este nombre. Por favor elige un nombre diferente.",
       "no_actions_performed": "No se puede guardar el robot. Por favor realice al menos una acción de captura antes de guardar."
     },
     "tooltips": {
@@ -440,7 +441,8 @@
       "warning": "⚠️ Asegúrate de que la nueva página tenga la misma estructura que la página original."
     },
     "fields": {
-      "target_url": "URL Destino del Robot"
+      "target_url": "URL Destino del Robot",
+      "new_name": "Nombre del Robot"
     },
     "buttons": {
       "duplicate": "Duplicar Robot",
@@ -449,6 +451,7 @@
     "notifications": {
       "robot_not_found": "No se pudieron encontrar los detalles del robot. Por favor, inténtalo de nuevo.",
       "url_required": "Se requiere la URL de destino.",
+      "name_required": "El nombre del robot es obligatorio.",
       "duplicate_success": "Robot duplicado con éxito.",
       "duplicate_error": "Error al actualizar la URL de destino. Por favor, inténtalo de nuevo.",
       "unknown_error": "Ocurrió un error al actualizar la URL de destino."

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -279,6 +279,7 @@
         "errors": {
             "user_not_logged": "ユーザーがログインしていません。録画を保存できません。",
             "exists_warning": "この名前のロボットは既に存在します。ロボットの上書きを確認してください。",
+            "name_exists": "この名前のロボットは既に存在します。別の名前を選んでください。",
             "no_actions_performed": "ロボットを保存できません。保存する前に少なくとも1つのキャプチャアクションを実行してください。"
         },
         "tooltips": {
@@ -440,7 +441,8 @@
             "warning": "⚠️ 新しいページが元のページと同じ構造であることを確認してください。"
         },
         "fields": {
-            "target_url": "ロボットのターゲットURL"
+            "target_url": "ロボットのターゲットURL",
+            "new_name": "ロボット名"
         },
         "buttons": {
             "duplicate": "ロボットを複製",
@@ -449,6 +451,7 @@
         "notifications": {
             "robot_not_found": "ロボットの詳細が見つかりません。もう一度お試しください。",
             "url_required": "ターゲットURLが必要です。",
+            "name_required": "ロボット名は必須です。",
             "duplicate_success": "ロボットが正常に複製されました。",
             "duplicate_error": "ターゲットURLの更新に失敗しました。もう一度お試しください。",
             "unknown_error": "ターゲットURLの更新中にエラーが発生しました。"
@@ -457,6 +460,7 @@
     "robot_settings": {
         "title": "ロボット設定",
         "target_url": "ロボットのターゲットURL",
+            "new_name": "ロボット名",
         "robot_id": "ロボットID",
         "robot_limit": "ロボットの制限",
         "created_by_user": "作成したユーザー",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -278,6 +278,7 @@
     "errors": {
       "user_not_logged": "Kullanıcı girişi yok. Kaydedilemedi.",
       "exists_warning": "Bu isimde robot zaten var; üzerine yazmayı onaylayın.",
+      "name_exists": "Bu isimde bir robot zaten mevcut. Lütfen farklı bir isim seçin.",
       "no_actions_performed": "Robot kaydedilemez. Lütfen kaydetmeden önce en az bir yakalama eylemi gerçekleştirin."
     },
     "tooltips": {
@@ -439,7 +440,8 @@
       "warning": "⚠️ Yeni sayfanın yapısının aynı olduğundan emin olun."
     },
     "fields": {
-      "target_url": "Robot Hedef URL"
+      "target_url": "Robot Hedef URL",
+      "new_name": "Robot Adı"
     },
     "buttons": {
       "duplicate": "Robotu Çoğalt",
@@ -448,6 +450,7 @@
     "notifications": {
       "robot_not_found": "Robot bulunamadı. Tekrar deneyin.",
       "url_required": "Hedef URL gerekli.",
+      "name_required": "Robot adı gereklidir.",
       "duplicate_success": "Robot çoğaltıldı",
       "duplicate_error": "Hedef URL güncellenemedi. Tekrar deneyin.",
       "unknown_error": "Hedef URL güncellenirken hata oluştu"
@@ -456,6 +459,7 @@
   "robot_settings": {
     "title": "Robot Ayarları",
     "target_url": "Robot Hedef URL",
+      "new_name": "Robot Adı",
     "robot_id": "Robot ID",
     "robot_limit": "Robot Limiti",
     "created_by_user": "Oluşturan",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -279,6 +279,7 @@
     "errors": {
       "user_not_logged": "用户未登录。无法保存录制。",
       "exists_warning": "已存在同名机器人，请确认是否覆盖机器人。",
+      "name_exists": "已存在同名机器人，请选择不同的名称。",
       "no_actions_performed": "无法保存机器人。请在保存之前至少执行一次捕获操作。"
     },
     "tooltips": {
@@ -440,7 +441,8 @@
       "warning": "⚠️ 确保新页面与原始页面具有相同的结构。"
     },
     "fields": {
-      "target_url": "机器人目标URL"
+      "target_url": "机器人目标URL",
+      "new_name": "机器人名称"
     },
     "buttons": {
       "duplicate": "复制机器人",
@@ -449,6 +451,7 @@
     "notifications": {
       "robot_not_found": "找不到机器人详细信息。请重试。",
       "url_required": "需要目标URL。",
+      "name_required": "机器人名称为必填项。",
       "duplicate_success": "机器人复制成功。",
       "duplicate_error": "更新目标URL失败。请重试。",
       "unknown_error": "更新目标URL时发生错误。"
@@ -457,6 +460,7 @@
   "robot_settings": {
     "title": "机器人设置",
     "target_url": "机器人目标URL",
+      "new_name": "机器人名称",
     "robot_id": "机器人ID",
     "robot_limit": "机器人限制",
     "created_by_user": "由用户创建",

--- a/server/src/db/migrations/20250612000000-add-robot-name-unique-index.js
+++ b/server/src/db/migrations/20250612000000-add-robot-name-unique-index.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS robot_user_name_unique
+      ON robot (
+        "userId",
+        lower(trim(recording_meta->>'name'))
+      );
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS robot_user_name_unique;
+    `);
+  }
+};

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -358,13 +358,22 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
       }
     }
 
-    const trimmedName = name?.trim();
-    if (trimmedName && trimmedName.toLowerCase() !== robot.recording_meta.name.trim().toLowerCase()) {
-      const nameTaken = await isRobotNameTaken(trimmedName, robot.userId as number, id);
-      if (nameTaken) {
-        return res.status(409).json({ error: `A robot with the name "${trimmedName}" already exists.` });
+    if (name !== undefined) {
+      if (typeof name !== 'string') {
+        return res.status(400).json({ error: 'Robot name must be a string.' });
+      }
+      const trimmedName = name.trim();
+      if (!trimmedName) {
+        return res.status(400).json({ error: 'Robot name cannot be empty.' });
+      }
+      if (trimmedName.toLowerCase() !== robot.recording_meta.name.trim().toLowerCase()) {
+        const nameTaken = await isRobotNameTaken(trimmedName, robot.userId as number, id);
+        if (nameTaken) {
+          return res.status(409).json({ error: `A robot with the name "${trimmedName}" already exists.` });
+        }
       }
     }
+    const trimmedName = typeof name === 'string' ? name.trim() : undefined;
 
     let updatedMeta = { ...robot.recording_meta };
     if (trimmedName) updatedMeta.name = trimmedName;
@@ -382,7 +391,10 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
     logger.log('info', `Robot with ID ${id} was updated successfully.`);
 
     return res.status(200).json({ message: 'Robot updated successfully', robot });
-  } catch (error) {
+  } catch (error: any) {
+    if (error.name === 'SequelizeUniqueConstraintError' || error.parent?.code === '23505') {
+      return res.status(409).json({ error: 'A robot with this name already exists.' });
+    }
     // Safely handle the error type
     if (error instanceof Error) {
       logger.log('error', `Error updating robot with ID ${req.params.id}: ${error.message}`);
@@ -428,7 +440,10 @@ router.post('/recordings/scrape', requireSignIn, async (req: AuthenticatedReques
       return res.status(400).json({ error: `Invalid formats: ${invalid.join(', ')}` });
     }
 
-    const robotName = (name || `Markdown Robot - ${new URL(url).hostname}`).trim();
+    const robotName = (typeof name === 'string' ? name.trim() : '') || `Markdown Robot - ${new URL(url).hostname}`;
+    if (!robotName) {
+      return res.status(400).json({ error: 'Robot name cannot be empty.' });
+    }
 
     if (await isRobotNameTaken(robotName, req.user.id)) {
       return res.status(409).json({ error: `A robot with the name "${robotName}" already exists.` });
@@ -473,7 +488,10 @@ router.post('/recordings/scrape', requireSignIn, async (req: AuthenticatedReques
       message: 'Markdown robot created successfully.',
       robot: newRobot,
     });
-  } catch (error) {
+  } catch (error: any) {
+    if (error.name === 'SequelizeUniqueConstraintError' || error.parent?.code === '23505') {
+      return res.status(409).json({ error: 'A robot with this name already exists.' });
+    }
     if (error instanceof Error) {
       logger.log('error', `Error creating markdown robot: ${error.message}`);
       return res.status(500).json({ error: error.message });
@@ -542,7 +560,10 @@ router.post('/recordings/llm', requireSignIn, async (req: AuthenticatedRequest, 
 
     const robotId = uuid();
     const currentTimestamp = new Date().toISOString();
-    const finalRobotName = (robotName || `LLM Extract: ${prompt.substring(0, 50)}`).trim();
+    const finalRobotName = (typeof robotName === 'string' ? robotName.trim() : '') || `LLM Extract: ${prompt.substring(0, 50)}`;
+    if (!finalRobotName) {
+      return res.status(400).json({ error: 'Robot name cannot be empty.' });
+    }
 
     if (await isRobotNameTaken(finalRobotName, req.user.id)) {
       return res.status(409).json({ error: `A robot with the name "${finalRobotName}" already exists.` });
@@ -584,7 +605,10 @@ router.post('/recordings/llm', requireSignIn, async (req: AuthenticatedRequest, 
       message: 'LLM robot created successfully.',
       robot: newRobot,
     });
-  } catch (error) {
+  } catch (error: any) {
+    if (error.name === 'SequelizeUniqueConstraintError' || error.parent?.code === '23505') {
+      return res.status(409).json({ error: 'A robot with this name already exists.' });
+    }
     if (error instanceof Error) {
       logger.log('error', `Error creating LLM robot: ${error.message}`);
       return res.status(500).json({ error: error.message });
@@ -1448,7 +1472,10 @@ router.post('/recordings/crawl', requireSignIn, async (req: AuthenticatedRequest
       return res.status(400).json({ error: 'Invalid URL format' });
     }
 
-    const robotName = (name || `Crawl Robot - ${new URL(url).hostname}`).trim();
+    const robotName = (typeof name === 'string' ? name.trim() : '') || `Crawl Robot - ${new URL(url).hostname}`;
+    if (!robotName) {
+      return res.status(400).json({ error: 'Robot name cannot be empty.' });
+    }
 
     if (await isRobotNameTaken(robotName, req.user.id)) {
       return res.status(409).json({ error: `A robot with the name "${robotName}" already exists.` });
@@ -1529,7 +1556,10 @@ router.post('/recordings/crawl', requireSignIn, async (req: AuthenticatedRequest
       message: 'Crawl robot created successfully.',
       robot: newRobot,
     });
-  } catch (error) {
+  } catch (error: any) {
+    if (error.name === 'SequelizeUniqueConstraintError' || error.parent?.code === '23505') {
+      return res.status(409).json({ error: 'A robot with this name already exists.' });
+    }
     if (error instanceof Error) {
       logger.log('error', `Error creating crawl robot: ${error.message}`);
       return res.status(500).json({ error: error.message });
@@ -1557,7 +1587,10 @@ router.post('/recordings/search', requireSignIn, async (req: AuthenticatedReques
       return res.status(401).send({ error: 'Unauthorized' });
     }
 
-    const robotName = (name || `Search Robot - ${searchConfig.query.substring(0, 50)}`).trim();
+    const robotName = (typeof name === 'string' ? name.trim() : '') || `Search Robot - ${searchConfig.query.substring(0, 50)}`;
+    if (!robotName) {
+      return res.status(400).json({ error: 'Robot name cannot be empty.' });
+    }
 
     if (await isRobotNameTaken(robotName, req.user.id)) {
       return res.status(409).json({ error: `A robot with the name "${robotName}" already exists.` });
@@ -1622,7 +1655,10 @@ router.post('/recordings/search', requireSignIn, async (req: AuthenticatedReques
       message: 'Search robot created successfully.',
       robot: newRobot,
     });
-  } catch (error) {
+  } catch (error: any) {
+    if (error.name === 'SequelizeUniqueConstraintError' || error.parent?.code === '23505') {
+      return res.status(409).json({ error: 'A robot with this name already exists.' });
+    }
     if (error instanceof Error) {
       logger.log('error', `Error creating search robot: ${error.message}`);
       return res.status(500).json({ error: error.message });

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -16,8 +16,28 @@ import { WorkflowFile } from 'maxun-core';
 import { cancelScheduledWorkflow, scheduleWorkflow } from '../storage/schedule';
 import { pgBossClient } from '../storage/pgboss';
 import { WorkflowEnricher } from '../sdk/workflowEnricher';
+import sequelizeInstance from '../storage/db';
+import { Op } from 'sequelize';
 
 export const router = Router();
+
+async function isRobotNameTaken(name: string, userId: number, excludeId?: string): Promise<boolean> {
+  const normalised = name.trim().toLowerCase();
+  const robots = await Robot.findAll({
+    where: {
+      userId,
+      [Op.and]: sequelizeInstance.where(
+        sequelizeInstance.fn('lower', sequelizeInstance.fn('trim', sequelizeInstance.literal("recording_meta->>'name'"))),
+        normalised
+      ),
+    } as any,
+  });
+  if (robots.length === 0) return false;
+  if (excludeId) {
+    return robots.some((r: any) => r.recording_meta.id !== excludeId);
+  }
+  return true;
+}
 
 export const processWorkflowActions = async (workflow: any[], checkLimit: boolean = false): Promise<any[]> => {
   const processedWorkflow = JSON.parse(JSON.stringify(workflow));
@@ -338,8 +358,16 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
       }
     }
 
+    const trimmedName = name?.trim();
+    if (trimmedName && trimmedName.toLowerCase() !== robot.recording_meta.name.trim().toLowerCase()) {
+      const nameTaken = await isRobotNameTaken(trimmedName, robot.userId as number, id);
+      if (nameTaken) {
+        return res.status(409).json({ error: `A robot with the name "${trimmedName}" already exists.` });
+      }
+    }
+
     let updatedMeta = { ...robot.recording_meta };
-    if (name) updatedMeta.name = name;
+    if (trimmedName) updatedMeta.name = trimmedName;
     if (targetUrl) updatedMeta.url = targetUrl;
 
     const updates: any = {
@@ -400,7 +428,12 @@ router.post('/recordings/scrape', requireSignIn, async (req: AuthenticatedReques
       return res.status(400).json({ error: `Invalid formats: ${invalid.join(', ')}` });
     }
 
-    const robotName = name || `Markdown Robot - ${new URL(url).hostname}`;
+    const robotName = (name || `Markdown Robot - ${new URL(url).hostname}`).trim();
+
+    if (await isRobotNameTaken(robotName, req.user.id)) {
+      return res.status(409).json({ error: `A robot with the name "${robotName}" already exists.` });
+    }
+
     const currentTimestamp = new Date().toLocaleString();
     const robotId = uuid();
 
@@ -509,7 +542,11 @@ router.post('/recordings/llm', requireSignIn, async (req: AuthenticatedRequest, 
 
     const robotId = uuid();
     const currentTimestamp = new Date().toISOString();
-    const finalRobotName = robotName || `LLM Extract: ${prompt.substring(0, 50)}`;
+    const finalRobotName = (robotName || `LLM Extract: ${prompt.substring(0, 50)}`).trim();
+
+    if (await isRobotNameTaken(finalRobotName, req.user.id)) {
+      return res.status(409).json({ error: `A robot with the name "${finalRobotName}" already exists.` });
+    }
 
     const newRobot = await Robot.create({
       id: uuid(),
@@ -591,7 +628,7 @@ router.delete('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest
 router.post('/recordings/:id/duplicate', requireSignIn, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
-    const { targetUrl } = req.body;
+    const { targetUrl, newName } = req.body;
 
     if (!targetUrl) {
       return res.status(400).json({ error: 'The "targetUrl" field is required.' });
@@ -615,6 +652,11 @@ router.post('/recordings/:id/duplicate', requireSignIn, async (req: Authenticate
     }
 
     const lastWord = targetUrl.split('/').filter(Boolean).pop() || 'Unnamed';
+    const duplicateName = (newName?.trim() || `${originalRobot.recording_meta.name} (${lastWord})`).trim();
+
+    if (await isRobotNameTaken(duplicateName, originalRobot.userId as number)) {
+      return res.status(409).json({ error: `A robot with the name "${duplicateName}" already exists.` });
+    }
 
     const steps: any[] = originalRobot.recording.workflow;
     const entryStep = steps.findLast((step: any) => step.where?.url === 'about:blank');
@@ -655,7 +697,7 @@ router.post('/recordings/:id/duplicate', requireSignIn, async (req: Authenticate
       recording_meta: {
         ...originalRobot.recording_meta,
         id: uuid(),
-        name: `${originalRobot.recording_meta.name} (${lastWord})`,
+        name: duplicateName,
         url: targetUrl,
         createdAt: currentTimestamp,
         updatedAt: currentTimestamp,
@@ -1406,7 +1448,12 @@ router.post('/recordings/crawl', requireSignIn, async (req: AuthenticatedRequest
       return res.status(400).json({ error: 'Invalid URL format' });
     }
 
-    const robotName = name || `Crawl Robot - ${new URL(url).hostname}`;
+    const robotName = (name || `Crawl Robot - ${new URL(url).hostname}`).trim();
+
+    if (await isRobotNameTaken(robotName, req.user.id)) {
+      return res.status(409).json({ error: `A robot with the name "${robotName}" already exists.` });
+    }
+
     const currentTimestamp = new Date().toLocaleString('en-US');
     const robotId = uuid();
 
@@ -1510,7 +1557,12 @@ router.post('/recordings/search', requireSignIn, async (req: AuthenticatedReques
       return res.status(401).send({ error: 'Unauthorized' });
     }
 
-    const robotName = name || `Search Robot - ${searchConfig.query.substring(0, 50)}`;
+    const robotName = (name || `Search Robot - ${searchConfig.query.substring(0, 50)}`).trim();
+
+    if (await isRobotNameTaken(robotName, req.user.id)) {
+      return res.status(409).json({ error: `A robot with the name "${robotName}" already exists.` });
+    }
+
     const currentTimestamp = new Date().toLocaleString('en-US');
     const robotId = uuid();
 

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -358,11 +358,12 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
       }
     }
 
+    let trimmedName: string | undefined;
     if (name !== undefined) {
       if (typeof name !== 'string') {
         return res.status(400).json({ error: 'Robot name must be a string.' });
       }
-      const trimmedName = name.trim();
+      trimmedName = name.trim();
       if (!trimmedName) {
         return res.status(400).json({ error: 'Robot name cannot be empty.' });
       }
@@ -373,7 +374,6 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
         }
       }
     }
-    const trimmedName = typeof name === 'string' ? name.trim() : undefined;
 
     let updatedMeta = { ...robot.recording_meta };
     if (trimmedName) updatedMeta.name = trimmedName;
@@ -527,6 +527,15 @@ router.post('/recordings/llm', requireSignIn, async (req: AuthenticatedRequest, 
       }
     }
 
+    const finalRobotName = (typeof robotName === 'string' ? robotName.trim() : '') || `LLM Extract: ${prompt.substring(0, 50)}`;
+    if (!finalRobotName) {
+      return res.status(400).json({ error: 'Robot name cannot be empty.' });
+    }
+
+    if (await isRobotNameTaken(finalRobotName, req.user.id)) {
+      return res.status(409).json({ error: `A robot with the name "${finalRobotName}" already exists.` });
+    }
+
     let workflowResult: any;
     let finalUrl: string;
 
@@ -560,14 +569,6 @@ router.post('/recordings/llm', requireSignIn, async (req: AuthenticatedRequest, 
 
     const robotId = uuid();
     const currentTimestamp = new Date().toISOString();
-    const finalRobotName = (typeof robotName === 'string' ? robotName.trim() : '') || `LLM Extract: ${prompt.substring(0, 50)}`;
-    if (!finalRobotName) {
-      return res.status(400).json({ error: 'Robot name cannot be empty.' });
-    }
-
-    if (await isRobotNameTaken(finalRobotName, req.user.id)) {
-      return res.status(409).json({ error: `A robot with the name "${finalRobotName}" already exists.` });
-    }
 
     const newRobot = await Robot.create({
       id: uuid(),

--- a/server/src/workflow-management/classes/Generator.ts
+++ b/server/src/workflow-management/classes/Generator.ts
@@ -1010,8 +1010,10 @@ export class WorkflowGenerator {
           return;
         }
         const allUserRobots = await Robot.findAll({ where: { userId } as any });
+        const normalised = trimmedFileName.toLowerCase();
         const nameConflict = allUserRobots.some(
-          (r: any) => r.recording_meta.name.trim().toLowerCase() === trimmedFileName.toLowerCase()
+          (r: any) => typeof r.recording_meta?.name === 'string' &&
+            r.recording_meta.name.trim().toLowerCase() === normalised
         );
         if (nameConflict) {
           this.socket.emit('fileSaved', { actionType: 'nameExists' });

--- a/server/src/workflow-management/classes/Generator.ts
+++ b/server/src/workflow-management/classes/Generator.ts
@@ -1004,8 +1004,18 @@ export class WorkflowGenerator {
           logger.log('info', `Robot retrained with id: ${robot.id}`);
         }
       } else {
+        const trimmedFileName = fileName.trim();
+        const allUserRobots = await Robot.findAll({ where: { userId } as any });
+        const nameConflict = allUserRobots.some(
+          (r: any) => r.recording_meta.name.trim().toLowerCase() === trimmedFileName.toLowerCase()
+        );
+        if (nameConflict) {
+          this.socket.emit('fileSaved', { actionType: 'nameExists' });
+          return;
+        }
+
         this.recordingMeta = {
-          name: fileName,
+          name: trimmedFileName,
           id: uuid(),
           createdAt: this.recordingMeta.createdAt || new Date().toLocaleString(),
           pairs: recording.workflow.length,

--- a/server/src/workflow-management/classes/Generator.ts
+++ b/server/src/workflow-management/classes/Generator.ts
@@ -1005,6 +1005,10 @@ export class WorkflowGenerator {
         }
       } else {
         const trimmedFileName = fileName.trim();
+        if (!trimmedFileName) {
+          this.socket.emit('fileSaved', { actionType: 'error' });
+          return;
+        }
         const allUserRobots = await Robot.findAll({ where: { userId } as any });
         const nameConflict = allUserRobots.some(
           (r: any) => r.recording_meta.name.trim().toLowerCase() === trimmedFileName.toLowerCase()
@@ -1041,8 +1045,11 @@ export class WorkflowGenerator {
         logger.log('info', `Robot saved with id: ${robot.id}`);
       }  
     }
-    catch (e) {
-      const { message } = e as Error;
+    catch (e: any) {
+      if (e.name === 'SequelizeUniqueConstraintError' || e.parent?.code === '23505') {
+        this.socket.emit('fileSaved', { actionType: 'nameExists' });
+        return;
+      }
       logger.log('warn', `Cannot save the file to the local file system ${e}`)
       actionType = 'error';
     }

--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -53,6 +53,8 @@ export const createScrapeRobot = async (
       throw new Error('Failed to create markdown robot');
     }
   } catch (error: any) {
+    const message = error.response?.data?.error;
+    if (message) throw new Error(message);
     console.error('Error creating markdown robot:', error);
     return null;
   }
@@ -92,6 +94,8 @@ export const createLLMRobot = async (
       throw new Error('Failed to create LLM robot');
     }
   } catch (error: any) {
+    const message = error.response?.data?.error;
+    if (message) throw new Error(message);
     console.error('Error creating LLM robot:', error);
     return null;
   }
@@ -112,6 +116,8 @@ export const updateRecording = async (id: string, data: {
       throw new Error(`Couldn't update recording with id ${id}`);
     }
   } catch (error: any) {
+    const message = error.response?.data?.error;
+    if (message) throw new Error(message);
     console.error(`Error updating recording: ${error.message}`);
     return false;
   }
@@ -131,10 +137,11 @@ export const getStoredRuns = async (): Promise<string[] | null> => {
   }
 };
 
-export const duplicateRecording = async (id: string, targetUrl: string): Promise<any> => {
+export const duplicateRecording = async (id: string, targetUrl: string, newName?: string): Promise<any> => {
   try {
     const response = await axios.post(`${apiUrl}/storage/recordings/${id}/duplicate`, {
       targetUrl,
+      newName,
     }, { withCredentials: true });
     if (response.status === 201) {
       return response.data;
@@ -142,6 +149,8 @@ export const duplicateRecording = async (id: string, targetUrl: string): Promise
       throw new Error(`Couldn't duplicate recording with id ${id}`);
     }
   } catch (error: any) {
+    const message = error.response?.data?.error;
+    if (message) throw new Error(message);
     console.error(`Error duplicating recording: ${error.message}`);
     return null;
   }
@@ -371,6 +380,8 @@ export const createCrawlRobot = async (
       throw new Error('Failed to create crawl robot');
     }
   } catch (error: any) {
+    const message = error.response?.data?.error;
+    if (message) throw new Error(message);
     console.error('Error creating crawl robot:', error);
     return null;
   }
@@ -409,6 +420,8 @@ export const createSearchRobot = async (
       throw new Error('Failed to create search robot');
     }
   } catch (error: any) {
+    const message = error.response?.data?.error;
+    if (message) throw new Error(message);
     console.error('Error creating search robot:', error);
     return null;
   }

--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -117,7 +117,12 @@ export const updateRecording = async (id: string, data: {
     }
   } catch (error: any) {
     const message = error.response?.data?.error;
-    if (message) throw new Error(message);
+    const status = error.response?.status;
+    if (message) {
+      const err = new Error(message) as any;
+      err.isDuplicate = status === 409;
+      throw err;
+    }
     console.error(`Error updating recording: ${error.message}`);
     return false;
   }

--- a/src/components/recorder/SaveRecording.tsx
+++ b/src/components/recorder/SaveRecording.tsx
@@ -6,8 +6,6 @@ import { useGlobalInfoStore } from "../../context/globalInfo";
 import { AuthContext } from '../../context/auth';
 import { useSocketStore } from "../../context/socket";
 import { TextField, Typography } from "@mui/material";
-import { WarningText } from "../ui/texts";
-import NotificationImportantIcon from "@mui/icons-material/NotificationImportant";
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -18,7 +16,6 @@ interface SaveRecordingProps {
 export const SaveRecording = ({ fileName }: SaveRecordingProps) => {
   const { t } = useTranslation();
   const [openModal, setOpenModal] = useState<boolean>(false);
-  const [needConfirm, setNeedConfirm] = useState<boolean>(false);
   const [saveRecordingName, setSaveRecordingName] = useState<string>(fileName);
   const [waitingForSave, setWaitingForSave] = useState<boolean>(false);
 
@@ -35,21 +32,17 @@ export const SaveRecording = ({ fileName }: SaveRecordingProps) => {
   }, [recordingName]);
 
   const handleChangeOfTitle = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { value } = event.target;
-    if (needConfirm) {
-      setNeedConfirm(false);
-    }
-    setSaveRecordingName(value);
+    setSaveRecordingName(event.target.value);
   }
 
   const handleSaveRecording = async (event: React.SyntheticEvent) => {
     event.preventDefault();
-    if (recordings.includes(saveRecordingName)) {
-      if (needConfirm) { return; }
-      setNeedConfirm(true);
-    } else {
-      await saveRecording();
+    const trimmedName = saveRecordingName.trim();
+    if (!retrainRobotId && recordings.some(r => r.trim().toLowerCase() === trimmedName.toLowerCase())) {
+      notify('error', t('save_recording.errors.name_exists'));
+      return;
     }
+    await saveRecording();
   };
 
   const handleFinishClick = () => {
@@ -120,9 +113,9 @@ export const SaveRecording = ({ fileName }: SaveRecordingProps) => {
         return;
       }
 
-      const payload = { 
-        fileName: saveRecordingName || recordingName, 
-        userId: user.id, 
+      const payload = {
+        fileName: (saveRecordingName || recordingName).trim(),
+        userId: user.id,
         isLogin: isLogin,
         robotId: retrainRobotId,
       };
@@ -134,12 +127,21 @@ export const SaveRecording = ({ fileName }: SaveRecordingProps) => {
     }
   };
 
-  useEffect(() => {
-    socket?.on('fileSaved', exitRecording);
-    return () => {
-      socket?.off('fileSaved', exitRecording);
+  const handleFileSaved = useCallback(async (data?: { actionType: string }) => {
+    if (data?.actionType === 'nameExists') {
+      setWaitingForSave(false);
+      notify('error', t('save_recording.errors.name_exists'));
+      return;
     }
-  }, [socket, exitRecording]);
+    await exitRecording(data);
+  }, [exitRecording, notify, t]);
+
+  useEffect(() => {
+    socket?.on('fileSaved', handleFileSaved);
+    return () => {
+      socket?.off('fileSaved', handleFileSaved);
+    }
+  }, [socket, handleFileSaved]);
 
   return (
     <div>
@@ -170,21 +172,9 @@ export const SaveRecording = ({ fileName }: SaveRecordingProps) => {
             variant="outlined"
             value={saveRecordingName}
           />
-          {needConfirm
-            ?
-            (<React.Fragment>
-              <Button color="error" variant="contained" onClick={saveRecording} sx={{ marginTop: '10px' }}>
-                {t('save_recording.buttons.confirm')}
-              </Button>
-              <WarningText>
-                <NotificationImportantIcon color="warning" />
-                {t('save_recording.errors.exists_warning')}
-              </WarningText>
-            </React.Fragment>)
-            : <Button type="submit" variant="contained" sx={{ marginTop: '10px' }}>
-              {t('save_recording.buttons.save')}
-            </Button>
-          }
+          <Button type="submit" variant="contained" sx={{ marginTop: '10px' }}>
+            {t('save_recording.buttons.save')}
+          </Button>
           {waitingForSave &&
             <Tooltip title={t('save_recording.tooltips.optimizing')} placement={"bottom"}>
               <Box sx={{ width: '100%', marginTop: '10px' }}>

--- a/src/components/robot/pages/RobotCreate.tsx
+++ b/src/components/robot/pages/RobotCreate.tsx
@@ -54,7 +54,7 @@ function TabPanel(props: TabPanelProps) {
 const RobotCreate: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { setBrowserId, setRecordingUrl, notify, setRecordingId, setRerenderRobots } = useGlobalInfoStore();
+  const { setBrowserId, setRecordingUrl, notify, setRecordingId, setRerenderRobots, recordings } = useGlobalInfoStore();
 
   const [tabValue, setTabValue] = useState(0);
   const [url, setUrl] = useState('');
@@ -187,28 +187,32 @@ const RobotCreate: React.FC = () => {
     }
 
     setIsLoading(true);
-    const result = await createCrawlRobot(
-      crawlUrl,
-      crawlRobotName,
-      {
-        mode: crawlMode,
-        limit: crawlLimit,
-        maxDepth: crawlMaxDepth,
-        includePaths: crawlIncludePaths ? crawlIncludePaths.split(',').map(p => p.trim()) : [],
-        excludePaths: crawlExcludePaths ? crawlExcludePaths.split(',').map(p => p.trim()) : [],
-        useSitemap: crawlUseSitemap,
-        followLinks: crawlFollowLinks,
-        respectRobots: crawlRespectRobots
+    try {
+      const result = await createCrawlRobot(
+        crawlUrl,
+        crawlRobotName,
+        {
+          mode: crawlMode,
+          limit: crawlLimit,
+          maxDepth: crawlMaxDepth,
+          includePaths: crawlIncludePaths ? crawlIncludePaths.split(',').map(p => p.trim()) : [],
+          excludePaths: crawlExcludePaths ? crawlExcludePaths.split(',').map(p => p.trim()) : [],
+          useSitemap: crawlUseSitemap,
+          followLinks: crawlFollowLinks,
+          respectRobots: crawlRespectRobots
+        }
+      );
+      setIsLoading(false);
+      if (result) {
+        invalidateRecordings();
+        notify('success', `${crawlRobotName} created successfully!`);
+        navigate('/robots');
+      } else {
+        notify('error', 'Failed to create crawl robot');
       }
-    );
-    setIsLoading(false);
-
-    if (result) {
-      invalidateRecordings();
-      notify('success', `${crawlRobotName} created successfully!`);
-      navigate('/robots');
-    } else {
-      notify('error', 'Failed to create crawl robot');
+    } catch (error: any) {
+      setIsLoading(false);
+      notify('error', error.message || 'Failed to create crawl robot');
     }
   };
 
@@ -223,26 +227,30 @@ const RobotCreate: React.FC = () => {
     }
 
     setIsLoading(true);
-    const result = await createSearchRobot(
-      searchRobotName,
-      {
-        query: searchQuery,
-        limit: searchLimit,
-        provider: searchProvider,
-        filters: {
-          timeRange: searchTimeRange ? searchTimeRange as 'day' | 'week' | 'month' | 'year' : undefined
-        },
-        mode: searchMode
+    try {
+      const result = await createSearchRobot(
+        searchRobotName,
+        {
+          query: searchQuery,
+          limit: searchLimit,
+          provider: searchProvider,
+          filters: {
+            timeRange: searchTimeRange ? searchTimeRange as 'day' | 'week' | 'month' | 'year' : undefined
+          },
+          mode: searchMode
+        }
+      );
+      setIsLoading(false);
+      if (result) {
+        invalidateRecordings();
+        notify('success', `${searchRobotName} created successfully!`);
+        navigate('/robots');
+      } else {
+        notify('error', 'Failed to create search robot');
       }
-    );
-    setIsLoading(false);
-
-    if (result) {
-      invalidateRecordings();
-      notify('success', `${searchRobotName} created successfully!`);
-      navigate('/robots');
-    } else {
-      notify('error', 'Failed to create search robot');
+    } catch (error: any) {
+      setIsLoading(false);
+      notify('error', error.message || 'Failed to create search robot');
     }
   };
 
@@ -526,6 +534,10 @@ const RobotCreate: React.FC = () => {
                           notify('error', 'Please enter an extraction prompt');
                           return;
                         }
+                        if (recordings.some(r => r.trim().toLowerCase() === extractRobotName.trim().toLowerCase())) {
+                          notify('error', `A robot with the name "${extractRobotName.trim()}" already exists.`);
+                          return;
+                        }
 
                         const tempRobotId = `temp-${Date.now()}`;
                         const robotDisplayName = extractRobotName;
@@ -803,15 +815,19 @@ const RobotCreate: React.FC = () => {
                   }
 
                   setIsLoading(true);
-                  const result = await createScrapeRobot(url, scrapeRobotName, outputFormats);
-                  setIsLoading(false);
-
-                  if (result) {
-                    setRerenderRobots(true);
-                    notify('success', `${scrapeRobotName} created successfully!`);
-                    navigate('/robots');
-                  } else {
-                    notify('error', 'Failed to create scrape robot');
+                  try {
+                    const result = await createScrapeRobot(url, scrapeRobotName, outputFormats);
+                    setIsLoading(false);
+                    if (result) {
+                      setRerenderRobots(true);
+                      notify('success', `${scrapeRobotName} created successfully!`);
+                      navigate('/robots');
+                    } else {
+                      notify('error', 'Failed to create scrape robot');
+                    }
+                  } catch (error: any) {
+                    setIsLoading(false);
+                    notify('error', error.message || 'Failed to create scrape robot');
                   }
                 }}
                 disabled={!url.trim() || !scrapeRobotName.trim() || outputFormats.length === 0 || isLoading}

--- a/src/components/robot/pages/RobotDuplicatePage.tsx
+++ b/src/components/robot/pages/RobotDuplicatePage.tsx
@@ -15,6 +15,7 @@ export const RobotDuplicatePage = ({ handleStart }: RobotDuplicatePageProps) => 
   const navigate = useNavigate();
   const location = useLocation();
   const [targetUrl, setTargetUrl] = useState<string>("");
+  const [newName, setNewName] = useState<string>("");
   const [robot, setRobot] = useState<any>(null);
   const [isLoading, setIsLoading] = useState(false);
   const { recordingId, notify, setRerenderRobots } = useGlobalInfoStore();
@@ -34,7 +35,11 @@ export const RobotDuplicatePage = ({ handleStart }: RobotDuplicatePageProps) => 
         url = lastPair?.what?.find((action: any) => action.action === "goto")?.args?.[0];
       }
 
-      if (url) setTargetUrl(url);
+      if (url) {
+        setTargetUrl(url);
+        const lastWord = url.split('/').filter(Boolean).pop() || 'Unnamed';
+        setNewName(`${robot.recording_meta.name} (${lastWord})`);
+      }
     }
   }, [robot]);
 
@@ -57,9 +62,14 @@ export const RobotDuplicatePage = ({ handleStart }: RobotDuplicatePageProps) => 
       return;
     }
 
+    if (!newName.trim()) {
+      notify("error", t("robot_duplication.notifications.name_required"));
+      return;
+    }
+
     setIsLoading(true);
     try {
-      const result = await duplicateRecording(robot.recording_meta.id, targetUrl);
+      const result = await duplicateRecording(robot.recording_meta.id, targetUrl, newName.trim());
 
       if (result) {
         setRerenderRobots(true);
@@ -69,8 +79,8 @@ export const RobotDuplicatePage = ({ handleStart }: RobotDuplicatePageProps) => 
       } else {
         notify("error", t("robot_duplication.notifications.duplicate_error"));
       }
-    } catch (error) {
-      notify("error", t("robot_duplication.notifications.unknown_error"));
+    } catch (error: any) {
+      notify("error", error.message || t("robot_duplication.notifications.unknown_error"));
       console.error("Error duplicating robot:", error);
     } finally {
       setIsLoading(false);
@@ -103,10 +113,24 @@ export const RobotDuplicatePage = ({ handleStart }: RobotDuplicatePageProps) => 
                 <b>{t("robot_duplication.descriptions.warning")}</b>
               </span>
               <TextField
+                label={t("robot_duplication.fields.new_name")}
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                style={{ marginBottom: "20px", marginTop: "30px" }}
+                fullWidth
+              />
+              <TextField
                 label={t("robot_duplication.fields.target_url")}
                 value={targetUrl}
-                onChange={(e) => setTargetUrl(e.target.value)}
-                style={{ marginBottom: "20px", marginTop: "30px" }}
+                onChange={(e) => {
+                  setTargetUrl(e.target.value);
+                  if (robot) {
+                    const lastWord = e.target.value.split('/').filter(Boolean).pop() || 'Unnamed';
+                    setNewName(`${robot.recording_meta.name} (${lastWord})`);
+                  }
+                }}
+                style={{ marginBottom: "20px" }}
+                fullWidth
               />
             </>
           )}

--- a/src/components/robot/pages/RobotEditPage.tsx
+++ b/src/components/robot/pages/RobotEditPage.tsx
@@ -1051,8 +1051,8 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
       } else {
         notify("error", t("robot_edit.notifications.update_failed"));
       }
-    } catch (error) {
-      notify("error", t("robot_edit.notifications.update_error"));
+    } catch (error: any) {
+      notify("error", error.message || t("robot_edit.notifications.update_error"));
       console.error("Error updating robot:", error);
     } finally {
       setIsLoading(false);

--- a/src/components/robot/pages/RobotEditPage.tsx
+++ b/src/components/robot/pages/RobotEditPage.tsx
@@ -1052,7 +1052,11 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
         notify("error", t("robot_edit.notifications.update_failed"));
       }
     } catch (error: any) {
-      notify("error", error.message || t("robot_edit.notifications.update_error"));
+      if (error.isDuplicate) {
+        notify("error", t("save_recording.errors.name_exists"));
+      } else {
+        notify("error", error.message || t("robot_edit.notifications.update_error"));
+      }
       console.error("Error updating robot:", error);
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
## What was the issue

When saving a recorded robot, the app allowed multiple robots to be created with the same name. The existing check in \`SaveRecording.tsx\` would detect the duplicate and show a warning — but it also rendered a "Confirm" button that, when clicked, would go ahead and save the robot anyway, creating a duplicate entry in the database.

Additionally:
- Names with leading/trailing whitespace like \`"Ritam"\` and \`" Ritam "\` were treated as different names, so users could accidentally create near-duplicates
- There was no server-side enforcement — the uniqueness check existed only on the frontend and could be bypassed

## What we fixed

### 1. Blocked duplicate saves instead of confirming them (\`SaveRecording.tsx\`)

Removed the confirm-to-overwrite flow entirely. Now when a user tries to save with an existing name, an error notification is shown immediately and the save is blocked. The "Confirm" button is gone.

### 2. Added server-side uniqueness check (\`Generator.ts\`)

Added a database lookup before creating a new robot. If a robot with the same name already exists for that user, the save is rejected at the backend level — making it impossible to bypass via API or race conditions.

### 3. Added server-side uniqueness check for Scrape, Crawl, Search robots (\`storage.ts\`)

Each robot creation endpoint (\`/recordings/scrape\`, \`/recordings/crawl\`, \`/recordings/search\`) now checks for an existing robot with the same name before inserting, returning a \`409 DUPLICATE_NAME\` error if found.

### 4. Added server-side uniqueness check on robot rename (\`storage.ts\`)

The \`PUT /recordings/:id\` endpoint now validates uniqueness when the name changes, while correctly skipping the check when the name belongs to the robot being edited.

### 5. Normalized whitespace before comparison and save

Trimmed names on both frontend and backend so \`"Ritam"\`, \`"Ritam "\`, and \`"  Ritam  "\` are all treated as the same name.

## Files changed

- \`src/components/recorder/SaveRecording.tsx\` — removed confirm flow, block on duplicate
- \`server/src/workflow-management/classes/Generator.ts\` — server-side check before save
- \`server/src/routes/storage.ts\` — duplicate checks for scrape, crawl, search creation and robot rename
- \`src/api/storage.ts\` — \`updateRecording\` and \`createSearchRobot\` propagate \`DUPLICATE_NAME\` error
- \`src/components/robot/pages/RobotCreate.tsx\` — show warning on duplicate for crawl/search
- \`src/components/robot/pages/RobotEditPage.tsx\` — show warning on duplicate name during edit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced duplicate robot-name uniqueness at database/storage level with explicit duplicate-name responses
  * Added localized "name already exists" error messages (EN, DE, ES, JA, TR, ZH)

* **Bug Fixes**
  * Trimmed whitespace and applied case-insensitive name checks across create/update flows
  * Simplified Save UI to a single Save action and surfaced clear duplicate-name notifications during create/edit operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->