### PR TITLE
feat: add re-run button to runs table

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -95,6 +95,7 @@
         "finishedAt": "Beendet am",
         "delete": "Löschen",
         "settings": "Einstellungen",
+        "rerun": "Erneut ausführen",
         "search": "Ausführungen suchen...",
         "sort_tooltip": "Zum Sortieren klicken",
         "placeholder": {
@@ -577,7 +578,8 @@
                 "run_by_api": "Ausgeführt durch API",
                 "run_type": "Ausführungstyp"
             }
-        }
+        },
+        "rerun": "Erneut ausführen"
     },
     "run_content": {
         "tabs": {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -95,6 +95,7 @@
       "finishedAt":"Finished At",
       "delete":"Delete",
       "settings":"Settings",
+      "rerun":"Re-run",
       "search":"Search Runs...",
       "sort_tooltip": "Click to sort",
       "placeholder": {
@@ -577,7 +578,8 @@
           "run_by_api": "Run by API",
           "run_type": "Run Type"
         }
-      }
+      },
+      "rerun": "Re-run"
     },
     "run_content": {
       "tabs": {

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -95,6 +95,7 @@
     "finishedAt": "Finalizado el",
     "delete": "Eliminar",
     "settings": "Ajustes",
+    "rerun": "Re-ejecutar",
     "search": "Buscar ejecuciones...",
     "sort_tooltip": "Haga clic para ordenar",
     "placeholder": {
@@ -577,7 +578,8 @@
         "run_by_api": "Ejecutado por API",
         "run_type": "Tipo de Ejecución"
       }
-    }
+    },
+    "rerun": "Re-ejecutar"
   },
   "run_content": {
     "tabs": {

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -95,6 +95,7 @@
         "finishedAt": "終了日時",
         "delete": "削除",
         "settings": "設定",
+        "rerun": "再実行",
         "search": "実行を検索...",
         "sort_tooltip": "クリックして並べ替え",
         "placeholder": {
@@ -578,7 +579,8 @@
                 "run_by_api": "APIによる実行",
                 "run_type": "実行タイプ"
             }
-        }
+        },
+        "rerun": "再実行"
     },
     "run_content": {
         "tabs": {

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -95,6 +95,7 @@
     "finishedAt": "Bitiş",
     "delete": "Sil",
     "settings": "Ayarlar",
+    "rerun": "Yeniden Çalıştır",
     "search": "Çalıştırma Ara...",
     "sort_tooltip": "Sıralamak için tıkla",
     "placeholder": {
@@ -578,7 +579,8 @@
         "run_by_api": "API",
         "run_type": "Tür"
       }
-    }
+    },
+    "rerun": "Yeniden Çalıştır"
   },
   "run_content": {
     "tabs": {

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -95,6 +95,7 @@
     "finishedAt": "结束时间",
     "delete": "删除",
     "settings": "设置",
+    "rerun": "重新运行",
     "search": "搜索运行记录...",
     "sort_tooltip": "点击排序",
     "placeholder": {
@@ -578,7 +579,8 @@
         "run_by_api": "由API运行",
         "run_type": "运行类型"
       }
-    }
+    },
+    "rerun": "重新运行"
   },
   "run_content": {
     "tabs": {

--- a/src/components/run/ColapsibleRow.tsx
+++ b/src/components/run/ColapsibleRow.tsx
@@ -3,13 +3,13 @@ import * as React from "react";
 import TableRow from "@mui/material/TableRow";
 import TableCell from "@mui/material/TableCell";
 import {
-  Box, Collapse, IconButton, Typography, Chip, TextField, Dialog, DialogTitle,
+  Box, Collapse, IconButton, Tooltip, Typography, Chip, TextField, Dialog, DialogTitle,
   DialogContent,
   DialogContentText,
   DialogActions,
 } from "@mui/material";
 import { Button } from "@mui/material";
-import { DeleteForever, KeyboardArrowDown, KeyboardArrowUp, Settings } from "@mui/icons-material";
+import { DeleteForever, KeyboardArrowDown, KeyboardArrowUp, Replay, Settings } from "@mui/icons-material";
 import { deleteRunFromStorage } from "../../api/storage";
 import { columns, Data } from "./RunsTable";
 import { RunContent } from "./RunContent";
@@ -85,10 +85,11 @@ interface CollapsibleRowProps {
   onToggleExpanded: (shouldExpand: boolean) => void;
   currentLog: string;
   abortRunHandler: (runId: string, robotName: string, browserId: string) => void;
+  rerunHandler: (robotMetaId: string, robotName: string, interpreterSettings: any) => void;
   runningRecordingName: string;
   urlRunId: string | null;
 }
-export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, currentLog, abortRunHandler, runningRecordingName, urlRunId }: CollapsibleRowProps) => {
+export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, currentLog, abortRunHandler, rerunHandler, runningRecordingName, urlRunId }: CollapsibleRowProps) => {
   const { t } = useTranslation();
   const theme = useTheme();
   const [isDeleteOpen, setDeleteOpen] = useState(false);
@@ -223,6 +224,22 @@ export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, cu
                     {row.status === 'aborted' && <Chip label={t('runs_table.run_status_chips.aborted')} color="error" variant="outlined" />}
                   </TableCell>
                 )
