### PR TITLE
feat: Added Output Format Selection to Crawl and Search Robots

### DIFF
--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -2524,7 +2524,8 @@ export default class Interpreter extends EventEmitter {
         
         console.log("REPEAT COUNT", repeatCount);
         if (this.options.maxRepeats && repeatCount > this.options.maxRepeats) {
-          const failedAction = action?.what?.[0]?.action || 'unknown';
+
+          const failedAction = (action?.what?.find((w: any) => w?.action !== 'flag')?.action) || 'unknown';
           const maxRepeats = this.options.maxRepeats;
           this.log(`Action ${String(failedAction)} exceeded max retries (${maxRepeats})`, Level.ERROR);
           cleanup();

--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -2524,7 +2524,11 @@ export default class Interpreter extends EventEmitter {
         
         console.log("REPEAT COUNT", repeatCount);
         if (this.options.maxRepeats && repeatCount > this.options.maxRepeats) {
-          return;
+          const failedAction = action?.what?.[0]?.action || 'unknown';
+          const maxRepeats = this.options.maxRepeats;
+          this.log(`Action ${String(failedAction)} exceeded max retries (${maxRepeats})`, Level.ERROR);
+          cleanup();
+          throw new Error(`Action ${String(failedAction)} exceeded max retries (${maxRepeats})`);
         }
         lastAction = action;
         

--- a/maxun-core/src/utils/concurrency.ts
+++ b/maxun-core/src/utils/concurrency.ts
@@ -18,9 +18,14 @@ export default class Concurrency {
   private jobQueue: Function[] = [];
 
   /**
-  * "Resolve" callbacks of the waitForCompletion() promises.
+  * Resolve/reject callbacks of the waitForCompletion() promises.
   */
-  private waiting: Function[] = [];
+  private waiting: Array<{ resolve: () => void; reject: (error: Error) => void }> = [];
+
+  /**
+  * First worker error captured during current execution wave.
+  */
+  private firstError: Error | null = null;
 
   /**
   * Constructs a new instance of concurrency manager.
@@ -42,7 +47,11 @@ export default class Concurrency {
         // console.debug("Job finished, running the next waiting job...");
         this.runNextJob();
       }).catch((error) => {
-        console.error(`Job failed with error: ${error.message}`);
+        const normalizedError = error instanceof Error ? error : new Error(String(error));
+        console.error(`Job failed with error: ${normalizedError.message}`);
+        if (!this.firstError) {
+          this.firstError = normalizedError;
+        }
         // Continue processing other jobs even if one fails
         this.runNextJob();
       });
@@ -51,7 +60,18 @@ export default class Concurrency {
       this.activeWorkers -= 1;
       if (this.activeWorkers === 0) {
         // console.debug("This concurrency manager is idle!");
-        this.waiting.forEach((x) => x());
+        const pending = [...this.waiting];
+        this.waiting = [];
+        const pendingError = this.firstError;
+        this.firstError = null;
+
+        pending.forEach(({ resolve, reject }) => {
+          if (pendingError) {
+            reject(pendingError);
+          } else {
+            resolve();
+          }
+        });
       }
     }
   }
@@ -82,8 +102,8 @@ export default class Concurrency {
   * @returns Promise, resolved after there is no running/waiting worker.
   */
   waitForCompletion(): Promise<void> {
-    return new Promise((res) => {
-      this.waiting.push(res);
+    return new Promise((resolve, reject) => {
+      this.waiting.push({ resolve, reject });
     });
   }
 }

--- a/server/src/api/sdk.ts
+++ b/server/src/api/sdk.ts
@@ -17,6 +17,12 @@ import { WorkflowEnricher } from "../sdk/workflowEnricher";
 import { cancelScheduledWorkflow, scheduleWorkflow } from '../storage/schedule';
 import { computeNextRun } from "../utils/schedule";
 import moment from 'moment-timezone';
+import {
+    DEFAULT_OUTPUT_FORMATS,
+    parseOutputFormats,
+    OutputFormat,
+    SCRAPE_OUTPUT_FORMAT_OPTIONS,
+} from '../constants/output-formats';
 
 const router = Router();
 
@@ -66,12 +72,12 @@ router.post("/sdk/robots", requireAPIKey, async (req: AuthenticatedRequest, res:
             });
         }
 
-        const robotType = (workflowFile.meta as any).type || (workflowFile.meta as any).robotType || 'extract';
+        const type = (workflowFile.meta as any).type || (workflowFile.meta as any).robotType || 'extract';
 
         let enrichedWorkflow: any[] = [];
         let extractedUrl: string | undefined;
 
-        if (robotType === 'scrape') {
+        if (type === 'scrape') {
             enrichedWorkflow = [];
             extractedUrl = (workflowFile.meta as any).url;
 
@@ -96,6 +102,39 @@ router.post("/sdk/robots", requireAPIKey, async (req: AuthenticatedRequest, res:
             extractedUrl = enrichResult.url;
         }
 
+        const rawFormats = (workflowFile.meta as any).formats;
+        const { validFormats, invalidFormats } = parseOutputFormats(
+            rawFormats,
+            type === 'scrape' ? SCRAPE_OUTPUT_FORMAT_OPTIONS : undefined
+        );
+
+        if (invalidFormats.length > 0) {
+            return res.status(400).json({
+                error: `Invalid formats: ${invalidFormats.map(String).join(', ')}`
+            });
+        }
+
+        let normalizedFormats: OutputFormat[] = validFormats;
+
+        if (type === 'search') {
+            const searchAction = enrichedWorkflow
+                .flatMap((pair: any) => pair.what || [])
+                .find((action: any) => action?.action === 'search');
+            const searchMode = searchAction?.args?.[0]?.mode;
+
+            if (searchMode === 'discover') {
+                normalizedFormats = [];
+            } else {
+                normalizedFormats = validFormats.length > 0
+                    ? validFormats
+                    : [...DEFAULT_OUTPUT_FORMATS];
+            }
+        } else if (type === 'crawl' || type === 'scrape') {
+            normalizedFormats = validFormats.length > 0
+                ? validFormats
+                : [...DEFAULT_OUTPUT_FORMATS];
+        }
+
         const robotId = uuid();
         const metaId = uuid();
 
@@ -106,9 +145,9 @@ router.post("/sdk/robots", requireAPIKey, async (req: AuthenticatedRequest, res:
             updatedAt: new Date().toISOString(),
             pairs: enrichedWorkflow.length,
             params: [],
-            type: robotType,
+            type,
             url: extractedUrl,
-            formats: (workflowFile.meta as any).formats || [],
+            formats: normalizedFormats,
             isLLM: (workflowFile.meta as any).isLLM,
         };
 
@@ -838,7 +877,7 @@ router.post("/sdk/robots/:id/duplicate", requireAPIKey, async (req: Authenticate
 router.post("/sdk/crawl", requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
     try {
         const user = req.user;
-        const { url, name, crawlConfig } = req.body;
+        const { url, name, crawlConfig, formats } = req.body;
 
         if (!url || !crawlConfig) {
             return res.status(400).json({
@@ -860,6 +899,17 @@ router.post("/sdk/crawl", requireAPIKey, async (req: AuthenticatedRequest, res: 
             });
         }
 
+        const { validFormats: requestedFormats, invalidFormats } = parseOutputFormats(formats);
+        if (invalidFormats.length > 0) {
+            return res.status(400).json({
+                error: `Invalid formats: ${invalidFormats.map(String).join(', ')}`
+            });
+        }
+
+        const crawlFormats: OutputFormat[] = requestedFormats.length > 0
+            ? requestedFormats
+            : [...DEFAULT_OUTPUT_FORMATS];
+
         const robotName = name || `Crawl Robot - ${new URL(url).hostname}`;
         const robotId = uuid();
         const metaId = uuid();
@@ -876,7 +926,7 @@ router.post("/sdk/crawl", requireAPIKey, async (req: AuthenticatedRequest, res: 
                 params: [],
                 type: 'crawl',
                 url: url,
-                formats: crawlConfig.outputFormats || [],
+                formats: crawlFormats,
             },
             recording: {
                 workflow: [
@@ -942,7 +992,7 @@ router.post("/sdk/crawl", requireAPIKey, async (req: AuthenticatedRequest, res: 
 router.post("/sdk/search", requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
     try {
         const user = req.user;
-        const { name, searchConfig } = req.body;
+        const { name, searchConfig, formats } = req.body;
 
         if (!searchConfig) {
             return res.status(400).json({
@@ -968,6 +1018,17 @@ router.post("/sdk/search", requireAPIKey, async (req: AuthenticatedRequest, res:
             });
         }
 
+        const { validFormats: requestedFormats, invalidFormats } = parseOutputFormats(formats);
+        if (invalidFormats.length > 0) {
+            return res.status(400).json({
+                error: `Invalid formats: ${invalidFormats.map(String).join(', ')}`
+            });
+        }
+
+        const searchFormats: OutputFormat[] = searchConfig.mode === 'discover'
+            ? []
+            : (requestedFormats.length > 0 ? requestedFormats : [...DEFAULT_OUTPUT_FORMATS]);
+
         searchConfig.provider = 'duckduckgo';
 
         if (searchConfig.outputFormats && Array.isArray(searchConfig.outputFormats) && searchConfig.outputFormats.length > 0) {
@@ -989,7 +1050,7 @@ router.post("/sdk/search", requireAPIKey, async (req: AuthenticatedRequest, res:
                 pairs: 1,
                 params: [],
                 type: 'search',
-                formats: searchConfig.outputFormats || [],
+                formats: searchFormats,
             },
             recording: {
                 workflow: [

--- a/server/src/api/sdk.ts
+++ b/server/src/api/sdk.ts
@@ -103,7 +103,7 @@ router.post("/sdk/robots", requireAPIKey, async (req: AuthenticatedRequest, res:
         }
 
         const rawFormats = (workflowFile.meta as any).formats;
-        const { validFormats, invalidFormats } = parseOutputFormats(
+        const { validFormats, invalidFormats, wasProvided } = parseOutputFormats(
             rawFormats,
             type === 'scrape' ? SCRAPE_OUTPUT_FORMAT_OPTIONS : undefined
         );
@@ -123,16 +123,15 @@ router.post("/sdk/robots", requireAPIKey, async (req: AuthenticatedRequest, res:
             const searchMode = searchAction?.args?.[0]?.mode;
 
             if (searchMode === 'discover') {
-                normalizedFormats = [];
+                
+                normalizedFormats = validFormats.length > 0 ? validFormats : [];
             } else {
-                normalizedFormats = validFormats.length > 0
-                    ? validFormats
-                    : [...DEFAULT_OUTPUT_FORMATS];
+                
+                normalizedFormats = validFormats.length > 0 ? validFormats : [...DEFAULT_OUTPUT_FORMATS];
             }
         } else if (type === 'crawl' || type === 'scrape') {
-            normalizedFormats = validFormats.length > 0
-                ? validFormats
-                : [...DEFAULT_OUTPUT_FORMATS];
+            
+            normalizedFormats = validFormats.length > 0 ? validFormats : [...DEFAULT_OUTPUT_FORMATS];
         }
 
         const robotId = uuid();
@@ -899,15 +898,16 @@ router.post("/sdk/crawl", requireAPIKey, async (req: AuthenticatedRequest, res: 
             });
         }
 
-        const { validFormats: requestedFormats, invalidFormats } = parseOutputFormats(formats);
+        const { validFormats: requestedFormats, invalidFormats, wasProvided } = parseOutputFormats(formats);
         if (invalidFormats.length > 0) {
             return res.status(400).json({
                 error: `Invalid formats: ${invalidFormats.map(String).join(', ')}`
             });
         }
 
-        const crawlFormats: OutputFormat[] = requestedFormats.length > 0
-            ? requestedFormats
+        // Crawl always needs formats; use defaults even if explicit empty array is provided
+        const crawlFormats: OutputFormat[] = requestedFormats.length > 0 
+            ? requestedFormats 
             : [...DEFAULT_OUTPUT_FORMATS];
 
         const robotName = name || `Crawl Robot - ${new URL(url).hostname}`;
@@ -1018,7 +1018,7 @@ router.post("/sdk/search", requireAPIKey, async (req: AuthenticatedRequest, res:
             });
         }
 
-        const { validFormats: requestedFormats, invalidFormats } = parseOutputFormats(formats);
+        const { validFormats: requestedFormats, invalidFormats, wasProvided } = parseOutputFormats(formats);
         if (invalidFormats.length > 0) {
             return res.status(400).json({
                 error: `Invalid formats: ${invalidFormats.map(String).join(', ')}`
@@ -1026,7 +1026,7 @@ router.post("/sdk/search", requireAPIKey, async (req: AuthenticatedRequest, res:
         }
 
         const searchFormats: OutputFormat[] = searchConfig.mode === 'discover'
-            ? []
+            ? (requestedFormats.length > 0 ? requestedFormats : [])
             : (requestedFormats.length > 0 ? requestedFormats : [...DEFAULT_OUTPUT_FORMATS]);
 
         searchConfig.provider = 'duckduckgo';

--- a/server/src/constants/output-formats.ts
+++ b/server/src/constants/output-formats.ts
@@ -1,0 +1,47 @@
+export const OUTPUT_FORMAT_OPTIONS = [
+  'markdown',
+  'html',
+  'text',
+  'screenshot-visible',
+  'screenshot-fullpage',
+] as const;
+
+export type OutputFormat = (typeof OUTPUT_FORMAT_OPTIONS)[number];
+
+export const SCRAPE_OUTPUT_FORMAT_OPTIONS: OutputFormat[] = [
+  'markdown',
+  'html',
+  'screenshot-visible',
+  'screenshot-fullpage',
+];
+
+const OUTPUT_FORMAT_SET = new Set<string>(OUTPUT_FORMAT_OPTIONS as readonly string[]);
+
+export const DEFAULT_OUTPUT_FORMATS: OutputFormat[] = ['markdown'];
+
+export function isOutputFormat(value: unknown): value is OutputFormat {
+  return typeof value === 'string' && OUTPUT_FORMAT_SET.has(value);
+}
+
+export function parseOutputFormats(
+  formats: unknown,
+  allowedFormats: readonly OutputFormat[] = OUTPUT_FORMAT_OPTIONS
+): {
+  validFormats: OutputFormat[];
+  invalidFormats: unknown[];
+} {
+  const requestedFormats = Array.isArray(formats) ? formats : [];
+  const validFormats: OutputFormat[] = [];
+  const invalidFormats: unknown[] = [];
+  const allowedSet = new Set<string>(allowedFormats as readonly string[]);
+
+  requestedFormats.forEach((format) => {
+    if (isOutputFormat(format) && allowedSet.has(format)) {
+      validFormats.push(format);
+    } else {
+      invalidFormats.push(format);
+    }
+  });
+
+  return { validFormats, invalidFormats };
+}

--- a/server/src/constants/output-formats.ts
+++ b/server/src/constants/output-formats.ts
@@ -15,6 +15,14 @@ export const SCRAPE_OUTPUT_FORMAT_OPTIONS: OutputFormat[] = [
   'screenshot-fullpage',
 ];
 
+export const SEARCH_SCRAPE_OUTPUT_FORMAT_OPTIONS: OutputFormat[] = [
+  'markdown',
+  'html',
+  'text',
+  'screenshot-visible',
+  'screenshot-fullpage',
+];
+
 const OUTPUT_FORMAT_SET = new Set<string>(OUTPUT_FORMAT_OPTIONS as readonly string[]);
 
 export const DEFAULT_OUTPUT_FORMATS: OutputFormat[] = ['markdown'];

--- a/server/src/constants/output-formats.ts
+++ b/server/src/constants/output-formats.ts
@@ -29,7 +29,9 @@ export function parseOutputFormats(
 ): {
   validFormats: OutputFormat[];
   invalidFormats: unknown[];
+  wasProvided: boolean;
 } {
+  const wasProvided = formats !== undefined;
   const requestedFormats = Array.isArray(formats) ? formats : [];
   const validFormats: OutputFormat[] = [];
   const invalidFormats: unknown[] = [];
@@ -43,5 +45,5 @@ export function parseOutputFormats(
     }
   });
 
-  return { validFormats, invalidFormats };
+  return { validFormats, invalidFormats, wasProvided };
 }

--- a/server/src/markdownify/scrape.ts
+++ b/server/src/markdownify/scrape.ts
@@ -135,7 +135,10 @@ export async function convertPageToScreenshot(url: string, page: Page, fullPage:
     const screenshotType = fullPage ? 'full page' : 'visible viewport';
     logger.log('info', `[Scrape] Taking ${screenshotType} screenshot of ${url}`);
 
-    await gotoWithFallback(page, url);
+    const currentUrl = page.url();
+    if (currentUrl !== url) {
+      await gotoWithFallback(page, url);
+    }
 
     const screenshot = await page.screenshot({
       type: 'png',

--- a/server/src/models/Robot.ts
+++ b/server/src/models/Robot.ts
@@ -1,6 +1,7 @@
 import { Model, DataTypes, Optional } from 'sequelize';
 import sequelize from '../storage/db';
 import { WhereWhatPair } from 'maxun-core';
+import { OutputFormat } from '../constants/output-formats';
 
 interface RobotMeta {
   name: string;
@@ -11,7 +12,7 @@ interface RobotMeta {
   params: any[];
   type?: 'extract' | 'scrape' | 'crawl' | 'search';
   url?: string;
-  formats?: ('markdown' | 'html' | 'screenshot-visible' | 'screenshot-fullpage')[];
+  formats?: OutputFormat[];
   isLLM?: boolean;
 }
 

--- a/server/src/pgboss-worker.ts
+++ b/server/src/pgboss-worker.ts
@@ -21,6 +21,8 @@ import { io as serverIo } from "./server";
 import { sendWebhook } from './routes/webhook';
 import { BinaryOutputService } from './storage/mino';
 import { convertPageToMarkdown, convertPageToHTML, convertPageToScreenshot } from './markdownify/scrape';
+import { processRobotOutputFormats } from './utils/output-post-processor';
+import { getInterpretationFailureReason, hasExpectedRobotOutput } from './utils/output-validation';
 
 if (!process.env.DB_USER || !process.env.DB_PASSWORD || !process.env.DB_HOST || !process.env.DB_PORT || !process.env.DB_NAME) {
     throw new Error('Failed to start pgboss worker: one or more required environment variables are missing.');
@@ -125,7 +127,7 @@ async function triggerIntegrationUpdates(runId: string, robotMetaId: string): Pr
  * Modified processRunExecution function - only add browser reset
  */
 async function processRunExecution(job: Job<ExecuteRunData>) {
-  const BROWSER_INIT_TIMEOUT = 30000;
+  const BROWSER_INIT_TIMEOUT = 60000;
   const BROWSER_PAGE_TIMEOUT = 15000;
 
   const data = job.data;
@@ -161,7 +163,7 @@ async function processRunExecution(job: Job<ExecuteRunData>) {
     const browserWaitStart = Date.now();
     let lastLogTime = 0;
     let pollAttempts = 0;
-    const MAX_POLL_ATTEMPTS = 15;
+    const MAX_POLL_ATTEMPTS = Math.ceil(BROWSER_INIT_TIMEOUT / 2000);
     
     while (!browser && (Date.now() - browserWaitStart) < BROWSER_INIT_TIMEOUT && pollAttempts < MAX_POLL_ATTEMPTS) {
       const currentTime = Date.now();
@@ -467,12 +469,6 @@ async function processRunExecution(job: Job<ExecuteRunData>) {
 
       logger.log('info', `Workflow execution completed for run ${data.runId}`);
 
-      const binaryOutputService = new BinaryOutputService('maxun-run-screenshots');
-      const uploadedBinaryOutput = await binaryOutputService.uploadAndStoreBinaryOutput(
-        run, 
-        interpretationInfo.binaryOutput
-      );
-
       const finalRun = await Run.findByPk(run.id);
       const categorizedOutput = {
         scrapeSchema: finalRun?.serializableOutput?.scrapeSchema || {},
@@ -480,6 +476,54 @@ async function processRunExecution(job: Job<ExecuteRunData>) {
         crawl: finalRun?.serializableOutput?.crawl || {},
         search: finalRun?.serializableOutput?.search || {}
       };
+
+      let binaryOutput: Record<string, any> = {
+        ...(interpretationInfo.binaryOutput || {})
+      };
+
+      // Post-process crawl/search output according to selected output formats
+      const robotType = recording.recording_meta.type;
+      const outputFormats = (recording.recording_meta as any).formats as string[] | undefined;
+      if (robotType === 'crawl' || robotType === 'search') {
+        const processedOutput = await processRobotOutputFormats({
+          robotType,
+          outputFormats,
+          categorizedOutput: {
+            crawl: categorizedOutput.crawl as Record<string, any>,
+            search: categorizedOutput.search as Record<string, any>,
+          },
+          currentPage,
+          initialBinaryOutput: binaryOutput,
+        });
+
+        categorizedOutput.crawl = processedOutput.categorizedOutput.crawl;
+        categorizedOutput.search = processedOutput.categorizedOutput.search;
+        binaryOutput = processedOutput.binaryOutput;
+
+        await run.update({
+          serializableOutput: {
+            ...(finalRun?.serializableOutput || {}),
+            crawl: categorizedOutput.crawl,
+            search: categorizedOutput.search,
+          }
+        });
+
+        const hasOutput = hasExpectedRobotOutput(robotType, {
+          crawl: categorizedOutput.crawl as Record<string, any>,
+          search: categorizedOutput.search as Record<string, any>
+        });
+
+        if (!hasOutput) {
+          const humanRobotType = robotType.charAt(0).toUpperCase() + robotType.slice(1);
+          const fallbackReason = `${humanRobotType} run completed without producing output data`;
+          throw new Error(getInterpretationFailureReason(interpretationInfo.log, fallbackReason));
+        }
+      }
+
+      const binaryOutputService = new BinaryOutputService('maxun-run-screenshots');
+      const uploadedBinaryOutput = Object.keys(binaryOutput).length > 0
+        ? await binaryOutputService.uploadAndStoreBinaryOutput(run, binaryOutput)
+        : {};
       
       if (await isRunAborted()) {
         logger.log('info', `Run ${data.runId} was aborted while processing results, not updating status`);
@@ -495,7 +539,7 @@ async function processRunExecution(job: Job<ExecuteRunData>) {
 
       let totalSchemaItemsExtracted = 0;
       let totalListItemsExtracted = 0;
-      let extractedScreenshotsCount = 0;
+      let extractedScreenshotsCount = Object.keys(uploadedBinaryOutput).length;
       
       if (categorizedOutput) {
         if (categorizedOutput.scrapeSchema) {
@@ -516,9 +560,6 @@ async function processRunExecution(job: Job<ExecuteRunData>) {
           });
         }
         
-        if (run.binaryOutput) {
-          extractedScreenshotsCount = Object.keys(run.binaryOutput).length;
-        }
       }
       
       const totalRowsExtracted = totalSchemaItemsExtracted + totalListItemsExtracted;

--- a/server/src/pgboss-worker.ts
+++ b/server/src/pgboss-worker.ts
@@ -500,18 +500,10 @@ async function processRunExecution(job: Job<ExecuteRunData>) {
         categorizedOutput.search = processedOutput.categorizedOutput.search;
         binaryOutput = processedOutput.binaryOutput;
 
-        await run.update({
-          serializableOutput: {
-            ...(finalRun?.serializableOutput || {}),
-            crawl: categorizedOutput.crawl,
-            search: categorizedOutput.search,
-          }
-        });
-
         const hasOutput = hasExpectedRobotOutput(robotType, {
           crawl: categorizedOutput.crawl as Record<string, any>,
           search: categorizedOutput.search as Record<string, any>
-        });
+        }, outputFormats, binaryOutput);
 
         if (!hasOutput) {
           const humanRobotType = robotType.charAt(0).toUpperCase() + robotType.slice(1);
@@ -535,6 +527,11 @@ async function processRunExecution(job: Job<ExecuteRunData>) {
         finishedAt: new Date().toLocaleString(),
         log: interpretationInfo.log.join('\n'),
         binaryOutput: uploadedBinaryOutput,
+        serializableOutput: {
+          ...(finalRun?.serializableOutput || {}),
+          crawl: categorizedOutput.crawl,
+          search: categorizedOutput.search,
+        }
       });
 
       let totalSchemaItemsExtracted = 0;
@@ -650,7 +647,9 @@ async function processRunExecution(job: Job<ExecuteRunData>) {
       try {
         const hasData = (run.serializableOutput && 
           ((run.serializableOutput.scrapeSchema && run.serializableOutput.scrapeSchema.length > 0) ||
-           (run.serializableOutput.scrapeList && run.serializableOutput.scrapeList.length > 0))) ||
+           (run.serializableOutput.scrapeList && run.serializableOutput.scrapeList.length > 0) ||
+           (run.serializableOutput.crawl && Object.keys(run.serializableOutput.crawl).length > 0) ||
+           (run.serializableOutput.search && Object.keys(run.serializableOutput.search).length > 0))) ||
           (run.binaryOutput && Object.keys(run.binaryOutput).length > 0);
 
         if (hasData) {

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -277,10 +277,10 @@ function handleWorkflowActions(workflow: any[], credentials: Credentials) {
 router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, res) => {
   try {
     const { id } = req.params;
-    const { name, limits, credentials, targetUrl, workflow: incomingWorkflow } = req.body;
+    const { name, limits, credentials, targetUrl, workflow: incomingWorkflow, formats } = req.body;
 
-    if (!name && !limits && !credentials && !targetUrl && !incomingWorkflow) {
-      return res.status(400).json({ error: 'Either "name", "limits", "credentials" or "target_url" must be provided.' });
+    if (!name && !limits && !credentials && !targetUrl && !incomingWorkflow && formats === undefined) {
+      return res.status(400).json({ error: 'Either "name", "limits", "credentials", "target_url", "workflow" or "formats" must be provided.' });
     }
 
     const robot = await Robot.findOne({ where: { 'recording_meta.id': id } });
@@ -364,6 +364,35 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
       }
     }
 
+    let normalizedFormats: OutputFormat[] | undefined;
+    if (formats !== undefined) {
+      const allowedFormats = robot.recording_meta?.type === 'scrape' ? SCRAPE_OUTPUT_FORMAT_OPTIONS : undefined;
+      const { validFormats, invalidFormats } = parseOutputFormats(formats, allowedFormats);
+
+      if (invalidFormats.length > 0) {
+        return res.status(400).json({
+          error: `Invalid formats: ${invalidFormats.map(String).join(', ')}`,
+        });
+      }
+
+      if (robot.recording_meta?.type === 'crawl' || robot.recording_meta?.type === 'scrape') {
+        normalizedFormats = validFormats.length > 0 ? validFormats : [...DEFAULT_OUTPUT_FORMATS];
+      } else if (robot.recording_meta?.type === 'search') {
+        const searchAction = workflow
+          .flatMap((pair: any) => pair.what || [])
+          .find((action: any) => action?.action === 'search');
+        const searchMode = searchAction?.args?.[0]?.mode;
+
+        if (searchMode === 'discover') {
+          normalizedFormats = validFormats.length > 0 ? validFormats : [];
+        } else {
+          normalizedFormats = validFormats.length > 0 ? validFormats : [...DEFAULT_OUTPUT_FORMATS];
+        }
+      } else {
+        normalizedFormats = validFormats;
+      }
+    }
+
     let trimmedName: string | undefined;
     if (name !== undefined) {
       if (typeof name !== 'string') {
@@ -384,6 +413,7 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
     let updatedMeta = { ...robot.recording_meta };
     if (trimmedName) updatedMeta.name = trimmedName;
     if (targetUrl) updatedMeta.url = targetUrl;
+    if (normalizedFormats !== undefined) updatedMeta.formats = normalizedFormats;
 
     const updates: any = {
       recording: { ...robot.recording, workflow },
@@ -434,10 +464,6 @@ router.post('/recordings/scrape', requireSignIn, async (req: AuthenticatedReques
       return res.status(400).json({ error: 'Invalid URL format' });
     }
 
-    if (!Array.isArray(formats) || formats.length === 0) {
-      return res.status(400).json({ error: 'At least one output format must be selected.' });
-    }
-
     const { validFormats: scrapeFormats, invalidFormats } = parseOutputFormats(
       formats,
       SCRAPE_OUTPUT_FORMAT_OPTIONS
@@ -456,6 +482,10 @@ router.post('/recordings/scrape', requireSignIn, async (req: AuthenticatedReques
 
     if (await isRobotNameTaken(robotName, req.user.id)) {
       return res.status(409).json({ error: `A robot with the name "${robotName}" already exists.` });
+    }
+
+    if (scrapeFormats.length === 0 && formats !== undefined) {
+      return res.status(400).json({ error: 'At least one output format must be selected.' });
     }
 
     const currentTimestamp = new Date().toLocaleString();
@@ -1498,6 +1528,7 @@ router.post('/recordings/crawl', requireSignIn, async (req: AuthenticatedRequest
       });
     }
 
+    // Crawl always needs formats; use defaults even if explicit empty array is provided
     const crawlFormats: OutputFormat[] = requestedFormats.length > 0
       ? requestedFormats
       : [...DEFAULT_OUTPUT_FORMATS];
@@ -1627,11 +1658,11 @@ router.post('/recordings/search', requireSignIn, async (req: AuthenticatedReques
 
     let searchFormats: OutputFormat[];
     if (searchConfig.mode === 'discover') {
-      searchFormats = [];
+      // Discover-mode: preserve empty array if explicitly provided
+      searchFormats = requestedFormats.length > 0 ? requestedFormats : [];
     } else {
-      searchFormats = requestedFormats.length > 0
-        ? requestedFormats
-        : [...DEFAULT_OUTPUT_FORMATS];
+      // Scrape-mode: apply defaults if empty
+      searchFormats = requestedFormats.length > 0 ? requestedFormats : [...DEFAULT_OUTPUT_FORMATS];
     }
 
     const currentTimestamp = new Date().toLocaleString('en-US');

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -365,8 +365,23 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
     }
 
     let normalizedFormats: OutputFormat[] | undefined;
-    if (formats !== undefined) {
-      const allowedFormats = robot.recording_meta?.type === 'scrape' ? SCRAPE_OUTPUT_FORMAT_OPTIONS : undefined;
+    
+    let searchMode: string | undefined;
+    if (robot.recording_meta?.type === 'search') {
+      const searchAction = workflow
+        .flatMap((pair: any) => pair.what || [])
+        .find((action: any) => action?.action === 'search');
+      searchMode = searchAction?.args?.[0]?.mode;
+    }
+
+    if (formats !== undefined || (robot.recording_meta?.type === 'search' && searchMode === 'discover')) {
+      let allowedFormats: readonly OutputFormat[] | undefined;
+      if (robot.recording_meta?.type === 'scrape') {
+        allowedFormats = SCRAPE_OUTPUT_FORMAT_OPTIONS;
+      } else if (robot.recording_meta?.type === 'search' && searchMode === 'scrape') {
+        allowedFormats = SCRAPE_OUTPUT_FORMAT_OPTIONS;
+      }
+
       const { validFormats, invalidFormats } = parseOutputFormats(formats, allowedFormats);
 
       if (invalidFormats.length > 0) {
@@ -375,16 +390,13 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
         });
       }
 
-      if (robot.recording_meta?.type === 'crawl' || robot.recording_meta?.type === 'scrape') {
+      if (robot.recording_meta?.type === 'crawl') {
+        normalizedFormats = validFormats.length > 0 ? validFormats : [...DEFAULT_OUTPUT_FORMATS];
+      } else if (robot.recording_meta?.type === 'scrape') {
         normalizedFormats = validFormats.length > 0 ? validFormats : [...DEFAULT_OUTPUT_FORMATS];
       } else if (robot.recording_meta?.type === 'search') {
-        const searchAction = workflow
-          .flatMap((pair: any) => pair.what || [])
-          .find((action: any) => action?.action === 'search');
-        const searchMode = searchAction?.args?.[0]?.mode;
-
         if (searchMode === 'discover') {
-          normalizedFormats = validFormats.length > 0 ? validFormats : [];
+          normalizedFormats = [];
         } else {
           normalizedFormats = validFormats.length > 0 ? validFormats : [...DEFAULT_OUTPUT_FORMATS];
         }
@@ -475,6 +487,8 @@ router.post('/recordings/scrape', requireSignIn, async (req: AuthenticatedReques
       });
     }
 
+    const finalFormats = scrapeFormats.length > 0 ? scrapeFormats : DEFAULT_OUTPUT_FORMATS;
+
     const robotName = (typeof name === 'string' ? name.trim() : '') || `Markdown Robot - ${new URL(url).hostname}`;
     if (!robotName) {
       return res.status(400).json({ error: 'Robot name cannot be empty.' });
@@ -503,7 +517,7 @@ router.post('/recordings/scrape', requireSignIn, async (req: AuthenticatedReques
         params: [],
         type: 'scrape',
         url: url,
-        formats: scrapeFormats,
+        formats: finalFormats,
       },
       recording: { workflow: [] },
       google_sheet_email: null,
@@ -1649,7 +1663,10 @@ router.post('/recordings/search', requireSignIn, async (req: AuthenticatedReques
       return res.status(409).json({ error: `A robot with the name "${robotName}" already exists.` });
     }
 
-    const { validFormats: requestedFormats, invalidFormats } = parseOutputFormats(formats);
+    const { validFormats: requestedFormats, invalidFormats } = parseOutputFormats(
+      formats,
+      searchConfig.mode === 'scrape' ? SCRAPE_OUTPUT_FORMAT_OPTIONS : undefined
+    );
     if (invalidFormats.length > 0) {
       return res.status(400).json({
         error: `Invalid formats: ${invalidFormats.map(String).join(', ')}`,
@@ -1658,8 +1675,8 @@ router.post('/recordings/search', requireSignIn, async (req: AuthenticatedReques
 
     let searchFormats: OutputFormat[];
     if (searchConfig.mode === 'discover') {
-      // Discover-mode: preserve empty array if explicitly provided
-      searchFormats = requestedFormats.length > 0 ? requestedFormats : [];
+      // Discover-mode: always empty, ignore caller input
+      searchFormats = [];
     } else {
       // Scrape-mode: apply defaults if empty
       searchFormats = requestedFormats.length > 0 ? requestedFormats : [...DEFAULT_OUTPUT_FORMATS];

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -18,6 +18,12 @@ import { pgBossClient } from '../storage/pgboss';
 import { WorkflowEnricher } from '../sdk/workflowEnricher';
 import sequelizeInstance from '../storage/db';
 import { Op } from 'sequelize';
+import {
+  DEFAULT_OUTPUT_FORMATS,
+  parseOutputFormats,
+  SCRAPE_OUTPUT_FORMAT_OPTIONS,
+  OutputFormat,
+} from '../constants/output-formats';
 
 export const router = Router();
 
@@ -428,16 +434,19 @@ router.post('/recordings/scrape', requireSignIn, async (req: AuthenticatedReques
       return res.status(400).json({ error: 'Invalid URL format' });
     }
 
-    // Validate format
-    const validFormats = ['markdown', 'html', 'screenshot-visible', 'screenshot-fullpage'];
-
     if (!Array.isArray(formats) || formats.length === 0) {
       return res.status(400).json({ error: 'At least one output format must be selected.' });
     }
 
-    const invalid = formats.filter(f => !validFormats.includes(f));
-    if (invalid.length > 0) {
-      return res.status(400).json({ error: `Invalid formats: ${invalid.join(', ')}` });
+    const { validFormats: scrapeFormats, invalidFormats } = parseOutputFormats(
+      formats,
+      SCRAPE_OUTPUT_FORMAT_OPTIONS
+    );
+
+    if (invalidFormats.length > 0) {
+      return res.status(400).json({
+        error: `Invalid formats: ${invalidFormats.map(String).join(', ')}`,
+      });
     }
 
     const robotName = (typeof name === 'string' ? name.trim() : '') || `Markdown Robot - ${new URL(url).hostname}`;
@@ -464,7 +473,7 @@ router.post('/recordings/scrape', requireSignIn, async (req: AuthenticatedReques
         params: [],
         type: 'scrape',
         url: url,
-        formats: formats,
+        formats: scrapeFormats,
       },
       recording: { workflow: [] },
       google_sheet_email: null,
@@ -1457,7 +1466,7 @@ export async function recoverOrphanedRuns() {
  */
 router.post('/recordings/crawl', requireSignIn, async (req: AuthenticatedRequest, res) => {
   try {
-    const { url, name, crawlConfig } = req.body;
+    const { url, name, crawlConfig, formats } = req.body;
 
     if (!url || !crawlConfig) {
       return res.status(400).json({ error: 'URL and crawl configuration are required.' });
@@ -1482,6 +1491,17 @@ router.post('/recordings/crawl', requireSignIn, async (req: AuthenticatedRequest
       return res.status(409).json({ error: `A robot with the name "${robotName}" already exists.` });
     }
 
+    const { validFormats: requestedFormats, invalidFormats } = parseOutputFormats(formats);
+    if (invalidFormats.length > 0) {
+      return res.status(400).json({
+        error: `Invalid formats: ${invalidFormats.map(String).join(', ')}`,
+      });
+    }
+
+    const crawlFormats: OutputFormat[] = requestedFormats.length > 0
+      ? requestedFormats
+      : [...DEFAULT_OUTPUT_FORMATS];
+
     const currentTimestamp = new Date().toLocaleString('en-US');
     const robotId = uuid();
 
@@ -1497,6 +1517,7 @@ router.post('/recordings/crawl', requireSignIn, async (req: AuthenticatedRequest
         params: [],
         type: 'crawl',
         url: url,
+        formats: crawlFormats,
       },
       recording: {
         workflow: [
@@ -1578,7 +1599,7 @@ router.post('/recordings/crawl', requireSignIn, async (req: AuthenticatedRequest
  */
 router.post('/recordings/search', requireSignIn, async (req: AuthenticatedRequest, res) => {
   try {
-    const { searchConfig, name } = req.body;
+    const { searchConfig, name, formats } = req.body;
 
     if (!searchConfig || !searchConfig.query) {
       return res.status(400).json({ error: 'Search configuration with query is required.' });
@@ -1597,6 +1618,22 @@ router.post('/recordings/search', requireSignIn, async (req: AuthenticatedReques
       return res.status(409).json({ error: `A robot with the name "${robotName}" already exists.` });
     }
 
+    const { validFormats: requestedFormats, invalidFormats } = parseOutputFormats(formats);
+    if (invalidFormats.length > 0) {
+      return res.status(400).json({
+        error: `Invalid formats: ${invalidFormats.map(String).join(', ')}`,
+      });
+    }
+
+    let searchFormats: OutputFormat[];
+    if (searchConfig.mode === 'discover') {
+      searchFormats = [];
+    } else {
+      searchFormats = requestedFormats.length > 0
+        ? requestedFormats
+        : [...DEFAULT_OUTPUT_FORMATS];
+    }
+
     const currentTimestamp = new Date().toLocaleString('en-US');
     const robotId = uuid();
 
@@ -1611,6 +1648,7 @@ router.post('/recordings/search', requireSignIn, async (req: AuthenticatedReques
         pairs: 1,
         params: [],
         type: 'search',
+        formats: searchFormats,
       },
       recording: {
         workflow: [

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -21,6 +21,7 @@ import { Op } from 'sequelize';
 import {
   DEFAULT_OUTPUT_FORMATS,
   parseOutputFormats,
+  SEARCH_SCRAPE_OUTPUT_FORMAT_OPTIONS,
   SCRAPE_OUTPUT_FORMAT_OPTIONS,
   OutputFormat,
 } from '../constants/output-formats';
@@ -379,7 +380,7 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
       if (robot.recording_meta?.type === 'scrape') {
         allowedFormats = SCRAPE_OUTPUT_FORMAT_OPTIONS;
       } else if (robot.recording_meta?.type === 'search' && searchMode === 'scrape') {
-        allowedFormats = SCRAPE_OUTPUT_FORMAT_OPTIONS;
+        allowedFormats = SEARCH_SCRAPE_OUTPUT_FORMAT_OPTIONS;
       }
 
       const { validFormats, invalidFormats } = parseOutputFormats(formats, allowedFormats);
@@ -1665,7 +1666,7 @@ router.post('/recordings/search', requireSignIn, async (req: AuthenticatedReques
 
     const { validFormats: requestedFormats, invalidFormats } = parseOutputFormats(
       formats,
-      searchConfig.mode === 'scrape' ? SCRAPE_OUTPUT_FORMAT_OPTIONS : undefined
+      searchConfig.mode === 'scrape' ? SEARCH_SCRAPE_OUTPUT_FORMAT_OPTIONS : undefined
     );
     if (invalidFormats.length > 0) {
       return res.status(400).json({

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -24,11 +24,15 @@ import { startWorkers } from './pgboss-worker';
 import { stopPgBossClient, startPgBossClient } from './storage/pgboss'
 import Run from './models/Run';
 
-const app = express();
-app.use(cors({
-  origin: process.env.PUBLIC_URL ? process.env.PUBLIC_URL : 'http://localhost:5173',
+const CORS_CONFIG = {
+  origin: process.env.PUBLIC_URL || 'http://localhost:5173',
   credentials: true,
-}));
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+};
+
+const app = express();
+app.use(cors(CORS_CONFIG));
 app.use(express.json());
 
 const { Pool } = pg;
@@ -91,11 +95,7 @@ export let io = new Server(server, {
   maxHttpBufferSize: 1e8,
   transports: ['websocket', 'polling'],
   allowEIO3: true,
-  cors: {
-    origin: process.env.PUBLIC_URL ? process.env.PUBLIC_URL : 'http://localhost:5173',
-    credentials: true,
-    methods: ['GET', 'POST']
-  }
+  cors: CORS_CONFIG
 });
 
 /**
@@ -139,17 +139,6 @@ app.get('/', function (req, res) {
   }
   );
   return res.send('Maxun server started 🚀');
-});
-
-app.use((req, res, next) => {
-  res.header('Access-Control-Allow-Origin', process.env.PUBLIC_URL || 'http://localhost:5173');
-  res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
-  res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-  res.header('Access-Control-Allow-Credentials', 'true');
-  if (req.method === 'OPTIONS') {
-    return res.sendStatus(200);
-  }
-  next();
 });
 
 if (require.main === module) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -24,8 +24,18 @@ import { startWorkers } from './pgboss-worker';
 import { stopPgBossClient, startPgBossClient } from './storage/pgboss'
 import Run from './models/Run';
 
+const normalizeOrigin = (urlString?: string): string => {
+  if (!urlString) return 'http://localhost:5173';
+  try {
+    const url = new URL(urlString);
+    return `${url.protocol}//${url.host}`;
+  } catch {
+    return 'http://localhost:5173';
+  }
+};
+
 const CORS_CONFIG = {
-  origin: process.env.PUBLIC_URL || 'http://localhost:5173',
+  origin: normalizeOrigin(process.env.PUBLIC_URL),
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization'],
@@ -94,7 +104,6 @@ export let io = new Server(server, {
   pingInterval: 25000,
   maxHttpBufferSize: 1e8,
   transports: ['websocket', 'polling'],
-  allowEIO3: true,
   cors: CORS_CONFIG
 });
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -90,7 +90,12 @@ export let io = new Server(server, {
   pingInterval: 25000,
   maxHttpBufferSize: 1e8,
   transports: ['websocket', 'polling'],
-  allowEIO3: true
+  allowEIO3: true,
+  cors: {
+    origin: process.env.PUBLIC_URL ? process.env.PUBLIC_URL : 'http://localhost:5173',
+    credentials: true,
+    methods: ['GET', 'POST']
+  }
 });
 
 /**

--- a/server/src/utils/output-post-processor.ts
+++ b/server/src/utils/output-post-processor.ts
@@ -1,0 +1,181 @@
+import { Page } from 'playwright-core';
+import logger from '../logger';
+import { parseMarkdown } from '../markdownify/markdown';
+import { convertPageToScreenshot } from '../markdownify/scrape';
+import { DEFAULT_OUTPUT_FORMATS } from '../constants/output-formats';
+
+interface CategorizedOutput {
+  crawl: Record<string, any>;
+  search: Record<string, any>;
+}
+
+interface ProcessRobotOutputParams {
+  robotType: string | undefined;
+  outputFormats?: string[];
+  categorizedOutput: CategorizedOutput;
+  currentPage: Page;
+  initialBinaryOutput?: Record<string, any>;
+}
+
+interface ProcessRobotOutputResult {
+  categorizedOutput: CategorizedOutput;
+  binaryOutput: Record<string, any>;
+}
+
+export async function processRobotOutputFormats(
+  params: ProcessRobotOutputParams
+): Promise<ProcessRobotOutputResult> {
+  const {
+    robotType,
+    outputFormats,
+    categorizedOutput,
+    currentPage,
+    initialBinaryOutput,
+  } = params;
+
+  const binaryOutput: Record<string, any> = {
+    ...(initialBinaryOutput || {}),
+  };
+
+  const effectiveFormats = outputFormats && outputFormats.length > 0
+    ? outputFormats
+    : DEFAULT_OUTPUT_FORMATS;
+
+  if (robotType !== 'crawl' && robotType !== 'search') {
+    return { categorizedOutput, binaryOutput };
+  }
+
+  if (robotType === 'crawl' && Array.isArray((categorizedOutput.crawl as any)?.['Crawl Results'])) {
+    const crawlResults: any[] = (categorizedOutput.crawl as any)['Crawl Results'];
+    const includeVisibleScreenshot = effectiveFormats.includes('screenshot-visible');
+    const includeFullpageScreenshot = effectiveFormats.includes('screenshot-fullpage');
+
+    for (let pageIndex = 0; pageIndex < crawlResults.length; pageIndex++) {
+      const pageResult = crawlResults[pageIndex];
+      if (!pageResult.error) {
+        if (effectiveFormats.includes('markdown') && pageResult.html) {
+          try {
+            pageResult.markdown = await parseMarkdown(pageResult.html, pageResult.metadata?.url);
+          } catch (e: any) {
+            logger.log('warn', `Failed to convert crawl page to markdown: ${e.message}`);
+          }
+        }
+
+        if (!effectiveFormats.includes('html')) delete pageResult.html;
+        if (!effectiveFormats.includes('text')) delete pageResult.text;
+
+        const pageUrl = pageResult.metadata?.url || pageResult.url;
+        const hasPageUrl = typeof pageUrl === 'string' && pageUrl.trim() !== '';
+
+        if (!includeVisibleScreenshot) {
+          delete pageResult.screenshotVisible;
+        }
+
+        if (!includeFullpageScreenshot) {
+          delete pageResult.screenshotFullpage;
+        }
+
+        if ((includeVisibleScreenshot || includeFullpageScreenshot) && hasPageUrl) {
+          if (includeVisibleScreenshot) {
+            try {
+              const screenshotBuffer = await convertPageToScreenshot(pageUrl, currentPage, false);
+              const screenshotKey = `crawl-${pageIndex + 1}-screenshot-visible`;
+              binaryOutput[screenshotKey] = {
+                data: screenshotBuffer.toString('base64'),
+                mimeType: 'image/png',
+              };
+              pageResult.screenshotVisible = screenshotKey;
+            } catch (e: any) {
+              logger.log('warn', `Failed to capture visible crawl screenshot for ${pageUrl}: ${e.message}`);
+            }
+          }
+
+          if (includeFullpageScreenshot) {
+            try {
+              const screenshotBuffer = await convertPageToScreenshot(pageUrl, currentPage, true);
+              const screenshotKey = `crawl-${pageIndex + 1}-screenshot-fullpage`;
+              binaryOutput[screenshotKey] = {
+                data: screenshotBuffer.toString('base64'),
+                mimeType: 'image/png',
+              };
+              pageResult.screenshotFullpage = screenshotKey;
+            } catch (e: any) {
+              logger.log('warn', `Failed to capture fullpage crawl screenshot for ${pageUrl}: ${e.message}`);
+            }
+          }
+        } else if (includeVisibleScreenshot || includeFullpageScreenshot) {
+          logger.log('warn', `Skipping crawl screenshot capture for page index ${pageIndex} because URL is missing`);
+        }
+      }
+    }
+  }
+
+  if (robotType === 'search') {
+    const searchResultGroup = (categorizedOutput.search as any)?.['Search Results'];
+    if ((searchResultGroup?.mode === 'scrape' || !searchResultGroup?.mode) && Array.isArray(searchResultGroup?.results)) {
+      const includeVisibleScreenshot = effectiveFormats.includes('screenshot-visible');
+      const includeFullpageScreenshot = effectiveFormats.includes('screenshot-fullpage');
+
+      for (let resultIndex = 0; resultIndex < searchResultGroup.results.length; resultIndex++) {
+        const result = searchResultGroup.results[resultIndex];
+        if (!result.error) {
+          if (effectiveFormats.includes('markdown') && result.html) {
+            try {
+              result.markdown = await parseMarkdown(result.html, result.metadata?.url);
+            } catch (e: any) {
+              logger.log('warn', `Failed to convert search result to markdown: ${e.message}`);
+            }
+          }
+
+          if (!effectiveFormats.includes('html')) delete result.html;
+          if (!effectiveFormats.includes('text')) delete result.text;
+
+          const resultUrl = result.metadata?.url || result.url;
+          const hasResultUrl = typeof resultUrl === 'string' && resultUrl.trim() !== '';
+
+          if (!includeVisibleScreenshot) {
+            delete result.screenshotVisible;
+          }
+
+          if (!includeFullpageScreenshot) {
+            delete result.screenshotFullpage;
+          }
+
+          if ((includeVisibleScreenshot || includeFullpageScreenshot) && hasResultUrl) {
+            if (includeVisibleScreenshot) {
+              try {
+                const screenshotBuffer = await convertPageToScreenshot(resultUrl, currentPage, false);
+                const screenshotKey = `search-${resultIndex + 1}-screenshot-visible`;
+                binaryOutput[screenshotKey] = {
+                  data: screenshotBuffer.toString('base64'),
+                  mimeType: 'image/png',
+                };
+                result.screenshotVisible = screenshotKey;
+              } catch (e: any) {
+                logger.log('warn', `Failed to capture visible search screenshot for ${resultUrl}: ${e.message}`);
+              }
+            }
+
+            if (includeFullpageScreenshot) {
+              try {
+                const screenshotBuffer = await convertPageToScreenshot(resultUrl, currentPage, true);
+                const screenshotKey = `search-${resultIndex + 1}-screenshot-fullpage`;
+                binaryOutput[screenshotKey] = {
+                  data: screenshotBuffer.toString('base64'),
+                  mimeType: 'image/png',
+                };
+                result.screenshotFullpage = screenshotKey;
+              } catch (e: any) {
+                logger.log('warn', `Failed to capture fullpage search screenshot for ${resultUrl}: ${e.message}`);
+              }
+            }
+          } else if (includeVisibleScreenshot || includeFullpageScreenshot) {
+            logger.log('warn', `Skipping search screenshot capture for result index ${resultIndex} because URL is missing`);
+          }
+        }
+      }
+    }
+  }
+
+  return { categorizedOutput, binaryOutput };
+}

--- a/server/src/utils/output-post-processor.ts
+++ b/server/src/utils/output-post-processor.ts
@@ -37,8 +37,12 @@ export async function processRobotOutputFormats(
     ...(initialBinaryOutput || {}),
   };
 
-  const effectiveFormats = outputFormats && outputFormats.length > 0
-    ? outputFormats
+  const effectiveFormats = Array.isArray(outputFormats)
+    ? (outputFormats.length > 0
+      ? outputFormats
+      : robotType === 'crawl'
+        ? DEFAULT_OUTPUT_FORMATS
+        : outputFormats) 
     : DEFAULT_OUTPUT_FORMATS;
 
   if (robotType !== 'crawl' && robotType !== 'search') {

--- a/server/src/utils/output-post-processor.ts
+++ b/server/src/utils/output-post-processor.ts
@@ -57,15 +57,19 @@ export async function processRobotOutputFormats(
     for (let pageIndex = 0; pageIndex < crawlResults.length; pageIndex++) {
       const pageResult = crawlResults[pageIndex];
       if (!pageResult.error) {
+        let markdownConversionSucceeded = false;
         if (effectiveFormats.includes('markdown') && pageResult.html) {
           try {
             pageResult.markdown = await parseMarkdown(pageResult.html, pageResult.metadata?.url);
+            markdownConversionSucceeded = true;
           } catch (e: any) {
             logger.log('warn', `Failed to convert crawl page to markdown: ${e.message}`);
           }
         }
 
-        if (!effectiveFormats.includes('html')) delete pageResult.html;
+        if (!effectiveFormats.includes('html') && markdownConversionSucceeded) {
+          delete pageResult.html;
+        }
         if (!effectiveFormats.includes('text')) delete pageResult.text;
 
         const pageUrl = pageResult.metadata?.url || pageResult.url;
@@ -116,22 +120,26 @@ export async function processRobotOutputFormats(
 
   if (robotType === 'search') {
     const searchResultGroup = (categorizedOutput.search as any)?.['Search Results'];
-    if ((searchResultGroup?.mode === 'scrape' || !searchResultGroup?.mode) && Array.isArray(searchResultGroup?.results)) {
+    if (searchResultGroup?.mode === 'scrape' && Array.isArray(searchResultGroup?.results)) {
       const includeVisibleScreenshot = effectiveFormats.includes('screenshot-visible');
       const includeFullpageScreenshot = effectiveFormats.includes('screenshot-fullpage');
 
       for (let resultIndex = 0; resultIndex < searchResultGroup.results.length; resultIndex++) {
         const result = searchResultGroup.results[resultIndex];
         if (!result.error) {
+          let markdownConversionSucceeded = false;
           if (effectiveFormats.includes('markdown') && result.html) {
             try {
               result.markdown = await parseMarkdown(result.html, result.metadata?.url);
+              markdownConversionSucceeded = true;
             } catch (e: any) {
               logger.log('warn', `Failed to convert search result to markdown: ${e.message}`);
             }
           }
 
-          if (!effectiveFormats.includes('html')) delete result.html;
+          if (!effectiveFormats.includes('html') && markdownConversionSucceeded) {
+            delete result.html;
+          }
           if (!effectiveFormats.includes('text')) delete result.text;
 
           const resultUrl = result.metadata?.url || result.url;

--- a/server/src/utils/output-validation.ts
+++ b/server/src/utils/output-validation.ts
@@ -26,14 +26,68 @@ export function hasExpectedRobotOutput(
   categorizedOutput: {
     crawl?: Record<string, any>;
     search?: Record<string, any>;
-  }
+  },
+  selectedFormats?: string[],
+  binaryOutput?: Record<string, any>
 ): boolean {
+  const formatToFieldMap: Record<string, string> = {
+    'markdown': 'markdown',
+    'html': 'html',
+    'text': 'text',
+    'screenshot-visible': 'screenshotVisible',
+    'screenshot-fullpage': 'screenshotFullpage',
+  };
+
+  let requestedFields = new Set<string>();
+  if (selectedFormats && selectedFormats.length > 0) {
+    selectedFormats.forEach(format => {
+      const field = formatToFieldMap[format];
+      if (field) requestedFields.add(field);
+    });
+  }
+
+  if (binaryOutput && Object.keys(binaryOutput).length > 0) {
+    requestedFields.add('binary');
+  }
+
+  if (requestedFields.size === 0) {
+    if (robotType === 'search') {
+      return Array.isArray((categorizedOutput.search as any)?.['Search Results']?.results) &&
+             (categorizedOutput.search as any)?.['Search Results']?.results.length > 0;
+    }
+    if (robotType === 'crawl') {
+      return Array.isArray((categorizedOutput.crawl as any)?.['Crawl Results']) &&
+             (categorizedOutput.crawl as any)?.['Crawl Results'].length > 0;
+    }
+    return true;
+  }
+
   if (robotType === 'search') {
-    return Array.isArray((categorizedOutput.search as any)?.['Search Results']?.results);
+    const results = (categorizedOutput.search as any)?.['Search Results']?.results;
+    if (!Array.isArray(results) || results.length === 0) return false;
+
+    return results.some((result: any) => {
+      if (result.error) return false;
+      for (const field of requestedFields) {
+        if (field === 'binary') continue;
+        if (result[field]) return true;
+      }
+      return requestedFields.has('binary');
+    });
   }
 
   if (robotType === 'crawl') {
-    return Array.isArray((categorizedOutput.crawl as any)?.['Crawl Results']);
+    const results = (categorizedOutput.crawl as any)?.['Crawl Results'];
+    if (!Array.isArray(results) || results.length === 0) return false;
+
+    return results.some((result: any) => {
+      if (result.error) return false;
+      for (const field of requestedFields) {
+        if (field === 'binary') continue;
+        if (result[field]) return true;
+      }
+      return requestedFields.has('binary');
+    });
   }
 
   return true;

--- a/server/src/utils/output-validation.ts
+++ b/server/src/utils/output-validation.ts
@@ -1,0 +1,40 @@
+const SEARCH_OR_CRAWL_ERROR_MARKERS = [
+  'Search execution error:',
+  'Search action failed:',
+  'Crawl execution error:',
+  'Crawl action failed:',
+];
+
+export function getInterpretationFailureReason(logLines: unknown, fallbackMessage: string): string {
+  if (!Array.isArray(logLines)) {
+    return fallbackMessage;
+  }
+
+  const matchedLine = logLines.find(
+    (line) =>
+      typeof line === 'string' &&
+      SEARCH_OR_CRAWL_ERROR_MARKERS.some((marker) => line.includes(marker))
+  );
+
+  return typeof matchedLine === 'string' && matchedLine.trim().length > 0
+    ? matchedLine.trim()
+    : fallbackMessage;
+}
+
+export function hasExpectedRobotOutput(
+  robotType: string,
+  categorizedOutput: {
+    crawl?: Record<string, any>;
+    search?: Record<string, any>;
+  }
+): boolean {
+  if (robotType === 'search') {
+    return Array.isArray((categorizedOutput.search as any)?.['Search Results']?.results);
+  }
+
+  if (robotType === 'crawl') {
+    return Array.isArray((categorizedOutput.crawl as any)?.['Crawl Results']);
+  }
+
+  return true;
+}

--- a/server/src/workflow-management/scheduler/index.ts
+++ b/server/src/workflow-management/scheduler/index.ts
@@ -14,6 +14,8 @@ import { Page } from "playwright-core";
 import { sendWebhook } from "../../routes/webhook";
 import { addAirtableUpdateTask, airtableUpdateTasks, processAirtableUpdates } from "../integrations/airtable";
 import { convertPageToMarkdown, convertPageToHTML, convertPageToScreenshot } from "../../markdownify/scrape";
+import { processRobotOutputFormats } from "../../utils/output-post-processor";
+import { getInterpretationFailureReason, hasExpectedRobotOutput } from "../../utils/output-validation";
 
 async function createWorkflowAndStoreMetadata(id: string, userId: string) {
   try {
@@ -479,9 +481,6 @@ async function executeRun(id: string, userId: string) {
 
     const interpretationInfo = await Promise.race([interpretationPromise, timeoutPromise]);
 
-    const binaryOutputService = new BinaryOutputService('maxun-run-screenshots');
-    const uploadedBinaryOutput = await binaryOutputService.uploadAndStoreBinaryOutput(run, interpretationInfo.binaryOutput);
-
     const finalRun = await Run.findByPk(run.id);
     const categorizedOutput = {
       scrapeSchema: finalRun?.serializableOutput?.scrapeSchema || {},
@@ -489,6 +488,54 @@ async function executeRun(id: string, userId: string) {
       crawl: finalRun?.serializableOutput?.crawl || {},
       search: finalRun?.serializableOutput?.search || {}
     };
+
+    let binaryOutput: Record<string, any> = {
+      ...(interpretationInfo.binaryOutput || {})
+    };
+
+    const robotType = recording.recording_meta.type;
+    const outputFormats = (recording.recording_meta as any).formats as string[] | undefined;
+
+    if (robotType === 'crawl' || robotType === 'search') {
+      const processedOutput = await processRobotOutputFormats({
+        robotType,
+        outputFormats,
+        categorizedOutput: {
+          crawl: categorizedOutput.crawl as Record<string, any>,
+          search: categorizedOutput.search as Record<string, any>,
+        },
+        currentPage,
+        initialBinaryOutput: binaryOutput,
+      });
+
+      categorizedOutput.crawl = processedOutput.categorizedOutput.crawl;
+      categorizedOutput.search = processedOutput.categorizedOutput.search;
+      binaryOutput = processedOutput.binaryOutput;
+
+      await run.update({
+        serializableOutput: {
+          ...(finalRun?.serializableOutput || {}),
+          crawl: categorizedOutput.crawl,
+          search: categorizedOutput.search,
+        }
+      });
+
+      const hasOutput = hasExpectedRobotOutput(robotType, {
+        crawl: categorizedOutput.crawl as Record<string, any>,
+        search: categorizedOutput.search as Record<string, any>
+      });
+
+      if (!hasOutput) {
+        const humanRobotType = robotType.charAt(0).toUpperCase() + robotType.slice(1);
+        const fallbackReason = `${humanRobotType} run completed without producing output data`;
+        throw new Error(getInterpretationFailureReason(interpretationInfo.log, fallbackReason));
+      }
+    }
+
+    const binaryOutputService = new BinaryOutputService('maxun-run-screenshots');
+    const uploadedBinaryOutput = Object.keys(binaryOutput).length > 0
+      ? await binaryOutputService.uploadAndStoreBinaryOutput(run, binaryOutput)
+      : {};
 
     await destroyRemoteBrowser(plainRun.browserId, userId);
 
@@ -502,7 +549,7 @@ async function executeRun(id: string, userId: string) {
     // Get metrics from persisted data for analytics and webhooks
     let totalSchemaItemsExtracted = 0;
     let totalListItemsExtracted = 0;
-    let extractedScreenshotsCount = 0;
+    let extractedScreenshotsCount = Object.keys(uploadedBinaryOutput).length;
     
     if (categorizedOutput) {
       if (categorizedOutput.scrapeSchema) {
@@ -524,10 +571,6 @@ async function executeRun(id: string, userId: string) {
       }
     }
 
-    if (run.binaryOutput) {
-      extractedScreenshotsCount = Object.keys(run.binaryOutput).length;
-    }
-    
     const totalRowsExtracted = totalSchemaItemsExtracted + totalListItemsExtracted;
 
     capture(

--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -363,7 +363,8 @@ export const createCrawlRobot = async (
     useSitemap: boolean;
     followLinks: boolean;
     respectRobots: boolean;
-  }
+  },
+  formats: string[] = ['markdown']
 ): Promise<any> => {
   try {
     const response = await axios.post(
@@ -372,6 +373,7 @@ export const createCrawlRobot = async (
         url,
         name,
         crawlConfig,
+        formats,
       },
       {
         headers: { 'Content-Type': 'application/json' },
@@ -404,7 +406,8 @@ export const createSearchRobot = async (
       lang?: string;
     };
     mode: 'discover' | 'scrape';
-  }
+  },
+  formats?: string[]
 ): Promise<any> => {
   try {
     const response = await axios.post(
@@ -412,6 +415,7 @@ export const createSearchRobot = async (
       {
         name,
         searchConfig,
+        formats: formats || [],
       },
       {
         headers: { 'Content-Type': 'application/json' },

--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -107,6 +107,7 @@ export const updateRecording = async (id: string, data: {
   credentials?: Credentials; 
   targetUrl?: string;
   workflow?: any[];
+  formats?: string[];
 }): Promise<boolean> => {
   try {
     const response = await axios.put(`${apiUrl}/storage/recordings/${id}`, data);

--- a/src/components/robot/pages/RobotCreate.tsx
+++ b/src/components/robot/pages/RobotCreate.tsx
@@ -27,6 +27,7 @@ import { canCreateBrowserInState, getActiveBrowserId, stopRecording } from '../.
 import { createScrapeRobot, createLLMRobot, createAndRunRecording, createCrawlRobot, createSearchRobot } from "../../../api/storage";
 import { AuthContext } from '../../../context/auth';
 import { GenericModal } from '../../ui/GenericModal';
+import { DEFAULT_OUTPUT_FORMATS, OUTPUT_FORMAT_LABELS, OUTPUT_FORMAT_OPTIONS, OutputFormat } from '../../../constants/outputFormats';
 
 
 interface TabPanelProps {
@@ -92,6 +93,9 @@ const RobotCreate: React.FC = () => {
   const [searchProvider] = useState<'duckduckgo'>('duckduckgo');
   const [searchMode, setSearchMode] = useState<'discover' | 'scrape'>('discover');
   const [searchTimeRange, setSearchTimeRange] = useState<'day' | 'week' | 'month' | 'year' | ''>('');
+
+  const [crawlOutputFormats, setCrawlOutputFormats] = useState<OutputFormat[]>(DEFAULT_OUTPUT_FORMATS);
+  const [searchOutputFormats, setSearchOutputFormats] = useState<OutputFormat[]>(DEFAULT_OUTPUT_FORMATS);
 
   const { state } = React.useContext(AuthContext);
   const { user } = state;
@@ -187,6 +191,10 @@ const RobotCreate: React.FC = () => {
       notify('error', 'Please enter a robot name');
       return;
     }
+    if (crawlOutputFormats.length === 0) {
+      notify('error', 'Please select at least one output format');
+      return;
+    }
 
     setIsLoading(true);
     try {
@@ -202,7 +210,8 @@ const RobotCreate: React.FC = () => {
           useSitemap: crawlUseSitemap,
           followLinks: crawlFollowLinks,
           respectRobots: crawlRespectRobots
-        }
+        },
+        crawlOutputFormats
       );
       setIsLoading(false);
       if (result) {
@@ -227,6 +236,10 @@ const RobotCreate: React.FC = () => {
       notify('error', 'Please enter a robot name');
       return;
     }
+    if (searchMode === 'scrape' && searchOutputFormats.length === 0) {
+      notify('error', 'Please select at least one output format');
+      return;
+    }
 
     setIsLoading(true);
     try {
@@ -240,7 +253,8 @@ const RobotCreate: React.FC = () => {
             timeRange: searchTimeRange ? searchTimeRange as 'day' | 'week' | 'month' | 'year' : undefined
           },
           mode: searchMode
-        }
+        },
+        searchOutputFormats
       );
       setIsLoading(false);
       if (result) {
@@ -898,6 +912,33 @@ const RobotCreate: React.FC = () => {
                 />
 
                 <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-start', mb: 2 }}>
+                  <FormControl sx={{ width: '300px' }}>
+                    <InputLabel id="crawl-output-formats-label">Output Formats *</InputLabel>
+                    <Select
+                      labelId="crawl-output-formats-label"
+                      multiple
+                      value={crawlOutputFormats}
+                      label="Output Formats *"
+                      onChange={(e) => {
+                        const value = typeof e.target.value === 'string' ? e.target.value.split(',') : e.target.value;
+                        setCrawlOutputFormats(value as OutputFormat[]);
+                      }}
+                      renderValue={(selected) => {
+                        const labels = selected.map(v => OUTPUT_FORMAT_LABELS[v] ?? v);
+                        return labels.length > 2 ? `${labels.slice(0, 2).join(', ')}…` : labels.join(', ');
+                      }}
+                    >
+                      {OUTPUT_FORMAT_OPTIONS.map((format) => (
+                        <MenuItem key={format} value={format}>
+                          <Checkbox checked={crawlOutputFormats.includes(format)} />
+                          {OUTPUT_FORMAT_LABELS[format]}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                </Box>
+
+                <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-start', mb: 2 }}>
                   <Button
                   onClick={() => setShowCrawlAdvanced(!showCrawlAdvanced)}
                   sx={{
@@ -994,7 +1035,7 @@ const RobotCreate: React.FC = () => {
                 variant="contained"
                 fullWidth
                 onClick={handleCreateCrawlRobot}
-                disabled={!crawlUrl.trim() || !crawlRobotName.trim() || isLoading}
+                disabled={!crawlUrl.trim() || !crawlRobotName.trim() || crawlOutputFormats.length === 0 || isLoading}
                 sx={{
                   bgcolor: '#ff00c3',
                   py: 1.4,
@@ -1063,7 +1104,15 @@ const RobotCreate: React.FC = () => {
                   <Select
                     value={searchMode}
                     label="Mode"
-                    onChange={(e) => setSearchMode(e.target.value as any)}
+                    onChange={(e) => {
+                      const newMode = e.target.value as 'discover' | 'scrape';
+                      setSearchMode(newMode);
+                      if (newMode === 'discover') {
+                        setSearchOutputFormats([]);
+                      } else if (searchOutputFormats.length === 0) {
+                        setSearchOutputFormats(DEFAULT_OUTPUT_FORMATS);
+                      }
+                    }}
                   >
                     <MenuItem value="discover">Discover URLs Only</MenuItem>
                     <MenuItem value="scrape">Extract Data from Results</MenuItem>
@@ -1085,13 +1134,48 @@ const RobotCreate: React.FC = () => {
                   </Select>
                   </FormControl>
                 </Box>
+
+                {searchMode === 'scrape' ? (
+                  <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-start', mb: 2 }}>
+                    <FormControl sx={{ width: '300px' }}>
+                      <InputLabel id="search-output-formats-label">Output Formats *</InputLabel>
+                      <Select
+                        labelId="search-output-formats-label"
+                        multiple
+                        value={searchOutputFormats}
+                        label="Output Formats *"
+                        onChange={(e) => {
+                          const value = typeof e.target.value === 'string' ? e.target.value.split(',') : e.target.value;
+                          setSearchOutputFormats(value as OutputFormat[]);
+                        }}
+                        renderValue={(selected) => {
+                          const labels = selected.map(v => OUTPUT_FORMAT_LABELS[v] ?? v);
+                          return labels.length > 2 ? `${labels.slice(0, 2).join(', ')}…` : labels.join(', ');
+                        }}
+                      >
+                        {OUTPUT_FORMAT_OPTIONS.map((format) => (
+                          <MenuItem key={format} value={format}>
+                            <Checkbox checked={searchOutputFormats.includes(format)} />
+                            {OUTPUT_FORMAT_LABELS[format]}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </Box>
+                ) : (
+                  <Box sx={{ width: '100%', display: 'flex', justifyContent: 'flex-start', mb: 2, alignItems: 'center' }}>
+                    <Typography variant="body2" color="text.secondary">
+                      Output formats are only available in "Extract Data from Results" mode
+                    </Typography>
+                  </Box>
+                )}
               </Box>
 
               <Button
                 variant="contained"
                 fullWidth
                 onClick={handleCreateSearchRobot}
-                disabled={!searchQuery.trim() || !searchRobotName.trim() || isLoading}
+                disabled={!searchQuery.trim() || !searchRobotName.trim() || (searchMode === 'scrape' && searchOutputFormats.length === 0) || isLoading}
                 sx={{
                   bgcolor: '#ff00c3',
                   py: 1.4,

--- a/src/components/robot/pages/RobotCreate.tsx
+++ b/src/components/robot/pages/RobotCreate.tsx
@@ -243,6 +243,8 @@ const RobotCreate: React.FC = () => {
 
     setIsLoading(true);
     try {
+      const formatsForRequest = searchMode === 'discover' ? [] : searchOutputFormats;
+      
       const result = await createSearchRobot(
         searchRobotName,
         {
@@ -254,7 +256,7 @@ const RobotCreate: React.FC = () => {
           },
           mode: searchMode
         },
-        searchOutputFormats
+        formatsForRequest
       );
       setIsLoading(false);
       if (result) {

--- a/src/components/robot/pages/RobotEditPage.tsx
+++ b/src/components/robot/pages/RobotEditPage.tsx
@@ -21,6 +21,12 @@ import { getStoredRecording, updateRecording } from "../../../api/storage";
 import { WhereWhatPair } from "maxun-core";
 import { RobotConfigPage } from "./RobotConfigPage";
 import { useNavigate, useLocation } from "react-router-dom";
+import {
+  DEFAULT_OUTPUT_FORMATS,
+  OUTPUT_FORMAT_LABELS,
+  OUTPUT_FORMAT_OPTIONS,
+  OutputFormat,
+} from "../../../constants/outputFormats";
 
 interface RobotMeta {
   name: string;
@@ -142,6 +148,8 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const [crawlConfig, setCrawlConfig] = useState<CrawlConfig>({});
   const [searchConfig, setSearchConfig] = useState<SearchConfig>({});
+  const [crawlOutputFormats, setCrawlOutputFormats] = useState<OutputFormat[]>(DEFAULT_OUTPUT_FORMATS);
+  const [searchOutputFormats, setSearchOutputFormats] = useState<OutputFormat[]>(DEFAULT_OUTPUT_FORMATS);
   const [showCrawlAdvanced, setShowCrawlAdvanced] = useState(false);
 
   const isEmailPattern = (value: string): boolean => {
@@ -193,6 +201,38 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
       findScrapeListLimits(robot.recording.workflow);
       extractCrawlConfig(robot.recording.workflow);
       extractSearchConfig(robot.recording.workflow);
+
+      const rawFormats = Array.isArray(robot.recording_meta?.formats)
+        ? robot.recording_meta.formats
+        : [];
+
+      const filteredFormats = rawFormats.filter((format): format is OutputFormat =>
+        OUTPUT_FORMAT_OPTIONS.includes(format as OutputFormat)
+      );
+
+      if (robot.recording_meta?.type === 'crawl') {
+        setCrawlOutputFormats(
+          filteredFormats.length > 0 ? filteredFormats : DEFAULT_OUTPUT_FORMATS
+        );
+      }
+
+      if (robot.recording_meta?.type === 'search') {
+        const isDiscoverMode = robot.recording?.workflow?.some((pair: any) =>
+          (pair.what || []).some(
+            (action: any) =>
+              action.action === 'search' &&
+              action.args?.[0]?.mode === 'discover'
+          )
+        );
+
+        if (isDiscoverMode) {
+          setSearchOutputFormats(filteredFormats);
+        } else {
+          setSearchOutputFormats(
+            filteredFormats.length > 0 ? filteredFormats : DEFAULT_OUTPUT_FORMATS
+          );
+        }
+      }
     }
   }, [robot]);
 
@@ -783,6 +823,31 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
 
     return (
       <>
+        <FormControl fullWidth sx={{ mb: 2 }}>
+          <InputLabel id="crawl-edit-output-formats-label">Output Formats *</InputLabel>
+          <Select
+            labelId="crawl-edit-output-formats-label"
+            multiple
+            value={crawlOutputFormats}
+            label="Output Formats *"
+            onChange={(e) => {
+              const value = typeof e.target.value === 'string' ? e.target.value.split(',') : e.target.value;
+              setCrawlOutputFormats(value as OutputFormat[]);
+            }}
+            renderValue={(selected) => {
+              const labels = (selected as OutputFormat[]).map(v => OUTPUT_FORMAT_LABELS[v] ?? v);
+              return labels.length > 2 ? `${labels.slice(0, 2).join(', ')}...` : labels.join(', ');
+            }}
+          >
+            {OUTPUT_FORMAT_OPTIONS.map((format) => (
+              <MenuItem key={format} value={format}>
+                <Checkbox checked={crawlOutputFormats.includes(format)} />
+                {OUTPUT_FORMAT_LABELS[format]}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
         <TextField
           label="Max Pages to Crawl"
           type="number"
@@ -904,6 +969,8 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
   const renderSearchConfigFields = () => {
     if (robot?.recording_meta.type !== 'search') return null;
 
+    const currentSearchMode = searchConfig.mode || 'discover';
+
     return (
       <>
         <TextField
@@ -937,12 +1004,51 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
           <Select
             value={searchConfig.mode || 'discover'}
             label="Mode"
-            onChange={(e) => setSearchConfig((prev) => ({ ...prev, mode: e.target.value as 'discover' | 'scrape' }))}
+            onChange={(e) => {
+              const newMode = e.target.value as 'discover' | 'scrape';
+              setSearchConfig((prev) => ({ ...prev, mode: newMode }));
+              if (newMode === 'discover') {
+                setSearchOutputFormats([]);
+              } else if (searchOutputFormats.length === 0) {
+                setSearchOutputFormats(DEFAULT_OUTPUT_FORMATS);
+              }
+            }}
           >
             <MenuItem value="discover">Discover URLs Only</MenuItem>
             <MenuItem value="scrape">Extract Data from Results</MenuItem>
           </Select>
         </FormControl>
+
+        {currentSearchMode === 'scrape' ? (
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <InputLabel id="search-edit-output-formats-label">Output Formats *</InputLabel>
+            <Select
+              labelId="search-edit-output-formats-label"
+              multiple
+              value={searchOutputFormats}
+              label="Output Formats *"
+              onChange={(e) => {
+                const value = typeof e.target.value === 'string' ? e.target.value.split(',') : e.target.value;
+                setSearchOutputFormats(value as OutputFormat[]);
+              }}
+              renderValue={(selected) => {
+                const labels = (selected as OutputFormat[]).map(v => OUTPUT_FORMAT_LABELS[v] ?? v);
+                return labels.length > 2 ? `${labels.slice(0, 2).join(', ')}...` : labels.join(', ');
+              }}
+            >
+              {OUTPUT_FORMAT_OPTIONS.map((format) => (
+                <MenuItem key={format} value={format}>
+                  <Checkbox checked={searchOutputFormats.includes(format)} />
+                  {OUTPUT_FORMAT_LABELS[format]}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        ) : (
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Output formats are only available in "Extract Data from Results" mode
+          </Typography>
+        )}
 
         <FormControl fullWidth sx={{ mb: 2 }}>
           <InputLabel>Time Range</InputLabel>
@@ -967,6 +1073,20 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
 
   const handleSave = async () => {
     if (!robot) return;
+
+    if (robot.recording_meta.type === 'crawl' && crawlOutputFormats.length === 0) {
+      notify("error", "Please select at least one output format");
+      return;
+    }
+
+    if (
+      robot.recording_meta.type === 'search' &&
+      (searchConfig.mode || 'discover') === 'scrape' &&
+      searchOutputFormats.length === 0
+    ) {
+      notify("error", "Please select at least one output format");
+      return;
+    }
 
     setIsLoading(true);
     try {
@@ -1038,6 +1158,11 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
         credentials: credentialsForPayload,
         targetUrl: targetUrl,
         workflow: updatedWorkflow,
+        formats: robot.recording_meta.type === 'crawl'
+          ? crawlOutputFormats
+          : robot.recording_meta.type === 'search'
+            ? ((searchConfig.mode || 'discover') === 'discover' ? [] : searchOutputFormats)
+            : undefined,
       };
 
       const success = await updateRecording(robot.recording_meta.id, payload);

--- a/src/components/robot/pages/RobotEditPage.tsx
+++ b/src/components/robot/pages/RobotEditPage.tsx
@@ -38,7 +38,7 @@ interface RobotMeta {
   params: any[];
   type?: 'extract' | 'scrape' | 'crawl' | 'search';
   url?: string;
-  formats?: ('markdown' | 'html' | 'screenshot-visible' | 'screenshot-fullpage')[];
+  formats?: OutputFormat[];
   isLLM?: boolean;
 }
 

--- a/src/components/run/ColapsibleRow.tsx
+++ b/src/components/run/ColapsibleRow.tsx
@@ -24,7 +24,7 @@ function getOrCreateSocket(browserId: string): Socket {
   }
 
   const socket = io(`${apiUrl}/${browserId}`, {
-    transports: ["websocket"],
+    transports: ["websocket", "polling"],
     rejectUnauthorized: false
   });
 
@@ -105,7 +105,7 @@ export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, cu
 
   // Subscribe to progress updates using module-level socket cache
   useEffect(() => {
-    if (!row.browserId) return;
+    if (!row.browserId || row.status !== 'running') return;
 
     // Get or create socket (from module cache)
     getOrCreateSocket(row.browserId);
@@ -130,7 +130,7 @@ export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, cu
         cleanupSocketIfUnused(row.browserId);
       }
     };
-  }, [row.browserId]);
+  }, [row.browserId, row.status]);
 
   // Clear progress UI when run completes and trigger socket cleanup
   useEffect(() => {

--- a/src/components/run/RunContent.tsx
+++ b/src/components/run/RunContent.tsx
@@ -68,6 +68,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
   const [screenshotKeys, setScreenshotKeys] = useState<string[]>([]);
   const [screenshotKeyMap, setScreenshotKeyMap] = useState<Record<string, string>>({});
   const [currentScreenshotIndex, setCurrentScreenshotIndex] = useState<number>(0);
+  const [currentCrawlScreenshotTab, setCurrentCrawlScreenshotTab] = useState<number>(0);
   const [currentSearchScreenshotTab, setCurrentSearchScreenshotTab] = useState<number>(0);
   const [currentSchemaIndex, setCurrentSchemaIndex] = useState<number>(0);
 
@@ -179,9 +180,16 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
         normalizedScreenshotKeys = rawKeys.map((_, index) => `Screenshot ${index + 1}`);
       } else {
         normalizedScreenshotKeys = rawKeys.map((key, index) => {
-          if (key === 'screenshot-visible') {
+          const crawlMatch = key.match(/^crawl-(\d+)-screenshot-(visible|fullpage)$/);
+          if (crawlMatch) {
+            const pageNo = crawlMatch[1];
+            const type = crawlMatch[2] === 'visible' ? 'Visible' : 'Full Page';
+            return `Page ${pageNo} (${type})`;
+          }
+
+          if (key === 'screenshot-visible' || key.includes('screenshot-visible')) {
             return 'Screenshot (Visible)';
-          } else if (key === 'screenshot-fullpage') {
+          } else if (key === 'screenshot-fullpage' || key.includes('screenshot-fullpage')) {
             return 'Screenshot (Full Page)';
           } else if (!key || key.toLowerCase().includes("screenshot")) {
             return `Screenshot ${index + 1}`;
@@ -550,6 +558,30 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
     }, 100);
   };
 
+  const resolveScreenshotSrc = (value?: string): string | null => {
+    if (!value || typeof value !== 'string') return null;
+
+    if (value.startsWith('http') || value.startsWith('data:')) {
+      return value;
+    }
+
+    if (row.binaryOutput && row.binaryOutput[value]) {
+      const binaryEntry = row.binaryOutput[value];
+      const binaryData = typeof binaryEntry === 'object' && binaryEntry !== null
+        ? (binaryEntry.data || binaryEntry)
+        : binaryEntry;
+
+      if (typeof binaryData === 'string') {
+        if (binaryData.startsWith('http') || binaryData.startsWith('data:')) {
+          return binaryData;
+        }
+        return `data:image/png;base64,${binaryData}`;
+      }
+    }
+
+    return `data:image/png;base64,${value}`;
+  };
+
   const downloadAllCrawlsAsZip = async (crawlDataArray: any[], zipFilename: string) => {
     const zip = new JSZip();
 
@@ -591,12 +623,22 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
       ];
 
       for (const screenshot of screenshots) {
-        if (screenshot.id && row.binaryOutput && row.binaryOutput[screenshot.id]) {
-          const binaryData = row.binaryOutput[screenshot.id].data;
-          if (binaryData && !binaryData.startsWith('http')) {
-            const base64Data = binaryData.replace(/^data:image\/\w+;base64,/, "");
-            pageFolder.file(screenshot.name, base64Data, { base64: true });
+        const src = resolveScreenshotSrc(screenshot.id);
+        if (!src) continue;
+
+        if (src.startsWith('http')) {
+          try {
+            const response = await fetch(src);
+            if (response.ok) {
+              const blob = await response.blob();
+              pageFolder.file(screenshot.name, blob);
+            }
+          } catch {
+            // Skip screenshot download errors while building ZIP
           }
+        } else if (src.startsWith('data:')) {
+          const base64Data = src.replace(/^data:image\/\w+;base64,/, '');
+          pageFolder.file(screenshot.name, base64Data, { base64: true });
         }
       }
     }
@@ -614,6 +656,113 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
     setTimeout(() => {
       URL.revokeObjectURL(url);
     }, 100);
+  };
+
+  const downloadScreenshot = async (label: string, value: string) => {
+    const src = resolveScreenshotSrc(value);
+    if (!src) return;
+    if (typeof src === 'string' && src.startsWith('http')) {
+      const blob = await fetch(src).then(res => res.blob());
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${label}.png`;
+      a.click();
+      window.URL.revokeObjectURL(url);
+    } else {
+      const link = document.createElement('a');
+      link.href = src as string;
+      link.download = `${label}.png`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
+  };
+
+  const renderCapturedScreenshotsAccordion = (
+    title: string,
+    tabs: { key: string; label: string; value: string }[],
+    currentIndex: number,
+    setIndex: (idx: number) => void,
+    defaultExpanded: boolean = true
+  ) => {
+    if (tabs.length === 0) return null;
+    const activeIdx = Math.min(currentIndex, tabs.length - 1);
+    const activeTab = tabs[activeIdx >= 0 ? activeIdx : 0];
+    const activeSrc = resolveScreenshotSrc(activeTab?.value);
+    return (
+      <Accordion defaultExpanded={defaultExpanded} sx={{ mb: 2 }}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Typography variant='h6'>{title}</Typography>
+          </Box>
+        </AccordionSummary>
+        <AccordionDetails>
+          {tabs.length > 1 && (
+            <Box
+              sx={{
+                display: 'flex',
+                overflowX: 'auto',
+                maxWidth: '100%',
+                borderBottom: '1px solid',
+                borderColor: 'divider',
+                mb: 2,
+                '&::-webkit-scrollbar': { height: '8px' },
+                '&::-webkit-scrollbar-thumb': {
+                  backgroundColor: darkMode ? '#555' : '#888',
+                  borderRadius: '4px',
+                },
+              }}
+            >
+              {tabs.map((tab, idx) => (
+                <Box
+                  key={tab.key}
+                  onClick={() => setIndex(idx)}
+                  sx={{
+                    px: 3,
+                    py: 1,
+                    cursor: 'pointer',
+                    backgroundColor:
+                      activeIdx === idx
+                        ? (theme) => theme.palette.mode === 'dark'
+                          ? '#121111ff'
+                          : '#e9ecef'
+                        : 'transparent',
+                    borderBottom: activeIdx === idx ? '3px solid #FF00C3' : 'none',
+                    color: (theme) => theme.palette.mode === 'dark' ? '#fff' : '#000',
+                    flexShrink: 0,
+                  }}
+                >
+                  {tab.label}
+                </Box>
+              ))}
+            </Box>
+          )}
+          <Box sx={{ mt: 1 }}>
+            {activeSrc && (
+              <img
+                src={activeSrc as string}
+                alt={activeTab?.label}
+                style={{
+                  maxWidth: '100%',
+                  height: 'auto',
+                  border: '1px solid #e0e0e0',
+                  borderRadius: '4px',
+                }}
+              />
+            )}
+          </Box>
+          <Box sx={{ mt: 2 }}>
+            <Button
+              onClick={() => activeTab && downloadScreenshot(activeTab.label, activeTab.value)}
+              sx={{ color: '#FF00C3', textTransform: 'none', p: 0, minWidth: 'auto', backgroundColor: 'transparent', '&:hover': { textDecoration: 'underline', backgroundColor: 'transparent' } }}
+            >
+              Download Screenshot
+            </Button>
+          </Box>
+        </AccordionDetails>
+      </Accordion>
+    );
   };
 
   const renderDataTable = (
@@ -878,6 +1027,9 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
   const hasScreenshots = row.binaryOutput && Object.keys(row.binaryOutput).length > 0;
   const hasMarkdown = markdownContent.length > 0;
   const hasHTML = htmlContent.length > 0;
+  const hasCrawlPageScreenshots = crawlData.some(group => Array.isArray(group) && group.some((item: any) => item?.screenshotVisible || item?.screenshotFullpage));
+  const hasSearchResultScreenshots = searchData.some((item: any) => item?.screenshotVisible || item?.screenshotFullpage);
+  const showCapturedScreenshotSection = hasScreenshots && !hasCrawlPageScreenshots && !hasSearchResultScreenshots;
 
   return (
     <Box sx={{ width: '100%' }}>
@@ -944,98 +1096,11 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                 </Accordion>
               )}
 
-              {hasScreenshots && (
-                <Accordion defaultExpanded sx={{ mb: 2 }}>
-                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                    <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                      <Typography variant='h6'>
-                        {t('run_content.captured_screenshot.title', 'Captured Screenshots')}
-                      </Typography>
-                    </Box>
-                  </AccordionSummary>
-                  <AccordionDetails>
-                    {screenshotKeys.length > 1 && (
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          borderBottom: '1px solid',
-                          borderColor: 'divider',
-                          mb: 2,
-                        }}
-                      >
-                        {screenshotKeys.map((key, idx) => (
-                          <Box
-                            key={key}
-                            onClick={() => setCurrentScreenshotIndex(idx)}
-                            sx={{
-                              px: 3,
-                              py: 1,
-                              cursor: 'pointer',
-                              backgroundColor:
-                                currentScreenshotIndex === idx
-                                  ? (theme) => theme.palette.mode === 'dark'
-                                    ? '#121111ff'
-                                    : '#e9ecef'
-                                  : 'transparent',
-                              borderBottom: currentScreenshotIndex === idx ? '3px solid #FF00C3' : 'none',
-                              color: (theme) => theme.palette.mode === 'dark' ? '#fff' : '#000',
-                            }}
-                          >
-                            {key}
-                          </Box>
-                        ))}
-                      </Box>
-                    )}
-
-                    <Box sx={{ mt: 1 }}>
-                      {screenshotKeys.length > 0 && (
-                        <img
-                          src={row.binaryOutput[screenshotKeyMap[screenshotKeys[currentScreenshotIndex]]]}
-                          alt={`Screenshot ${screenshotKeys[currentScreenshotIndex]}`}
-                          style={{
-                            maxWidth: '100%',
-                            height: 'auto',
-                            border: '1px solid #e0e0e0',
-                            borderRadius: '4px'
-                          }}
-                        />
-                      )}
-                    </Box>
-                    <Box sx={{ mt: 2 }}>
-                      <Button
-                        onClick={() => {
-                          const key = screenshotKeys[currentScreenshotIndex];
-                          const orig = screenshotKeyMap[key];
-                          const src = row.binaryOutput[orig];
-                          // Use fetch/blob for URL-based screenshots
-                          if (src && typeof src === 'string' && src.startsWith('http')) {
-                            fetch(src)
-                              .then(res => res.blob())
-                              .then(blob => {
-                                const url = window.URL.createObjectURL(blob);
-                                const a = document.createElement('a');
-                                a.href = url;
-                                a.download = `${key}.png`;
-                                a.click();
-                                window.URL.revokeObjectURL(url);
-                              });
-                          } else {
-                            // Fallback for data URIs
-                            const link = document.createElement('a');
-                            link.href = src;
-                            link.download = `${key}.png`;
-                            document.body.appendChild(link);
-                            link.click();
-                            document.body.removeChild(link);
-                          }
-                        }}
-                        sx={{ color: '#FF00C3', textTransform: 'none', p: 0, minWidth: 'auto', backgroundColor: 'transparent', '&:hover': { textDecoration: 'underline', backgroundColor: 'transparent' } }}
-                      >
-                        Download Screenshot
-                      </Button>
-                    </Box>
-                  </AccordionDetails>
-                </Accordion>
+              {showCapturedScreenshotSection && renderCapturedScreenshotsAccordion(
+                t('run_content.captured_screenshot.title', 'Captured Screenshots'),
+                screenshotKeys.map(key => ({ key, label: key, value: screenshotKeyMap[key] })).filter(tab => tab.value),
+                currentScreenshotIndex,
+                setCurrentScreenshotIndex
               )}
             </>
           ) : (
@@ -1063,7 +1128,9 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
               </Button>
             </>
           ) : (!hasData && !hasScreenshots
-            ? <Typography>{t('run_content.empty_output')}</Typography>
+            ? (row.status === 'failed'
+              ? <Typography color='error'>{t('run_content.failed_no_output', 'Run failed before generating output. Check run logs for details.')}</Typography>
+              : <Typography>{t('run_content.empty_output')}</Typography>)
             : null)}
 
           {hasData && (
@@ -1316,7 +1383,10 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                         return (
                           <Box
                             key={idx}
-                            onClick={() => setCurrentCrawlIndex(idx)}
+                            onClick={() => {
+                              setCurrentCrawlIndex(idx);
+                              setCurrentCrawlScreenshotTab(0);
+                            }}
                             sx={{
                               px: 2,
                               py: 1,
@@ -1534,6 +1604,17 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                               </Box>
                             </AccordionDetails>
                           </Accordion>
+                        )}
+
+                        {renderCapturedScreenshotsAccordion(
+                          t('run_content.captured_screenshot.title', 'Captured Screenshots'),
+                          [
+                            ...(crawlData[0][currentCrawlIndex].screenshotVisible ? [{ key: 'visible', label: 'Screenshot (Visible)', value: crawlData[0][currentCrawlIndex].screenshotVisible }] : []),
+                            ...(crawlData[0][currentCrawlIndex].screenshotFullpage ? [{ key: 'fullpage', label: 'Screenshot (Full Page)', value: crawlData[0][currentCrawlIndex].screenshotFullpage }] : []),
+                          ],
+                          currentCrawlScreenshotTab,
+                          setCurrentCrawlScreenshotTab,
+                          false
                         )}
 
                         {(() => {
@@ -1926,90 +2007,15 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                               );
                             })()}
 
-                            {(searchData[currentSearchIndex].screenshotVisible || searchData[currentSearchIndex].screenshotFullpage) && (
-                              <Accordion sx={{ mb: 2 }}>
-                                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                                    <Typography variant='h6'>
-                                      Screenshots
-                                    </Typography>
-                                  </Box>
-                                </AccordionSummary>
-                                <AccordionDetails>
-                                  {(() => {
-                                    const tabs: { key: string; label: string; value: string }[] = [];
-                                    if (searchData[currentSearchIndex].screenshotVisible) 
-                                      tabs.push({ key: 'visible', label: 'Screenshot (Visible)', value: searchData[currentSearchIndex].screenshotVisible });
-                                    if (searchData[currentSearchIndex].screenshotFullpage) 
-                                      tabs.push({ key: 'fullpage', label: 'Screenshot (Full Page)', value: searchData[currentSearchIndex].screenshotFullpage });
-                                    
-                                    // Ensure activeTab is valid for current tabs array
-                                    const activeTab = Math.min(currentSearchScreenshotTab, tabs.length - 1);
-                                    
-                                    const getImageSrc = (val: string) => {
-                                      if (val.startsWith('http')) return val;
-                                      if (row.binaryOutput && row.binaryOutput[val]) {
-                                        const binaryData = row.binaryOutput[val].data || row.binaryOutput[val];
-                                        return typeof binaryData === 'string' && binaryData.startsWith('http') 
-                                          ? binaryData 
-                                          : typeof binaryData === 'string' && binaryData.startsWith('data:')
-                                            ? binaryData
-                                            : `data:image/png;base64,${binaryData}`;
-                                      }
-                                      return `data:image/png;base64,${val}`;
-                                    };
-                                    
-                                    return (
-                                      <>
-                                        {tabs.length > 1 && (
-                                          <Box sx={{ display: 'flex', borderBottom: '1px solid', borderColor: darkMode ? '#2a3441' : '#dee2e6', mb: 2 }}>
-                                            {tabs.map((tab, idx) => (
-                                              <Box 
-                                                key={tab.key} 
-                                                onClick={() => setCurrentSearchScreenshotTab(idx)}
-                                                sx={{
-                                                  px: 3, py: 1, 
-                                                  cursor: 'pointer',
-                                                  backgroundColor: activeTab === idx ? (darkMode ? '#121111ff' : '#e9ecef') : 'transparent',
-                                                  borderBottom: activeTab === idx ? '3px solid #FF00C3' : 'none',
-                                                  color: darkMode ? '#fff' : '#000',
-                                                }}
-                                              >
-                                                {tab.label}
-                                              </Box>
-                                            ))}
-                                          </Box>
-                                        )}
-                                        {tabs.length > 0 && (
-                                          <>
-                                            <img 
-                                              src={getImageSrc(tabs[activeTab >= 0 ? activeTab : 0].value)} 
-                                              alt={tabs[activeTab >= 0 ? activeTab : 0].label}
-                                              style={{ maxWidth: '100%', borderRadius: '4px', border: '1px solid rgba(255,255,255,0.1)' }} 
-                                            />
-                                            <Box sx={{ mt: 1 }}>
-                                              <Button 
-                                                onClick={() => {
-                                                  const src = getImageSrc(tabs[activeTab >= 0 ? activeTab : 0].value);
-                                                  const link = document.createElement('a');
-                                                  link.href = src;
-                                                  link.download = `${tabs[activeTab >= 0 ? activeTab : 0].label}.png`;
-                                                  document.body.appendChild(link);
-                                                  link.click();
-                                                  document.body.removeChild(link);
-                                                }}
-                                                sx={{ color: '#FF00C3', textTransform: 'none', p: 0, minWidth: 'auto', backgroundColor: 'transparent', '&:hover': { textDecoration: 'underline', backgroundColor: 'transparent' } }}
-                                              >
-                                                Download Screenshot
-                                              </Button>
-                                            </Box>
-                                          </>
-                                        )}
-                                      </>
-                                    );
-                                  })()}
-                                </AccordionDetails>
-                              </Accordion>
+                            {renderCapturedScreenshotsAccordion(
+                              t('run_content.captured_screenshot.title', 'Captured Screenshots'),
+                              [
+                                ...(searchData[currentSearchIndex].screenshotVisible ? [{ key: 'visible', label: 'Screenshot (Visible)', value: searchData[currentSearchIndex].screenshotVisible }] : []),
+                                ...(searchData[currentSearchIndex].screenshotFullpage ? [{ key: 'fullpage', label: 'Screenshot (Full Page)', value: searchData[currentSearchIndex].screenshotFullpage }] : []),
+                              ],
+                              currentSearchScreenshotTab,
+                              setCurrentSearchScreenshotTab,
+                              false
                             )}
 
                             <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
@@ -2142,94 +2148,11 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
             </Box>
           )}
 
-          {hasScreenshots && (
-            <Accordion defaultExpanded sx={{ mb: 2 }}>
-              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  <Typography variant='h6'>
-                    {t('run_content.captured_screenshot.title', 'Captured Screenshots')}
-                  </Typography>
-                </Box>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    mb: 2,
-                  }}
-                >
-                  {screenshotKeys.length > 0 && (
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        borderBottom: '1px solid',
-                        borderColor: 'divider',
-                        mb: 2,
-                      }}
-                    >
-                      {screenshotKeys.map((key, idx) => (
-                        <Box
-                          key={key}
-                          onClick={() => setCurrentScreenshotIndex(idx)}
-                          sx={{
-                            px: 3,
-                            py: 1,
-                            cursor: 'pointer',
-                            backgroundColor:
-                              currentScreenshotIndex === idx
-                                ? (theme) => theme.palette.mode === 'dark'
-                                  ? '#121111ff'
-                                  : '#e9ecef'
-                                : 'transparent',
-                            borderBottom: currentScreenshotIndex === idx ? '3px solid #FF00C3' : 'none',
-                            color: (theme) => theme.palette.mode === 'dark' ? '#fff' : '#000',
-                          }}
-                        >
-                          {key}
-                        </Box>
-                      ))}
-                    </Box>
-                  )}
-                </Box>
-
-                <Box sx={{ mt: 1 }}>
-                  {screenshotKeys.length > 0 && (
-                    <img
-                      src={row.binaryOutput[screenshotKeyMap[screenshotKeys[currentScreenshotIndex]]]}
-                      alt={`Screenshot ${screenshotKeys[currentScreenshotIndex]}`}
-                      style={{
-                        maxWidth: '100%',
-                        height: 'auto',
-                        border: '1px solid #e0e0e0',
-                        borderRadius: '4px'
-                      }}
-                    />
-                  )}
-                </Box>
-                <Box sx={{ mt: 2 }}>
-                  <Button onClick={() => {
-                    const key = screenshotKeys[currentScreenshotIndex];
-                    const orig = screenshotKeyMap[key];
-                    const src = row.binaryOutput[orig];
-                    if (src && src.startsWith && src.startsWith('http')) {
-                      fetch(src).then(res => res.blob()).then(blob => {
-                        const url = window.URL.createObjectURL(blob);
-                        const a = document.createElement('a'); a.href = url; a.download = key + '.png'; a.click();
-                      });
-                    } else {
-                      const link = document.createElement('a');
-                      link.href = src;
-                      link.download = key + '.png';
-                      document.body.appendChild(link);
-                      link.click();
-                      document.body.removeChild(link);
-                    }
-                  }} sx={{ color: '#FF00C3', textTransform: 'none', p: 0, minWidth: 'auto', backgroundColor: 'transparent', '&:hover': { textDecoration: 'underline', backgroundColor: 'transparent' } }}>Download Screenshot</Button>
-                </Box>
-              </AccordionDetails>
-            </Accordion>
+          {showCapturedScreenshotSection && renderCapturedScreenshotsAccordion(
+            t('run_content.captured_screenshot.title', 'Captured Screenshots'),
+            screenshotKeys.map(key => ({ key, label: key, value: screenshotKeyMap[key] })).filter(tab => tab.value),
+            currentScreenshotIndex,
+            setCurrentScreenshotIndex
           )}
           </>
           )}

--- a/src/components/run/RunContent.tsx
+++ b/src/components/run/RunContent.tsx
@@ -714,6 +714,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
     tabs: { key: string; label: string; value: string }[],
     currentIndex: number,
     setIndex: (idx: number) => void,
+    idPrefix: string,
     defaultExpanded: boolean = true
   ) => {
     if (tabs.length === 0) return null;
@@ -764,13 +765,18 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                 <Tab
                   key={tab.key}
                   label={tab.label}
-                  id={`screenshot-tab-${tab.key}`}
-                  aria-controls={`screenshot-tabpanel-${tab.key}`}
+                  id={`screenshot-tab-${idPrefix}-${tab.key}`}
+                  aria-controls={`screenshot-tabpanel-${idPrefix}-${tab.key}`}
                 />
               ))}
             </Tabs>
           )}
-          <Box sx={{ mt: 1 }}>
+          <Box
+            role="tabpanel"
+            id={`screenshot-tabpanel-${idPrefix}-${activeTab?.key || 'active'}`}
+            aria-labelledby={`screenshot-tab-${idPrefix}-${activeTab?.key || 'active'}`}
+            sx={{ mt: 1 }}
+          >
             {activeSrc && (
               <img
                 src={activeSrc as string}
@@ -927,12 +933,14 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
       );
     }
 
+    const accordionIdBase = `${title.toLowerCase().replace(/\s+/g, '-')}-${csvFilename.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+
     return (
       <Accordion defaultExpanded sx={{ mb: 2 }}>
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls={`${title.toLowerCase()}-content`}
-          id={`${title.toLowerCase()}-header`}
+          aria-controls={`${accordionIdBase}-content`}
+          id={`${accordionIdBase}-header`}
         >
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <Typography variant='h6'>
@@ -1132,7 +1140,8 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                 t('run_content.captured_screenshot.title', 'Captured Screenshots'),
                 screenshotKeys.map(key => ({ key, label: key, value: screenshotKeyMap[key] })).filter(tab => tab.value),
                 currentScreenshotIndex,
-                setCurrentScreenshotIndex
+                setCurrentScreenshotIndex,
+                'global-screenshots-primary'
               )}
             </>
           ) : (
@@ -1160,7 +1169,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
               </Button>
             </>
           ) : (!hasData && !hasScreenshots
-            ? (row.status === 'failed'
+            ? (['failed', 'aborted', 'aborting'].includes(row.status)
               ? <Typography color='error'>{t('run_content.failed_no_output', 'Run failed before generating output. Check run logs for details.')}</Typography>
               : <Typography>{t('run_content.empty_output')}</Typography>)
             : null)}
@@ -1646,6 +1655,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                           ],
                           currentCrawlScreenshotTab,
                           setCurrentCrawlScreenshotTab,
+                          `crawl-${currentCrawlIndex}`,
                           false
                         )}
 
@@ -2047,6 +2057,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                               ],
                               currentSearchScreenshotTab,
                               setCurrentSearchScreenshotTab,
+                              `search-${currentSearchIndex}`,
                               false
                             )}
 
@@ -2184,7 +2195,8 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
             t('run_content.captured_screenshot.title', 'Captured Screenshots'),
             screenshotKeys.map(key => ({ key, label: key, value: screenshotKeyMap[key] })).filter(tab => tab.value),
             currentScreenshotIndex,
-            setCurrentScreenshotIndex
+            setCurrentScreenshotIndex,
+            'global-screenshots-secondary'
           )}
           </>
           )}

--- a/src/components/run/RunContent.tsx
+++ b/src/components/run/RunContent.tsx
@@ -68,7 +68,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
   const [currentSearchIndex, setCurrentSearchIndex] = useState<number>(0);
 
   const [screenshotKeys, setScreenshotKeys] = useState<string[]>([]);
-  const [screenshotKeyMap, setScreenshotKeyMap] = useState<Record<string, string>>({});
+  const [rawScreenshotKeys, setRawScreenshotKeys] = useState<string[]>([]);
   const [currentScreenshotIndex, setCurrentScreenshotIndex] = useState<number>(0);
   const [currentCrawlScreenshotTab, setCurrentCrawlScreenshotTab] = useState<number>(0);
   const [currentSearchScreenshotTab, setCurrentSearchScreenshotTab] = useState<number>(0);
@@ -166,7 +166,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
   useEffect(() => {
     if (row.status === 'running' || row.status === 'queued' || row.status === 'scheduled') {
       setScreenshotKeys([]);
-      setScreenshotKeyMap({});
+      setRawScreenshotKeys([]);
       setCurrentScreenshotIndex(0);
       return;
     }
@@ -200,17 +200,18 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
         });
       }
 
-      const keyMap: Record<string, string> = {};
+      const keyMap: Record<string, { id: string; label: string }> = {};
       normalizedScreenshotKeys.forEach((displayName, index) => {
-        keyMap[displayName] = rawKeys[index];
+        const rawKey = rawKeys[index];
+        keyMap[rawKey] = { id: rawKey, label: displayName };
       });
 
       setScreenshotKeys(normalizedScreenshotKeys);
-      setScreenshotKeyMap(keyMap);
+      setRawScreenshotKeys(rawKeys);
       setCurrentScreenshotIndex(0);
     } else {
       setScreenshotKeys([]);
-      setScreenshotKeyMap({});
+      setRawScreenshotKeys([]);
       setCurrentScreenshotIndex(0);
     }
   }, [row.binaryOutput, row.status]);
@@ -577,11 +578,13 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
         if (binaryData.startsWith('http') || binaryData.startsWith('data:')) {
           return binaryData;
         }
-        return `data:image/png;base64,${binaryData}`;
+        if (/^[A-Za-z0-9+/=]+$/.test(binaryData)) {
+          return `data:image/png;base64,${binaryData}`;
+        }
       }
     }
 
-    return `data:image/png;base64,${value}`;
+    return null;
   };
 
   const downloadAllCrawlsAsZip = async (crawlDataArray: any[], zipFilename: string) => {
@@ -1138,7 +1141,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
 
               {showCapturedScreenshotSection && renderCapturedScreenshotsAccordion(
                 t('run_content.captured_screenshot.title', 'Captured Screenshots'),
-                screenshotKeys.map(key => ({ key, label: key, value: screenshotKeyMap[key] })).filter(tab => tab.value),
+                screenshotKeys.map((label, index) => ({ key: label, label, value: rawScreenshotKeys[index] })).filter(tab => tab.value),
                 currentScreenshotIndex,
                 setCurrentScreenshotIndex,
                 'global-screenshots-primary'
@@ -2193,7 +2196,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
 
           {showCapturedScreenshotSection && renderCapturedScreenshotsAccordion(
             t('run_content.captured_screenshot.title', 'Captured Screenshots'),
-            screenshotKeys.map(key => ({ key, label: key, value: screenshotKeyMap[key] })).filter(tab => tab.value),
+            screenshotKeys.map((label, index) => ({ key: label, label, value: rawScreenshotKeys[index] })).filter(tab => tab.value),
             currentScreenshotIndex,
             setCurrentScreenshotIndex,
             'global-screenshots-secondary'

--- a/src/components/run/RunContent.tsx
+++ b/src/components/run/RunContent.tsx
@@ -7,7 +7,9 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
-  Link
+  Link,
+  Tabs,
+  Tab
 } from "@mui/material";
 import * as React from "react";
 import { Data } from "./RunsTable";
@@ -659,23 +661,51 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
   };
 
   const downloadScreenshot = async (label: string, value: string) => {
-    const src = resolveScreenshotSrc(value);
-    if (!src) return;
-    if (typeof src === 'string' && src.startsWith('http')) {
-      const blob = await fetch(src).then(res => res.blob());
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${label}.png`;
-      a.click();
-      window.URL.revokeObjectURL(url);
-    } else {
-      const link = document.createElement('a');
-      link.href = src as string;
-      link.download = `${label}.png`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+    try {
+      const src = resolveScreenshotSrc(value);
+      if (!src) {
+        console.warn(`[downloadScreenshot] No valid source for label: ${label}`);
+        return;
+      }
+
+      if (typeof src === 'string' && src.startsWith('http')) {
+        // Handles HTTP-based screenshots with error handling
+        const response = await fetch(src);
+        
+        if (!response.ok) {
+          const errorMsg = `Failed to download screenshot: ${response.status} ${response.statusText}`;
+          console.error(errorMsg);
+          alert(`Error: ${errorMsg}`);
+          return;
+        }
+
+        try {
+          const blob = await response.blob();
+          const url = window.URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = `${label}.png`;
+          a.click();
+          window.URL.revokeObjectURL(url);
+        } catch (blobError) {
+          const errorMsg = 'Failed to process downloaded image. Please try again.';
+          console.error(`[downloadScreenshot] Blob processing error:`, blobError);
+          alert(errorMsg);
+          return;
+        }
+      } else {
+        // Handles URL based screenshots
+        const link = document.createElement('a');
+        link.href = src as string;
+        link.download = `${label}.png`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      }
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : 'Unknown error downloading screenshot';
+      console.error(`[downloadScreenshot] Error:`, error);
+      alert(`Failed to download screenshot: ${errorMsg}`);
     }
   };
 
@@ -690,6 +720,11 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
     const activeIdx = Math.min(currentIndex, tabs.length - 1);
     const activeTab = tabs[activeIdx >= 0 ? activeIdx : 0];
     const activeSrc = resolveScreenshotSrc(activeTab?.value);
+
+    const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+      setIndex(newValue);
+    };
+
     return (
       <Accordion defaultExpanded={defaultExpanded} sx={{ mb: 2 }}>
         <AccordionSummary expandIcon={<ExpandMoreIcon />}>
@@ -699,44 +734,41 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
         </AccordionSummary>
         <AccordionDetails>
           {tabs.length > 1 && (
-            <Box
+            <Tabs
+              value={activeIdx}
+              onChange={handleTabChange}
+              variant="scrollable"
+              scrollButtons="auto"
               sx={{
-                display: 'flex',
-                overflowX: 'auto',
-                maxWidth: '100%',
-                borderBottom: '1px solid',
-                borderColor: 'divider',
                 mb: 2,
-                '&::-webkit-scrollbar': { height: '8px' },
-                '&::-webkit-scrollbar-thumb': {
-                  backgroundColor: darkMode ? '#555' : '#888',
-                  borderRadius: '4px',
+                '& .MuiTabs-indicator': {
+                  backgroundColor: '#FF00C3',
+                  height: '3px',
+                },
+                '& .MuiTab-root': {
+                  textTransform: 'none',
+                  minWidth: 'auto',
+                  px: 3,
+                  color: darkMode ? '#fff' : '#000',
+                  '&.Mui-selected': {
+                    backgroundColor: darkMode ? '#121111ff' : '#e9ecef',
+                  },
+                  '&:hover': {
+                    backgroundColor: darkMode ? 'rgba(255, 0, 195, 0.1)' : 'rgba(255, 0, 195, 0.05)',
+                  },
                 },
               }}
+              aria-label={`${title} tabs`}
             >
-              {tabs.map((tab, idx) => (
-                <Box
+              {tabs.map((tab) => (
+                <Tab
                   key={tab.key}
-                  onClick={() => setIndex(idx)}
-                  sx={{
-                    px: 3,
-                    py: 1,
-                    cursor: 'pointer',
-                    backgroundColor:
-                      activeIdx === idx
-                        ? (theme) => theme.palette.mode === 'dark'
-                          ? '#121111ff'
-                          : '#e9ecef'
-                        : 'transparent',
-                    borderBottom: activeIdx === idx ? '3px solid #FF00C3' : 'none',
-                    color: (theme) => theme.palette.mode === 'dark' ? '#fff' : '#000',
-                    flexShrink: 0,
-                  }}
-                >
-                  {tab.label}
-                </Box>
+                  label={tab.label}
+                  id={`screenshot-tab-${tab.key}`}
+                  aria-controls={`screenshot-tabpanel-${tab.key}`}
+                />
               ))}
-            </Box>
+            </Tabs>
           )}
           <Box sx={{ mt: 1 }}>
             {activeSrc && (

--- a/src/components/run/RunsTable.tsx
+++ b/src/components/run/RunsTable.tsx
@@ -309,7 +309,7 @@ export const RunsTable: React.FC<RunsTableProps> = ({
 
       try {
         const socket = io(`${apiUrl}/${browserId}`, {
-          transports: ['websocket'],
+          transports: ['websocket', 'polling'],
           rejectUnauthorized: false
         });
 
@@ -372,8 +372,9 @@ export const RunsTable: React.FC<RunsTableProps> = ({
         activeSocketsRef.current.delete(browserId);
       }
     });
+  }, [rows, notify, t, invalidateRuns, setRerenderRuns]);
 
-    // Cleanup on unmount
+  useEffect(() => {
     return () => {
       console.log('[RunsTable] Cleaning up all socket connections');
       activeSocketsRef.current.forEach((socket) => {
@@ -381,7 +382,7 @@ export const RunsTable: React.FC<RunsTableProps> = ({
       });
       activeSocketsRef.current.clear();
     };
-  }, [rows, notify, t, invalidateRuns, setRerenderRuns]);
+  }, []);
 
   const handleDelete = useCallback(() => {
     notify('success', t('runstable.notifications.delete_success'));

--- a/src/constants/outputFormats.ts
+++ b/src/constants/outputFormats.ts
@@ -1,0 +1,19 @@
+export const OUTPUT_FORMAT_OPTIONS = [
+  'markdown',
+  'html',
+  'text',
+  'screenshot-visible',
+  'screenshot-fullpage',
+] as const;
+
+export type OutputFormat = (typeof OUTPUT_FORMAT_OPTIONS)[number];
+
+export const DEFAULT_OUTPUT_FORMATS: OutputFormat[] = ['markdown'];
+
+export const OUTPUT_FORMAT_LABELS: Record<OutputFormat, string> = {
+  markdown: 'Markdown',
+  html: 'HTML',
+  text: 'Text Content',
+  'screenshot-visible': 'Screenshot (Visible)',
+  'screenshot-fullpage': 'Screenshot (Full Page)',
+};

--- a/src/context/socket.tsx
+++ b/src/context/socket.tsx
@@ -37,7 +37,7 @@ export const SocketProvider = ({ children }: { children: JSX.Element }) => {
     // the socket client connection is recomputed whenever id changes -> the new browser has been initialized
     const socket =
       io(`${SERVER_ENDPOINT}/${id}`, {
-        transports: ["websocket"],
+        transports: ["websocket", "polling"],
         rejectUnauthorized: false
       });
 
@@ -55,7 +55,7 @@ export const SocketProvider = ({ children }: { children: JSX.Element }) => {
     runScheduledCallbackRef.current = onRunScheduled || null;
 
     const newQueueSocket = io(`${SERVER_ENDPOINT}/queued-run`, {
-      transports: ["websocket"],
+      transports: ["websocket", "polling"],
       rejectUnauthorized: false,
       query: { userId }
     });

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -91,7 +91,7 @@ export const MainPage = ({ handleEditRecording, initialContent }: MainPageProps)
       }
       
       const abortSocket = io(`${apiUrl}/${browserId}`, {
-        transports: ["websocket"],
+        transports: ["websocket", "polling"],
         rejectUnauthorized: false
       });
       
@@ -171,7 +171,7 @@ export const MainPage = ({ handleEditRecording, initialContent }: MainPageProps)
         notify('info', `Run queued: ${runningRecordingName}`);
       } else {
         const socket = io(`${apiUrl}/${browserId}`, {
-          transports: ["websocket"],
+          transports: ["websocket", "polling"],
           rejectUnauthorized: false
         });
         


### PR DESCRIPTION
/fixes #990 

## Add output format selection for Crawl/Search robots and unify backend output processing

This PR adds configurable output formats for Crawl and Search robots (with Search formats only applicable in `scrape` mode), centralizes output-format validation, and removes duplicated crawl/search post-processing logic between manual and scheduled run paths.

## What Changed

### Frontend
- Added shared output format constants/types:
  - `src/constants/outputFormats.ts`
- Updated Robot Create UI:
  - Added Crawl output format multi-select
  - Added Search output format multi-select (shown only in `scrape` mode)
  - Enforced Search format requirement only when `searchMode === 'scrape'`
  - Improved mode switch behavior:
    - `discover` -> clears search formats
    - switching back to `scrape` restores default formats if empty
- Updated API calls to send selected formats:
  - `src/api/storage.ts`
  - `createCrawlRobot(..., formats)`
  - `createSearchRobot(..., formats?)`

### Backend
- Added shared backend format constants/parser:
  - `server/src/constants/output-formats.ts`
- Added shared validation helpers:
  - `server/src/utils/output-validation.ts`
- Added shared output post-processor:
  - `server/src/utils/output-post-processor.ts`
- Refactored duplicated logic in:
  - `server/src/pgboss-worker.ts`
  - `server/src/workflow-management/scheduler/index.ts`
  - both now use shared post-processing + validation helpers
- Centralized route validation/default handling:
  - `server/src/routes/storage.ts`
  - `server/src/api/sdk.ts`
- Fixed SDK consistency:
  - `/sdk/robots` now validates/normalizes `meta.formats` like dedicated SDK routes
- Updated robot metadata typing:
  - `server/src/models/Robot.ts` uses shared `OutputFormat[]`

## Additional Notes
- Search robots in `discover` mode store `formats: []` and do not require output formats.
- Crawl/Search default to `['markdown']` when formats are omitted (except Search `discover`, which remains `[]`).
- Scrape robots only allow scrape-compatible formats (`markdown`, `html`, screenshot variants).

## Testing
- Build checks passed:
  - `npm run build:server`
  - `npm run build`

## Screen Recording

**1. Crawl Robot**


https://github.com/user-attachments/assets/626365fc-9d88-4642-b414-0eca71731452

**2. Search Robot** 



https://github.com/user-attachments/assets/7f04327c-c63a-4cf4-9bec-3841d045bb33



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified output-format support (options, labels, defaults) across UI, API, and server; server now validates/normalizes requested formats and returns 400 on invalid entries.
  * Output post-processing: conversion/pruning, screenshot capture into binary payloads, and conditional binary uploads.
  * UI: output-format selectors in create/edit flows; consolidated captured-screenshots view with download/export.

* **Bug Fixes**
  * Interpreter now logs, cleans up, and throws when actions exceed retry limits.
  * Concurrency waiters surface first worker errors; avoid redundant navigations before screenshot capture.
  * Progress subscriptions now tied to run state.

* **Performance**
  * Increased browser-init timeout and added socket polling fallback for more resilient realtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->