### PR TITLE
fix: sdk doc link path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ It supports extraction, crawling, scraping, and search — designed to scale fro
 2. **[Scrape](https://docs.maxun.dev/robot/scrape/scrape-robots)** – Convert full webpages into clean Markdown or HTML and capture screenshots.
 3. **[Crawl](https://docs.maxun.dev/robot/crawl/crawl-introduction)** – Crawl entire websites and extract content from every relevant page, with full control over scope and discovery.
 4. **[Search](https://docs.maxun.dev/robot/search/search-introduction)** – Run automated web searches to discover or scrape results, with support for time-based filters.
-5. **[SDK](https://docs.maxun.dev/sdk/sdk-overview)** – A complete developer toolkit for scraping, extraction, scheduling, and end-to-end data automation.
+5. **[SDK](https://docs.maxun.dev/category/sdk)** – A complete developer toolkit for scraping, extraction, scheduling, and end-to-end data automation.
 
 ## How Does It Work?
 

--- a/src/components/dashboard/MainMenu.tsx
+++ b/src/components/dashboard/MainMenu.tsx
@@ -166,7 +166,7 @@ export const MainMenu = ({ value = 'robots', handleChangeContent }: MainMenuProp
           <Divider sx={{ borderColor: theme.palette.mode === 'dark' ? "#080808ff" : "" }} />
           <Box sx={{ display: 'flex', flexDirection: 'column', textAlign: 'left' }}>
             <Button
-              href='https://docs.maxun.dev/sdk/sdk-overview'
+              href='https://docs.maxun.dev/category/sdk'
               target="_blank"
               rel="noopener noreferrer"
               sx={buttonStyles} startIcon={<ArrowForwardIos sx={{ fontSize: 20 }} />}>


### PR DESCRIPTION
What this PR does?

The SDK section was pointing to the wrong doc link. This PR fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * SDK documentation links have been updated to reference the new documentation structure, ensuring users can access the latest SDK resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->