+              case 'rerun':
+                return (
+                  <TableCell key={column.id} align={column.align}>
+                    {['success', 'failed', 'aborted'].includes(row.status) && (
+                      <Tooltip title={t('runs_table.rerun')}>
+                        <IconButton
+                          aria-label={t('runs_table.rerun')}
+                          size="small"
+                          onClick={() => rerunHandler(row.robotMetaId, row.name, row.interpreterSettings)}
+                        >
+                          <Replay />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                  </TableCell>
+                );
               case 'delete':
                 return (
                   <TableCell key={column.id} align={column.align}>
@@ -288,7 +305,7 @@ export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, cu
         })}
       </TableRow>
       <TableRow>
-        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={6}>
+        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={columns.length}>
           <Collapse in={isOpen} timeout="auto" unmountOnExit>
             <RunContent row={row} abortRunHandler={handleAbort} currentLog={currentLog}
               logEndRef={logEndRef} interpretationInProgress={runningRecordingName === row.name}

--- a/src/components/run/ColapsibleRow.tsx
+++ b/src/components/run/ColapsibleRow.tsx
@@ -3,14 +3,14 @@ import * as React from "react";
 import TableRow from "@mui/material/TableRow";
 import TableCell from "@mui/material/TableCell";
 import {
-  Box, Collapse, IconButton, Typography, Chip, TextField, Dialog, DialogTitle,
+  Box, Collapse, IconButton, Tooltip, Typography, Chip, TextField, Dialog, DialogTitle,
   DialogContent,
   DialogContentText,
   DialogActions,
   CircularProgress,
 } from "@mui/material";
 import { Button } from "@mui/material";
-import { DeleteForever, KeyboardArrowDown, KeyboardArrowUp, Settings } from "@mui/icons-material";
+import { DeleteForever, KeyboardArrowDown, KeyboardArrowUp, Replay, Settings } from "@mui/icons-material";
 import { deleteRunFromStorage, getStoredRun } from "../../api/storage";
 import { columns, Data } from "./RunsTable";
 import { RunContent } from "./RunContent";
@@ -47,10 +47,11 @@ interface CollapsibleRowProps {
   onToggleExpanded: (shouldExpand: boolean) => void;
   currentLog: string;
   abortRunHandler: (runId: string, robotName: string, browserId: string) => void;
+  rerunHandler: (robotMetaId: string, robotName: string, interpreterSettings: any) => void;
   runningRecordingName: string;
   urlRunId: string | null;
 }
-export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, currentLog, abortRunHandler, runningRecordingName, urlRunId }: CollapsibleRowProps) => {
+export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, currentLog, abortRunHandler, rerunHandler, runningRecordingName, urlRunId }: CollapsibleRowProps) => {
   const { t } = useTranslation();
   const theme = useTheme();
   const [isDeleteOpen, setDeleteOpen] = useState(false);
@@ -205,6 +206,22 @@ export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, cu
                     {row.status === 'aborted' && <Chip label={t('runs_table.run_status_chips.aborted')} color="error" variant="outlined" />}
                   </TableCell>
                 )
+              case 'rerun':
+                return (
+                  <TableCell key={column.id} align={column.align}>
+                    {['success', 'failed', 'aborted'].includes(row.status) && (
+                      <Tooltip title={t('runs_table.rerun')}>
+                        <IconButton
+                          aria-label={t('runs_table.rerun')}
+                          size="small"
+                          onClick={() => rerunHandler(row.robotMetaId, row.name, row.interpreterSettings)}
+                        >
+                          <Replay />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                  </TableCell>
+                );
               case 'delete':
                 return (
                   <TableCell key={column.id} align={column.align}>
@@ -297,7 +314,7 @@ export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, cu
         })}
       </TableRow>
       <TableRow>
