### PR TITLE
fix: duplicate field naming for captured data

### DIFF
--- a/src/components/run/InterpretationLog.tsx
+++ b/src/components/run/InterpretationLog.tsx
@@ -95,6 +95,17 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
       const listStep = browserSteps.find(step => step.id === editingField.listId);
       const actionId = listStep?.actionId;
 
+      if (listStep && listStep.type === 'list') {
+        const newLabel = editingValue.trim();
+        const duplicate = Object.entries(listStep.fields).some(
+          ([key, field]: [string, any]) => key !== editingField.fieldKey && field.label === newLabel
+        );
+        if (duplicate) {
+          notify('error', `A field with the name "${newLabel}" already exists. Please choose a different name.`);
+          return;
+        }
+      }
+
       updateListTextFieldLabel(editingField.listId, editingField.fieldKey, editingValue.trim());
 
       // Emit updated action to backend after state update completes
@@ -241,6 +252,13 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
       const duplicate = screenshotSteps.find(step => step.name === trimmedName);
       if (duplicate) {
         notify('error', `A screenshot with the name "${trimmedName}" already exists. Please choose a different name.`);
+        return true;
+      }
+    } else if (type === 'text') {
+      const textSteps = browserSteps.filter(step => step.type === 'text' && step.id !== stepId);
+      const duplicate = textSteps.find((step: any) => step.label === trimmedName);
+      if (duplicate) {
+        notify('error', `A field with the name "${trimmedName}" already exists. Please choose a different name.`);
         return true;
       }
     }


### PR DESCRIPTION
What this PR does?

It was noticed that on updating the name of any field with a duplicate name, the update was being allowed for capture list and capture text. This PR fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation to prevent duplicate field names when editing list and text fields
  * Added error notifications when attempting to save duplicate field labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->