### PR TITLE
fix(recorder): auto-discard recording session after 10-minute timeout

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -294,7 +294,8 @@
         "notifications": {
             "terminated": "Aktuelle Aufnahme wurde beendet",
             "environment_reset": "Browser-Umgebung wurde zurückgesetzt",
-            "reset_successful": "Alle Aufnahmen erfolgreich zurückgesetzt und zum Ausgangszustand zurückgekehrt"
+            "reset_successful": "Alle Aufnahmen erfolgreich zurückgesetzt und zum Ausgangszustand zurückgekehrt",
+            "timeout_discarded": "Die Aufnahmesitzung ist nach 10 Minuten abgelaufen und wurde automatisch verworfen."
         }
     },
     "interpretation_log": {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -294,7 +294,8 @@
       "notifications": {
           "terminated": "Current Recording was terminated",
           "environment_reset": "Browser environment has been reset",
-          "reset_successful": "Successfully reset all captures and returned to initial state"
+          "reset_successful": "Successfully reset all captures and returned to initial state",
+          "timeout_discarded": "Recording session timed out after 10 minutes and was automatically discarded."
       }
     },
     "interpretation_log": {

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -294,7 +294,8 @@
     "notifications": {
       "terminated": "La grabación actual fue terminada",
       "environment_reset": "El entorno del navegador ha sido reiniciado",
-      "reset_successful": "Se reiniciaron correctamente todas las capturas y se volvió al estado inicial"
+      "reset_successful": "Se reiniciaron correctamente todas las capturas y se volvió al estado inicial",
+      "timeout_discarded": "La sesión de grabación expiró después de 10 minutos y fue descartada automáticamente."
     }
   },
   "interpretation_buttons": {

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -294,7 +294,8 @@
         "notifications": {
             "terminated": "現在の録画は終了しました",
             "environment_reset": "ブラウザー環境がリセットされました",
-            "reset_successful": "すべてのキャプチャーを正常にリセットし、初期状態に戻りました"
+            "reset_successful": "すべてのキャプチャーを正常にリセットし、初期状態に戻りました",
+            "timeout_discarded": "録画セッションが10分後にタイムアウトし、自動的に破棄されました。"
         }
     },
     "interpretation_log": {

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -293,7 +293,8 @@
     "notifications": {
       "terminated": "Kayıt sonlandırıldı",
       "environment_reset": "Tarayıcı ortamı sıfırlandı",
-      "reset_successful": "Yakalamalar sıfırlandı ve başlangıç durumuna dönüldü"
+      "reset_successful": "Yakalamalar sıfırlandı ve başlangıç durumuna dönüldü",
+      "timeout_discarded": "Kayıt oturumu 10 dakika sonra zaman aşımına uğradı ve otomatik olarak atıldı."
     }
   },
   "interpretation_log": {

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -294,7 +294,8 @@
     "notifications": {
       "terminated": "当前录制已终止",
       "environment_reset": "浏览器环境已重置",
-      "reset_successful": "已成功重置所有捕获并返回初始状态"
+      "reset_successful": "已成功重置所有捕获并返回初始状态",
+      "timeout_discarded": "录制会话在10分钟后超时并自动丢弃。"
     }
   },
   "interpretation_log": {

--- a/server/src/browser-management/controller.ts
+++ b/server/src/browser-management/controller.ts
@@ -11,6 +11,9 @@ import { RemoteBrowser } from "./classes/RemoteBrowser";
 import { RemoteBrowserOptions } from "../types";
 import logger from "../logger";
 
+const RECORDING_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const recordingTimeouts = new Map<string, NodeJS.Timeout>();
+
 /**
  * Starts and initializes a {@link RemoteBrowser} instance.
  * Creates a new socket connection over a dedicated namespace
@@ -41,7 +44,31 @@ export const initializeRemoteBrowserForRecording = (userId: string, mode: string
 
           logger.info('DOM streaming started for remote browser in recording mode');
 
-          browserPool.addRemoteBrowser(id, browserSession, userId, false, "recording");
+          const added = browserPool.addRemoteBrowser(id, browserSession, userId, false, "recording");
+          if (!added) {
+            logger.error(`Failed to add recording browser ${id} to pool; cleaning up session`);
+            socket.emit('dom-mode-error', {
+              userId,
+              error: 'Failed to start the browser, please try again in some time.'
+            });
+            await browserSession.switchOff();
+            return id;
+          }
+
+          const timeoutHandle = setTimeout(async () => {
+            recordingTimeouts.delete(id);
+            logger.warn(`Recording session ${id} timed out, auto-discarding`);
+            try {
+              io.of(id).emit('recording-timeout');
+            } catch (e) {
+              logger.warn(`Failed to emit recording-timeout event for session ${id}: ${e}`);
+            }
+            // Wait for the frontend to receive the event, post BroadcastChannel message,
+            // and close the recording tab before we tear down the socket connection.
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            await destroyRemoteBrowser(id, userId);
+          }, RECORDING_TIMEOUT_MS);
+          recordingTimeouts.set(id, timeoutHandle);
         } catch (initError: any) {
           logger.error(`Failed to initialize browser for recording: ${initError.message}`);
           logger.info('Sending browser failure notification to frontend');
@@ -116,7 +143,18 @@ export const createRemoteBrowserForRun = (userId: string): string => {
  * @returns {Promise<boolean>}
  * @category BrowserManagement-Controller
  */
+export const clearRecordingTimeout = (id: string): void => {
+  const existingTimeout = recordingTimeouts.get(id);
+  if (existingTimeout) {
+    clearTimeout(existingTimeout);
+    recordingTimeouts.delete(id);
+    logger.log('debug', `Recording timeout cancelled for session ${id}`);
+  }
+};
+
 export const destroyRemoteBrowser = async (id: string, userId: string): Promise<boolean> => {
+  clearRecordingTimeout(id);
+
   const DESTROY_TIMEOUT = 30000;
 
   const destroyPromise = (async () => {

--- a/server/src/routes/record.ts
+++ b/server/src/routes/record.ts
@@ -12,6 +12,7 @@ import {
     getActiveBrowserIdByState,
     destroyRemoteBrowser,
     canCreateBrowserInState,
+    clearRecordingTimeout,
 } from '../browser-management/controller';
 import logger from "../logger";
 import { requireSignIn } from '../middlewares/auth';
@@ -134,6 +135,10 @@ router.get('/stop/:browserId', requireSignIn, async (req: AuthenticatedRequest, 
     if (!req.user) {
         return res.status(401).send('User not authenticated');
     }
+
+    // Cancel the recording timeout synchronously before any async work
+    // to prevent the timer firing during the pgBoss job queue window.
+    clearRecordingTimeout(req.params.browserId);
 
     try {
         await pgBossClient.createQueue('destroy-browser');

--- a/src/components/robot/pages/RobotCreate.tsx
+++ b/src/components/robot/pages/RobotCreate.tsx
@@ -135,6 +135,7 @@ const RobotCreate: React.FC = () => {
 
       const sessionId = Date.now().toString();
       window.sessionStorage.setItem('recordingSessionId', sessionId);
+      window.sessionStorage.setItem('recordingOriginPage', window.location.pathname + window.location.search);
 
       window.open(`/recording-setup?session=${sessionId}`, '_blank');
       window.sessionStorage.setItem('nextTabIsRecording', 'true');
@@ -169,6 +170,7 @@ const RobotCreate: React.FC = () => {
 
     const sessionId = Date.now().toString();
     window.sessionStorage.setItem('recordingSessionId', sessionId);
+    window.sessionStorage.setItem('recordingOriginPage', window.location.pathname + window.location.search);
 
     window.open(`/recording-setup?session=${sessionId}`, '_blank');
     window.sessionStorage.setItem('nextTabIsRecording', 'true');

--- a/src/pages/PageWrapper.tsx
+++ b/src/pages/PageWrapper.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { NavBar } from "../components/dashboard/NavBar";
 import { SocketProvider } from "../context/socket";
 import { BrowserDimensionsProvider } from "../context/browserDimensions";
@@ -18,10 +19,11 @@ import { Box } from '@mui/material';
 export const PageWrapper = () => {
   const [open, setOpen] = useState(false);
   const [isRecordingMode, setIsRecordingMode] = useState(false);
+  const { t } = useTranslation();
 
   const navigate = useNavigate();
 
-  const { browserId, setBrowserId, notification, recordingName, setRecordingName, recordingId, setRecordingId, setRecordingUrl } = useGlobalInfoStore();
+  const { browserId, setBrowserId, notification, notify, recordingName, setRecordingName, recordingId, setRecordingId, setRecordingUrl } = useGlobalInfoStore();
 
   const handleEditRecording = (recordingId: string, fileName: string) => {
     setRecordingName(fileName);
@@ -85,6 +87,21 @@ export const PageWrapper = () => {
       }
     }
   }, [location.pathname, navigate, setBrowserId, setRecordingId, setRecordingName, setRecordingUrl]);
+
+  useEffect(() => {
+    const channel = new BroadcastChannel('maxun-recording');
+    channel.onmessage = (event) => {
+      if (event.data?.type === 'recording-timeout') {
+        notify('warning', t('browser_recording.notifications.timeout_discarded'));
+        const originPage = window.sessionStorage.getItem('recordingOriginPage');
+        window.sessionStorage.removeItem('recordingOriginPage');
+        navigate(originPage || '/robots');
+      }
+    };
+    return () => {
+      channel.close();
+    };
+  }, [notify, t, navigate]);
 
   const isAuthPage = location.pathname === '/login' || location.pathname === '/register';
   const isRecordingPage = location.pathname === '/recording';

--- a/src/pages/RecordingPage.tsx
+++ b/src/pages/RecordingPage.tsx
@@ -16,6 +16,7 @@ import styled from "styled-components";
 import BrowserRecordingSave from '../components/browser/BrowserRecordingSave';
 import { useThemeMode } from '../context/theme-provider';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 
 interface RecordingPageProps {
   recordingName?: string;
@@ -29,6 +30,7 @@ export interface PairForEdit {
 export const RecordingPage = ({ recordingName }: RecordingPageProps) => {
   const { darkMode } = useThemeMode();
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const [isLoaded, setIsLoaded] = React.useState(false);
   const [hasScrollbar, setHasScrollbar] = React.useState(false);
   const [pairForEdit, setPairForEdit] = useState<PairForEdit>({
@@ -44,6 +46,21 @@ export const RecordingPage = ({ recordingName }: RecordingPageProps) => {
   const { setId, socket } = useSocketStore();
   const { setWidth } = useBrowserDimensionsStore();
   const { browserId, setBrowserId, recordingId, recordingUrl, setRecordingUrl, setRecordingName, setRetrainRobotId, setIsDOMMode } = useGlobalInfoStore();
+
+  useEffect(() => {
+    const handleRecordingTimeout = () => {
+      const channel = new BroadcastChannel('maxun-recording');
+      channel.postMessage({ type: 'recording-timeout' });
+      channel.close();
+      window.close();
+      // Fallback: if window.close() is blocked by the browser, navigate away
+      setTimeout(() => navigate('/robots'), 300);
+    };
+    socket?.on('recording-timeout', handleRecordingTimeout);
+    return () => {
+      socket?.off('recording-timeout', handleRecordingTimeout);
+    };
+  }, [socket, navigate]);
 
   const handleShowOutputData = useCallback(() => {
     setShowOutputData(true);

--- a/src/pages/RecordingPage.tsx
+++ b/src/pages/RecordingPage.tsx
@@ -45,10 +45,17 @@ export const RecordingPage = ({ recordingName }: RecordingPageProps) => {
 
   const { setId, socket } = useSocketStore();
   const { setWidth } = useBrowserDimensionsStore();
-  const { browserId, setBrowserId, recordingId, recordingUrl, setRecordingUrl, setRecordingName, setRetrainRobotId, setIsDOMMode } = useGlobalInfoStore();
+  const { browserId, setBrowserId, recordingId, setRecordingId, recordingUrl, setRecordingUrl, setRecordingName, setRetrainRobotId, setCurrentWorkflowActionsState, setIsDOMMode } = useGlobalInfoStore();
 
   useEffect(() => {
     const handleRecordingTimeout = () => {
+      setBrowserId(null);
+      setRecordingId(null);
+      setRecordingName('');
+      setRecordingUrl('');
+      setRetrainRobotId(null);
+      setCurrentWorkflowActionsState({ hasScrapeListAction: false, hasScreenshotAction: false, hasScrapeSchemaAction: false });
+      setIsDOMMode(false);
       const channel = new BroadcastChannel('maxun-recording');
       channel.postMessage({ type: 'recording-timeout' });
       channel.close();
@@ -60,7 +67,7 @@ export const RecordingPage = ({ recordingName }: RecordingPageProps) => {
     return () => {
       socket?.off('recording-timeout', handleRecordingTimeout);
     };
-  }, [socket, navigate]);
+  }, [socket, navigate, setBrowserId, setRecordingId, setRecordingName, setRecordingUrl, setRetrainRobotId, setCurrentWorkflowActionsState, setIsDOMMode]);
 
   const handleShowOutputData = useCallback(() => {
     setShowOutputData(true);


### PR DESCRIPTION
## Problem
Recording browser sessions ran indefinitely if the user navigated away or abandoned the session without saving or discarding. This left orphaned Playwright browser instances consuming memory and occupying the browser pool slot for that user.

## Fix
Added a 10-minute timeout to automatically discard abandoned recording sessions.

**Backend (`server/src/browser-management/controller.ts`)**
- Added a module-level `recordingTimeouts` Map to track a `setTimeout` handle per active recording session
- Timer starts immediately after the browser is initialized and added to the pool
- On timeout: emits `recording-timeout` socket event to the frontend, then calls `destroyRemoteBrowser` to clean up the Playwright browser, socket namespace, and pool entry
- `destroyRemoteBrowser` clears the timer at the start — if the user saves or discards before 10 minutes, the timeout is cancelled and never fires

**Frontend (`src/pages/RecordingPage.tsx`)**
- Listens for the `recording-timeout` socket event
- Shows a warning notification: *"Recording session timed out after 10 minutes and was automatically discarded."*
- Navigates the user back to the dashboard

## Behaviour
| Scenario | Result |
|---|---|
| User saves the robot | Timeout cancelled, normal flow |
| User discards the recording | Timeout cancelled, normal flow |
| Session abandoned for 10 min | Auto-discarded, user redirected to dashboard with warning |

## Testing evidence

https://drive.google.com/file/d/1B9hHjL-H522B8PfTEyyb6weOSmiIzqNx/view?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recording sessions now automatically expire after 10 minutes and are discarded.
  * On timeout, users receive a notification and are returned to their originating page (fallback to robots list).

* **Bug Fixes**
  * Recording timeouts are reliably cleared when a recording is stopped or the session is ended.
  * Improved user-facing error notification when a recording cannot be started.

* **Localization**
  * Added timeout notification translations for en, de, es, ja, tr, and zh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->