-        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={6}>
+        <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={columns.length + 1}>
           <Collapse in={isOpen} timeout="auto" unmountOnExit>
             {isLoadingRunDetails ? (
               <Box display="flex" justifyContent="center" py={3}>

--- a/src/components/run/Runs.tsx
+++ b/src/components/run/Runs.tsx
@@ -5,12 +5,13 @@ import { RunsTable } from "./RunsTable";
 interface RunsProps {
   currentInterpretationLog: string;
   abortRunHandler: (runId: string, robotName: string, browserId: string) => void;
+  rerunHandler: (robotMetaId: string, robotName: string, interpreterSettings: any) => void;
   runId: string;
   runningRecordingName: string;
 }
 
 export const Runs = (
-  { currentInterpretationLog, abortRunHandler, runId, runningRecordingName }: RunsProps) => {
+  { currentInterpretationLog, abortRunHandler, rerunHandler, runId, runningRecordingName }: RunsProps) => {
 
   return (
     <Grid container direction="column" sx={{ padding: '30px' }}>
@@ -18,6 +19,7 @@ export const Runs = (
         <RunsTable
           currentInterpretationLog={currentInterpretationLog}
           abortRunHandler={abortRunHandler}
+          rerunHandler={rerunHandler}
           runId={runId}
           runningRecordingName={runningRecordingName}
         />

--- a/src/components/run/RunsTable.tsx
+++ b/src/components/run/RunsTable.tsx
@@ -26,6 +26,7 @@ export const columns: readonly Column[] = [
   { id: 'startedAt', label: 'Started At', minWidth: 80 },
   { id: 'finishedAt', label: 'Finished At', minWidth: 80 },
   { id: 'settings', label: 'Settings', minWidth: 80 },
+  { id: 'rerun', label: 'Re-run', minWidth: 80 },
   { id: 'delete', label: 'Delete', minWidth: 80 },
 ];
 
@@ -39,7 +40,7 @@ interface AccordionSortConfig {
 }
 
 interface Column {
-  id: 'runStatus' | 'name' | 'startedAt' | 'finishedAt' | 'delete' | 'settings';
+  id: 'runStatus' | 'name' | 'startedAt' | 'finishedAt' | 'delete' | 'settings' | 'rerun';
   label: string;
   minWidth?: number;
   align?: 'right';
@@ -71,6 +72,7 @@ export interface Data {
 interface RunsTableProps {
   currentInterpretationLog: string;
   abortRunHandler: (runId: string, robotName: string, browserId: string) => void;
+  rerunHandler: (robotMetaId: string, robotName: string, interpreterSettings: any) => void;
   runId: string;
   runningRecordingName: string;
 }
@@ -85,6 +87,7 @@ interface PaginationState {
 export const RunsTable: React.FC<RunsTableProps> = ({
   currentInterpretationLog,
   abortRunHandler,
+  rerunHandler,
   runId,
   runningRecordingName
 }) => {
@@ -472,11 +475,12 @@ export const RunsTable: React.FC<RunsTableProps> = ({
           onToggleExpanded={(shouldExpand) => handleRowExpand(row.runId, row.robotMetaId, shouldExpand)}
           currentLog={currentInterpretationLog}
           abortRunHandler={abortRunHandler}
+          rerunHandler={rerunHandler}
           runningRecordingName={runningRecordingName}
           urlRunId={urlRunId}
         />
       ));
-  }, [paginationStates, runId, runningRecordingName, currentInterpretationLog, abortRunHandler, handleDelete, accordionSortConfigs]);
+  }, [paginationStates, runId, runningRecordingName, currentInterpretationLog, abortRunHandler, rerunHandler, handleDelete, accordionSortConfigs, expandedRows, handleRowExpand, getPaginationState, urlRunId]);
 
   const renderSortIcon = useCallback((column: Column, robotMetaId: string) => {
     const sortConfig = accordionSortConfigs[robotMetaId];

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -246,6 +246,62 @@ export const MainPage = ({ handleEditRecording, initialContent }: MainPageProps)
     };
   }, []);
 
+  const handleReRunRecording = useCallback((robotMetaId: string, robotName: string, interpreterSettings: RunSettings) => {
+    createAndRunRecording(robotMetaId, interpreterSettings).then((response: CreateRunResponseWithQueue) => {
+      invalidateRuns();
+      const { browserId, runId, queued } = response;
+
+      if (!runId) {
+        notify('error', t('main_page.notifications.run_start_failed', { name: robotName }));
+        return;
+      }
+
+      navigate(`/runs/${robotMetaId}/run/${runId}`);
+
+      if (queued) {
+        setQueuedRuns(prev => new Set([...prev, runId]));
+        notify('info', `Run queued: ${robotName}`);
+      } else {
+        if (!browserId) {
+          notify('error', t('main_page.notifications.run_start_failed', { name: robotName }));
+          return;
+        }
+
+        const socket = io(`${apiUrl}/${browserId}`, {
+          transports: ["websocket", "polling"],
+          rejectUnauthorized: false
+        });
+
+        setSockets(sockets => [...sockets, socket]);
+
+        socket.on('run-completed', (data) => {
+          setRerenderRuns(true);
+          invalidateRuns();
+          if (data.status === 'success') {
+            notify('success', t('main_page.notifications.interpretation_success', { name: robotName }));
+          } else {
+            notify('error', t('main_page.notifications.interpretation_failed', { name: robotName }));
+          }
+        });
+
+        socket.on('connect_error', (error) => {
+          console.log('error', `Failed to connect to browser ${browserId}: ${error}`);
+        });
+
+        socket.on('disconnect', (reason) => {
+          console.log('warn', `Disconnected from browser ${browserId}: ${reason}`);
+        });
+
+        notify('info', t('main_page.notifications.run_started', { name: robotName }));
+      }
+
+      setContent('runs');
+    }).catch((error: any) => {
+      notify('error', t('main_page.notifications.run_start_failed', { name: robotName }));
+      console.error('Error in rerun:', error);
+    });
+  }, [navigate, notify, t, invalidateRuns, setRerenderRuns, setQueuedRuns, setSockets, setContent]);
+
   const handleScheduleRecording = async (settings: ScheduleSettings) => {
     const { message, runId }: ScheduleRunResponse = await scheduleStoredRecording(runningRecordingId, settings);
     if (message === 'success') {
@@ -330,6 +386,7 @@ export const MainPage = ({ handleEditRecording, initialContent }: MainPageProps)
         return <Runs
           currentInterpretationLog={currentInterpretationLog}
           abortRunHandler={abortRunHandler}
+          rerunHandler={handleReRunRecording}
           runId={ids.runId}
           runningRecordingName={runningRecordingName}
         />;


### PR DESCRIPTION
## Summary

- Adds a **Re-run** button (Replay icon) to each row in the runs table
- Button only appears for completed runs (`success`, `failed`, `aborted`) — not for active or queued ones
- Clicking re-triggers the same robot using its original interpreter settings (same `maxConcurrency`, `maxRepeats`, `debug` flags)
- Navigates to the new run's page automatically, just like a fresh run
- Translation key `runs_table.rerun` added for all 6 supported languages (en, de, es, ja, tr, zh)

Closes #687

## Changes

- `ColapsibleRow.tsx` — new `rerun` column case with `Replay` icon, only rendered for terminal run states
- `RunsTable.tsx` — added `rerun` column definition and `rerunHandler` prop
- `Runs.tsx` — threads `rerunHandler` prop down to `RunsTable`
- `MainPage.tsx` — `handleReRunRecording` handler using existing `createAndRunRecording` API
- `public/locales/*.json` — `runs_table.rerun` key in all locales

## Test plan

- [ ] Create a robot and run it to completion
- [ ] Verify the Replay icon appears on `success`, `failed`, and `aborted` runs
- [ ] Verify the Replay icon does NOT appear on `running` or `queued` runs
- [ ] Click Re-run and verify a new run starts and navigates to the run page
- [ ] Verify the re-run uses the same settings as the original run
- [ ] Check UI in a non-English locale to verify the column header is translated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-run completed recordings directly from the runs table via a new Re‑run control; queued reruns show a “run queued” notification and active reruns navigate to the run details.

* **Internationalization**
  * Added Re‑run translations for German, English, Spanish, Japanese, Turkish, and Chinese.

* **Enhancement**
  * UI now surfaces an SDK run type in run listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->