### PR TITLE
fix: filter out separators

### DIFF
--- a/src/components/browser/BrowserWindow.tsx
+++ b/src/components/browser/BrowserWindow.tsx
@@ -266,7 +266,9 @@ export const BrowserWindow = () => {
         };
 
         const isValidData = (text: string | null | undefined): boolean => {
-          return !!text && text.trim().length > 0;
+          if (!text) return false;
+          const trimmed = text.trim();
+          return trimmed.length > 0 && /[a-zA-Z0-9\u00C0-\u024F\u4E00-\u9FFF\u3040-\u30FF]/.test(trimmed);
         };
 
         const isElementVisible = (element: HTMLElement): boolean => {

--- a/src/helpers/clientSelectorGenerator.ts
+++ b/src/helpers/clientSelectorGenerator.ts
@@ -614,7 +614,7 @@ class ClientSelectorGenerator {
     }
 
     const text = (element.textContent || "").trim();
-    const hasVisibleText = text.length > 0;
+    const hasVisibleText = text.length > 0 && /[a-zA-Z0-9\u00C0-\u024F\u4E00-\u9FFF\u3040-\u30FF]/.test(text);
 
     if (hasVisibleText || element.querySelector("svg")) {
       return true;


### PR DESCRIPTION
What this PR does?

It was noticed that during auto field generation in capture list punctuation/separator fields were also being added. This PR filters it out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced text validation to more accurately identify meaningful content. Stricter validation rules now ensure only text containing human-readable characters is processed as meaningful, improving data extraction precision and reducing false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->