### PR TITLE
fix: stop click propagation on attribute modal option selection

### DIFF
--- a/src/components/browser/BrowserWindow.tsx
+++ b/src/components/browser/BrowserWindow.tsx
@@ -1647,7 +1647,8 @@ export const BrowserWindow = () => {
                     variant="outlined"
                     size="medium"
                     key={option.value}
-                    onClick={() => {
+                    onClick={(e) => {
+                      e.stopPropagation();
                       handleAttributeSelection(option.value);
                     }}
                     style={{


### PR DESCRIPTION
## Summary

The Select Attribute popup sometimes required two clicks to close after selecting a text/link option.

**Root cause**: The option `<Button>` click event was bubbling up to the parent `<div id="browser-window">` which has an `onClick={handleClick}` handler. This re-triggered element selection logic after the modal had already started closing, causing inconsistent behavior.

**Fix**: Add `e.stopPropagation()` to the button's `onClick` in the attribute modal — one line change in `BrowserWindow.tsx`.

Fixes #623

## Test plan

- [ ] Open the recorder on a page with links or images
- [ ] Click on an anchor/image element to trigger the Select Attribute modal
- [ ] Select any option (Text, URL, etc.)
- [ ] Verify the modal closes on the **first** click every time
- [ ] Verify the selected attribute is correctly applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where clicking attribute options in the browser window would not register correctly, preventing proper attribute selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->