### PR TITLE
feat: add run status for cli and mcp

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -555,6 +555,9 @@
             "manual_run": "Manuelle Ausführung",
             "scheduled_run": "Geplante Ausführung",
             "api": "API",
+            "sdk": "SDK",
+            "mcp": "MCP",
+            "cli": "CLI",
             "unknown_run_type": "Unbekannter Ausführungstyp"
         },
         "run_status_chips": {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -556,6 +556,8 @@
         "scheduled_run": "Scheduled", 
         "api": "API",
         "sdk": "SDK",
+        "mcp": "MCP",
+        "cli": "CLI",
         "unknown_run_type": "Unknown Run Type"
       },
       "run_status_chips": {

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -555,6 +555,9 @@
       "manual_run": "Ejecución Manual",
       "scheduled_run": "Ejecución Programada",
       "api": "API",
+      "sdk": "SDK",
+      "mcp": "MCP",
+      "cli": "CLI",
       "unknown_run_type": "Tipo de Ejecución Desconocido"
     },
     "run_status_chips": {

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -556,6 +556,9 @@
             "manual_run": "手動実行",
             "scheduled_run": "スケジュール実行",
             "api": "API",
+            "sdk": "SDK",
+            "mcp": "MCP",
+            "cli": "CLI",
             "unknown_run_type": "不明な実行タイプ"
         },
         "run_status_chips": {

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -555,6 +555,9 @@
       "manual_run": "Manuel",
       "scheduled_run": "Zamanlanmış",
       "api": "API",
+      "sdk": "SDK",
+      "mcp": "MCP",
+      "cli": "CLI",
       "unknown_run_type": "Bilinmeyen"
     },
     "run_status_chips": {

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -556,6 +556,9 @@
       "manual_run": "手动运行",
       "scheduled_run": "计划运行",
       "api": "API",
+      "sdk": "SDK",
+      "mcp": "MCP",
+      "cli": "CLI",
       "unknown_run_type": "未知运行类型"
     },
     "run_status_chips": {

--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -340,6 +340,8 @@ function formatRunResponse(run: any) {
         runByScheduleId: run.runByScheduleId,
         runByAPI: run.runByAPI,
         runBySDK: run.runBySDK,
+        runByMCP: run.runByMCP,
+        runByCLI: run.runByCLI,
         data: {
             textData: {},
             listData: {},
@@ -477,7 +479,7 @@ router.get("/robots/:id/runs/:runId", requireAPIKey, async (req: Request, res: R
     }
 });
 
-async function createWorkflowAndStoreMetadata(id: string, userId: string, isSDK: boolean) {
+async function createWorkflowAndStoreMetadata(id: string, userId: string, runSource: 'api' | 'sdk' | 'mcp' | 'cli') {
     try {
         const recording = await Robot.findOne({
             where: {
@@ -522,8 +524,10 @@ async function createWorkflowAndStoreMetadata(id: string, userId: string, isSDK:
             log: '',
             runId,
             runByUserId: userId,
-            runByAPI: !isSDK,
-            runBySDK: isSDK,
+            runByAPI: runSource === 'api',
+            runBySDK: runSource === 'sdk',
+            runByMCP: runSource === 'mcp',
+            runByCLI: runSource === 'cli',
             serializableOutput: {},
             binaryOutput: {},
             retryCount: 0
@@ -1194,11 +1198,11 @@ async function executeRun(id: string, userId: string, requestedFormats?: string[
     }
 }
 
-export async function handleRunRecording(id: string, userId: string, isSDK: boolean = false, requestedFormats?: string[]) {
+export async function handleRunRecording(id: string, userId: string, runSource: 'api' | 'sdk' | 'mcp' | 'cli' = 'api', requestedFormats?: string[]) {
     let socket: Socket | null = null;
 
     try {
-        const result = await createWorkflowAndStoreMetadata(id, userId, isSDK);
+        const result = await createWorkflowAndStoreMetadata(id, userId, runSource);
         const { browserId, runId: newRunId } = result;
 
         if (!browserId || !newRunId || !userId) {
@@ -1378,7 +1382,8 @@ router.post("/robots/:id/runs", requireAPIKey, async (req: AuthenticatedRequest,
         }
 
         const requestedFormats = req.body?.formats;
-        const runId = await handleRunRecording(req.params.id, req.user.id, false, requestedFormats);
+        const runSource = req.headers['x-run-source'] === 'mcp' ? 'mcp' : 'api';
+        const runId = await handleRunRecording(req.params.id, req.user.id, runSource, requestedFormats);
 
         if (!runId) {
             throw new Error('Run ID is undefined');

--- a/server/src/api/sdk.ts
+++ b/server/src/api/sdk.ts
@@ -489,7 +489,8 @@ router.post("/sdk/robots/:id/execute", requireAPIKey, async (req: AuthenticatedR
 
         logger.info(`[SDK] Starting execution for robot ${robotId}`);
 
-        const runId = await handleRunRecording(robotId, user.id.toString(), true);
+        const runSource = req.headers['x-run-source'] === 'cli' ? 'cli' : 'sdk';
+        const runId = await handleRunRecording(robotId, user.id.toString(), runSource);
         if (!runId) {
             throw new Error('Failed to start robot execution');
         }

--- a/server/src/mcp-worker.ts
+++ b/server/src/mcp-worker.ts
@@ -38,6 +38,7 @@ class MaxunMCPWorker {
     const headers = {
       'Content-Type': 'application/json',
       'x-api-key': this.apiKey,
+      'x-run-source': 'mcp',
       ...options.headers
     };
 

--- a/server/src/models/Run.ts
+++ b/server/src/models/Run.ts
@@ -24,6 +24,8 @@ interface RunAttributes {
   runByScheduleId?: string;
   runByAPI?: boolean;
   runBySDK?: boolean;
+  runByMCP?: boolean;
+  runByCLI?: boolean;
   serializableOutput: Record<string, any>;
   binaryOutput: Record<string, string>;
   retryCount?: number;
@@ -47,6 +49,8 @@ class Run extends Model<RunAttributes, RunCreationAttributes> implements RunAttr
   public runByScheduleId!: string;
   public runByAPI!: boolean;
   public runBySDK!: boolean;
+  public runByMCP!: boolean;
+  public runByCLI!: boolean;
   public serializableOutput!: Record<string, any>;
   public binaryOutput!: Record<string, any>;
   public retryCount!: number;
@@ -116,6 +120,14 @@ Run.init(
       allowNull: true,
     },
     runBySDK: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+    },
+    runByMCP: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+    },
+    runByCLI: {
       type: DataTypes.BOOLEAN,
       allowNull: true,
     },

--- a/src/components/run/ColapsibleRow.tsx
+++ b/src/components/run/ColapsibleRow.tsx
@@ -57,12 +57,16 @@ interface RunTypeChipProps {
   runByScheduledId?: string;
   runByAPI: boolean;
   runBySDK?: boolean;
+  runByMCP?: boolean;
+  runByCLI?: boolean;
 }
 
-const RunTypeChip: React.FC<RunTypeChipProps> = ({ runByUserId, runByScheduledId, runByAPI, runBySDK }) => {
+const RunTypeChip: React.FC<RunTypeChipProps> = ({ runByUserId, runByScheduledId, runByAPI, runBySDK, runByMCP, runByCLI }) => {
   const { t } = useTranslation();
 
   if (runByScheduledId) return <Chip label={t('runs_table.run_type_chips.scheduled_run')} color="primary" variant="outlined" />;
+  if (runByCLI) return <Chip label={t('runs_table.run_type_chips.cli')} color="primary" variant="outlined" />;
+  if (runByMCP) return <Chip label={t('runs_table.run_type_chips.mcp')} color="primary" variant="outlined" />;
   if (runBySDK) return <Chip label={t('runs_table.run_type_chips.sdk')} color="primary" variant="outlined" />;
   if (runByAPI) return <Chip label={t('runs_table.run_type_chips.api')} color="primary" variant="outlined" />;
   if (runByUserId) return <Chip label={t('runs_table.run_type_chips.manual_run')} color="primary" variant="outlined" />;
@@ -86,14 +90,18 @@ export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, cu
   const [openSettingsModal, setOpenSettingsModal] = useState(false);
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const runByLabel = row.runByScheduleId
-    ?  `${row.runByScheduleId}`
-      : row.runByUserId
-        ? `${userEmail}`
-        : row.runBySDK
-          ? 'SDK'
-          : row.runByAPI
-            ? 'API'
-            : 'Unknown';
+    ? `${row.runByScheduleId}`
+    : row.runByUserId
+      ? `${userEmail}`
+      : row.runByCLI
+        ? 'CLI'
+        : row.runByMCP
+          ? 'MCP'
+          : row.runBySDK
+            ? 'SDK'
+            : row.runByAPI
+              ? 'API'
+              : 'Unknown';
   
   const logEndRef = useRef<HTMLDivElement | null>(null);
 
@@ -259,6 +267,8 @@ export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, cu
                               runByScheduledId={row.runByScheduleId}
                               runByAPI={row.runByAPI ?? false}
                               runBySDK={row.runBySDK}
+                              runByMCP={row.runByMCP}
+                              runByCLI={row.runByCLI}
                             />
                           </Box>
                         </Box>

--- a/src/components/run/RunsTable.tsx
+++ b/src/components/run/RunsTable.tsx
@@ -57,6 +57,8 @@ export interface Data {
   browserId: string;
   runByAPI?: boolean;
   runBySDK?: boolean;
+  runByMCP?: boolean;
+  runByCLI?: boolean;
   log: string;
   runId: string;
   robotId: string;


### PR DESCRIPTION
What this PR does?

Tracks the run status for MCP and CLI robot runs by updating the database accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for distinguishing runs from CLI and MCP sources. These run origins now display with appropriate labels alongside existing API and SDK source types.

* **Chores**
  * Updated and expanded run-type label translations across German, English, Spanish, Japanese, Turkish, and Chinese language files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->