### PR TITLE
fix: malformed URLs not being processed

### DIFF
--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -38,14 +38,14 @@ const getRobotTargetUrl = (recording: any): string => {
 
     const workflow = recording?.recording?.workflow || [];
     const entryPair = [...workflow].reverse().find((pair: any) =>
-        pair?.what?.some((action: any) => action.action === 'goto' && action.args?.[0])
+        pair?.what?.some((action: any) => action.action === 'goto' && typeof action.args?.[0] === 'string' && action.args[0] !== 'about:blank')
     );
-    const gotoUrl = entryPair?.what?.find((action: any) => action.action === 'goto')?.args?.[0]?.trim();
+    const gotoUrl = entryPair?.what?.find((action: any) => action.action === 'goto' && typeof action.args?.[0] === 'string')?.args?.[0]?.trim();
     if (gotoUrl) {
         return gotoUrl;
     }
 
-    const firstWorkflowUrl = workflow.find((pair: any) => pair?.where?.url && pair.where.url !== 'about:blank')?.where?.url?.trim();
+    const firstWorkflowUrl = workflow.find((pair: any) => typeof pair?.where?.url === 'string' && pair.where.url !== 'about:blank')?.where?.url?.trim();
     return firstWorkflowUrl || '';
 };
 
@@ -1543,6 +1543,11 @@ router.post("/robots/:id/duplicate", requireAPIKey, async (req: Request, res: Re
                 if (!gotoUpdated && action.action === 'goto' && action.args?.[0] === originalEntryUrl) {
                     gotoUpdated = true;
                     return { ...action, args: [normalizedTargetUrl, ...action.args.slice(1)] };
+                }
+                if ((action.action === 'scrape' || action.action === 'crawl') &&
+                    action.args?.[0] && typeof action.args[0] === 'object' &&
+                    action.args[0].url === originalEntryUrl) {
+                    return { ...action, args: [{ ...action.args[0], url: normalizedTargetUrl }, ...action.args.slice(1)] };
                 }
                 return action;
             });

--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -20,6 +20,35 @@ import { convertPageToHTML, convertPageToMarkdown, convertPageToScreenshot } fro
 
 const router = Router();
 
+const normalizeRobotUrl = (rawUrl: string): string => {
+    const normalizedUrl = new URL(rawUrl.trim());
+    if (!['http:', 'https:'].includes(normalizedUrl.protocol)) {
+        throw new Error('Invalid URL protocol');
+    }
+
+    normalizedUrl.search = normalizedUrl.searchParams.toString();
+    return normalizedUrl.toString();
+};
+
+const getRobotTargetUrl = (recording: any): string => {
+    const metaUrl = recording?.recording_meta?.url?.trim();
+    if (metaUrl) {
+        return metaUrl;
+    }
+
+    const workflow = recording?.recording?.workflow || [];
+    const entryPair = [...workflow].reverse().find((pair: any) =>
+        pair?.what?.some((action: any) => action.action === 'goto' && action.args?.[0])
+    );
+    const gotoUrl = entryPair?.what?.find((action: any) => action.action === 'goto')?.args?.[0]?.trim();
+    if (gotoUrl) {
+        return gotoUrl;
+    }
+
+    const firstWorkflowUrl = workflow.find((pair: any) => pair?.where?.url && pair.where.url !== 'about:blank')?.where?.url?.trim();
+    return firstWorkflowUrl || '';
+};
+
 const formatRecording = (recordingData: any) => {
     const recordingMeta = recordingData.recording_meta;
     const workflow = recordingData.recording.workflow || [];
@@ -718,8 +747,7 @@ async function executeRun(id: string, userId: string, requestedFormats?: string[
             });
 
             try {
-                const url = recording.recording_meta.url;
-
+                const url = getRobotTargetUrl(recording);
                 if (!url) {
                     throw new Error('No URL specified for markdown robot');
                 }
@@ -1458,8 +1486,10 @@ router.post("/robots/:id/duplicate", requireAPIKey, async (req: Request, res: Re
             });
         }
 
+        let normalizedTargetUrl: string;
         try {
-            const parsed = new URL(targetUrl);
+            normalizedTargetUrl = normalizeRobotUrl(targetUrl);
+            const parsed = new URL(normalizedTargetUrl);
             if (!['http:', 'https:'].includes(parsed.protocol)) {
                 return res.status(400).json({
                     statusCode: 400,
@@ -1487,7 +1517,7 @@ router.post("/robots/:id/duplicate", requireAPIKey, async (req: Request, res: Re
             });
         }
 
-        const lastWord = targetUrl.split('/').filter(Boolean).pop() || 'Unnamed';
+        const lastWord = normalizedTargetUrl.split('/').filter(Boolean).pop() || 'Unnamed';
 
         const steps: any[] = originalRobot.recording.workflow;
         const entryStep = steps.findLast((step: any) => step.where?.url === 'about:blank');
@@ -1503,7 +1533,7 @@ router.post("/robots/:id/duplicate", requireAPIKey, async (req: Request, res: Re
 
             if (originalEntryUrl && step.where?.url !== 'about:blank' && !whereUpdateStopped) {
                 if (step.where?.url === originalEntryUrl) {
-                    updatedWhere = { ...step.where, url: targetUrl };
+                    updatedWhere = { ...step.where, url: normalizedTargetUrl };
                 } else {
                     whereUpdateStopped = true;
                 }
@@ -1512,7 +1542,7 @@ router.post("/robots/:id/duplicate", requireAPIKey, async (req: Request, res: Re
             const updatedWhat = step.what.map((action: any) => {
                 if (!gotoUpdated && action.action === 'goto' && action.args?.[0] === originalEntryUrl) {
                     gotoUpdated = true;
-                    return { ...action, args: [targetUrl, ...action.args.slice(1)] };
+                    return { ...action, args: [normalizedTargetUrl, ...action.args.slice(1)] };
                 }
                 return action;
             });
@@ -1529,7 +1559,7 @@ router.post("/robots/:id/duplicate", requireAPIKey, async (req: Request, res: Re
                 ...originalRobot.recording_meta,
                 id: uuid(),
                 name: `${originalRobot.recording_meta.name} (${lastWord})`,
-                url: targetUrl,
+                url: normalizedTargetUrl,
                 createdAt: currentTimestamp,
                 updatedAt: currentTimestamp,
             },

--- a/server/src/api/sdk.ts
+++ b/server/src/api/sdk.ts
@@ -31,6 +31,90 @@ interface AuthenticatedRequest extends Request {
 }
 
 /**
+ * Find an existing robot by name scoped to a user or team.
+ */
+const findExistingRobotByName = async (
+    name: string,
+    userId: number
+): Promise<any | null> => {
+    const where: any = { 'recording_meta.name': name, userId };
+    return Robot.findOne({ where });
+};
+
+/**
+ * Normalize a URL for comparison (strip trailing slash, lowercase host).
+ */
+const normalizeUrl = (raw: string): string => {
+    try {
+        const u = new URL(raw);
+        u.search = u.searchParams.toString();
+        return `${u.protocol}//${u.host.toLowerCase()}${u.pathname.replace(/\/$/, '')}${u.search}`;
+    } catch {
+        return raw.toLowerCase().trim();
+    }
+};
+
+const normalizeRobotUrl = (rawUrl: string): string => {
+    const normalizedUrl = new URL(rawUrl.trim());
+    if (!['http:', 'https:'].includes(normalizedUrl.protocol)) {
+        throw new Error('Invalid URL protocol');
+    }
+
+    normalizedUrl.search = normalizedUrl.searchParams.toString();
+    return normalizedUrl.toString();
+};
+
+const normalizeWorkflowUrls = (workflow: any[] = []): any[] =>
+    workflow.map((pair: any) => ({
+        ...pair,
+        where: pair?.where
+            ? {
+                ...pair.where,
+                ...(typeof pair.where.url === 'string' && pair.where.url !== 'about:blank'
+                    ? { url: normalizeRobotUrl(pair.where.url) }
+                    : {}),
+            }
+            : pair?.where,
+        what: Array.isArray(pair?.what)
+            ? pair.what.map((action: any) => {
+                if (
+                    action.action === 'goto' &&
+                    Array.isArray(action.args) &&
+                    typeof action.args[0] === 'string' &&
+                    action.args[0] !== 'about:blank'
+                ) {
+                    return {
+                        ...action,
+                        args: [normalizeRobotUrl(action.args[0]), ...action.args.slice(1)],
+                    };
+                }
+
+                if (
+                    (action.action === 'scrape' || action.action === 'crawl') &&
+                    Array.isArray(action.args) &&
+                    action.args[0] &&
+                    typeof action.args[0] === 'object' &&
+                    typeof action.args[0].url === 'string' &&
+                    action.args[0].url !== 'about:blank'
+                ) {
+                    return {
+                        ...action,
+                        args: [
+                            {
+                                ...action.args[0],
+                                url: normalizeRobotUrl(action.args[0].url),
+                            },
+                            ...action.args.slice(1),
+                        ],
+                    };
+                }
+
+                return action;
+            })
+            : pair?.what,
+    }));
+
+/**
  * Get the status of the authenticated user
  * GET /api/sdk/status
  */
@@ -50,6 +134,12 @@ router.get("/sdk/status", requireAPIKey, async (req: AuthenticatedRequest, res: 
         });
     }
 });
+
+/**
+ * Shallow sort-stable JSON stringify for config comparison.
+ */
+const stableStringify = (obj: any): string =>
+    JSON.stringify(obj, Object.keys(obj ?? {}).sort());
 
 /**
  * Create a new robot programmatically
@@ -86,6 +176,14 @@ router.post("/sdk/robots", requireAPIKey, async (req: AuthenticatedRequest, res:
                     error: "URL is required for scrape robots"
                 });
             }
+
+            try {
+                extractedUrl = normalizeRobotUrl(extractedUrl);
+            } catch {
+                return res.status(400).json({
+                    error: "Invalid URL format"
+                });
+            }
         } else {
             const enrichResult = await WorkflowEnricher.enrichWorkflow(workflowFile.workflow, user.id);
 
@@ -98,12 +196,12 @@ router.post("/sdk/robots", requireAPIKey, async (req: AuthenticatedRequest, res:
                 });
             }
 
-            enrichedWorkflow = enrichResult.workflow!;
-            extractedUrl = enrichResult.url;
+            enrichedWorkflow = normalizeWorkflowUrls(enrichResult.workflow!);
+            extractedUrl = enrichResult.url ? normalizeRobotUrl(enrichResult.url) : undefined;
         }
 
         const rawFormats = (workflowFile.meta as any).formats;
-        const { validFormats, invalidFormats, wasProvided } = parseOutputFormats(
+        const { validFormats, invalidFormats } = parseOutputFormats(
             rawFormats,
             type === 'scrape' ? SCRAPE_OUTPUT_FORMAT_OPTIONS : undefined
         );
@@ -122,20 +220,38 @@ router.post("/sdk/robots", requireAPIKey, async (req: AuthenticatedRequest, res:
                 .find((action: any) => action?.action === 'search');
             const searchMode = searchAction?.args?.[0]?.mode;
 
-            if (searchMode === 'discover') {
-                
+            if (searchMode === 'discover') {      
                 normalizedFormats = validFormats.length > 0 ? validFormats : [];
-            } else {
-                
+            } else {     
                 normalizedFormats = validFormats.length > 0 ? validFormats : [...DEFAULT_OUTPUT_FORMATS];
             }
         } else if (type === 'crawl' || type === 'scrape') {
-            
             normalizedFormats = validFormats.length > 0 ? validFormats : [...DEFAULT_OUTPUT_FORMATS];
         }
 
         const robotId = uuid();
         const metaId = uuid();
+
+        const existingRobot = await findExistingRobotByName(workflowFile.meta.name, user.id);
+        if (existingRobot) {
+            const meta = existingRobot.recording_meta;
+            const sameType = meta.type === type;
+            const sameUrl = normalizeUrl(meta.url || '') === normalizeUrl(extractedUrl || '');
+            const sameFormats = type === 'scrape'
+                ? JSON.stringify([...(meta.formats || [])].sort()) === JSON.stringify([...((workflowFile.meta as any).formats || ['markdown'])].sort())
+                : true;
+
+            if (sameType && sameUrl && sameFormats) {
+                return res.status(200).json({
+                    data: existingRobot,
+                    message: "Existing robot returned",
+                    existing: true
+                });
+            }
+            return res.status(409).json({
+                error: `A robot named "${workflowFile.meta.name}" already exists with a different configuration. Please choose a different name.`
+            });
+        }
 
         const robotMeta: any = {
             name: workflowFile.meta.name,
@@ -155,7 +271,7 @@ router.post("/sdk/robots", requireAPIKey, async (req: AuthenticatedRequest, res:
             userId: user.id,
             recording_meta: robotMeta,
             recording: {
-                workflow: enrichedWorkflow
+                workflow: normalizeWorkflowUrls(enrichedWorkflow)
             }
         });
 
@@ -262,14 +378,47 @@ router.put("/sdk/robots/:id", requireAPIKey, async (req: AuthenticatedRequest, r
 
         if (updates.workflow) {
             updateData.recording = {
-                workflow: updates.workflow
+                workflow: normalizeWorkflowUrls(updates.workflow)
             };
         }
 
         if (updates.meta) {
+            let normalizedMetaUrl: string | undefined;
+            if (updates.meta.url) {
+                try {
+                    normalizedMetaUrl = normalizeRobotUrl(updates.meta.url);
+                } catch {
+                    return res.status(400).json({
+                        error: "Invalid URL format"
+                    });
+                }
+            }
+
+            const workflow = updates.workflow ? normalizeWorkflowUrls(updates.workflow) : JSON.parse(JSON.stringify(robot.recording?.workflow || []));
+            if (normalizedMetaUrl) {
+                workflow.forEach((pair: any) => {
+                    let stepUpdate = false;
+                    pair.what?.forEach((action: any) => {
+                        if (action.action === 'goto' && action.args?.length) {
+                            action.args[0] = normalizedMetaUrl;
+                            stepUpdate = true;
+                        } else if ((action.action === 'scrape' || action.action === 'crawl') && action.args?.[0] && typeof action.args[0] === 'object') {
+                            action.args[0].url = normalizedMetaUrl;
+                            stepUpdate = true;
+                        }
+                    });
+
+                    if (stepUpdate && pair.where?.url && pair.where.url !== 'about:blank') {
+                        pair.where.url = normalizedMetaUrl;
+                    }
+                });
+                updateData.recording = { workflow };
+            }
+
             updateData.recording_meta = {
                 ...robot.recording_meta,
                 ...updates.meta,
+                ...(normalizedMetaUrl ? { url: normalizedMetaUrl } : {}),
                 updatedAt: new Date().toISOString()
             };
         }
@@ -770,8 +919,10 @@ router.post("/sdk/robots/:id/duplicate", requireAPIKey, async (req: Authenticate
             });
         }
 
+        let normalizedTargetUrl: string;
         try {
-            const parsed = new URL(targetUrl);
+            normalizedTargetUrl = normalizeRobotUrl(targetUrl);
+            const parsed = new URL(normalizedTargetUrl);
             if (!['http:', 'https:'].includes(parsed.protocol)) {
                 return res.status(400).json({
                     error: "The \"targetUrl\" must use http or https protocol."
@@ -793,7 +944,7 @@ router.post("/sdk/robots/:id/duplicate", requireAPIKey, async (req: Authenticate
             });
         }
 
-        const lastWord = targetUrl.split('/').filter(Boolean).pop() || 'Unnamed';
+        const lastWord = normalizedTargetUrl.split('/').filter(Boolean).pop() || 'Unnamed';
 
         const steps: any[] = originalRobot.recording.workflow;
         const entryStep = steps.findLast((step: any) => step.where?.url === 'about:blank');
@@ -809,7 +960,7 @@ router.post("/sdk/robots/:id/duplicate", requireAPIKey, async (req: Authenticate
 
             if (originalEntryUrl && step.where?.url !== 'about:blank' && !whereUpdateStopped) {
                 if (step.where?.url === originalEntryUrl) {
-                    updatedWhere = { ...step.where, url: targetUrl };
+                    updatedWhere = { ...step.where, url: normalizedTargetUrl };
                 } else {
                     whereUpdateStopped = true;
                 }
@@ -818,7 +969,7 @@ router.post("/sdk/robots/:id/duplicate", requireAPIKey, async (req: Authenticate
             const updatedWhat = step.what.map((action: any) => {
                 if (!gotoUpdated && action.action === 'goto' && action.args?.[0] === originalEntryUrl) {
                     gotoUpdated = true;
-                    return { ...action, args: [targetUrl, ...action.args.slice(1)] };
+                    return { ...action, args: [normalizedTargetUrl, ...action.args.slice(1)] };
                 }
                 return action;
             });
@@ -835,7 +986,7 @@ router.post("/sdk/robots/:id/duplicate", requireAPIKey, async (req: Authenticate
                 ...originalRobot.recording_meta,
                 id: uuid(),
                 name: `${originalRobot.recording_meta.name} (${lastWord})`,
-                url: targetUrl,
+                url: normalizedTargetUrl,
                 createdAt: currentTimestamp,
                 updatedAt: currentTimestamp,
             },
@@ -885,8 +1036,9 @@ router.post("/sdk/crawl", requireAPIKey, async (req: AuthenticatedRequest, res: 
             });
         }
 
+        let normalizedUrl: string;
         try {
-            new URL(url);
+            normalizedUrl = normalizeRobotUrl(url);
         } catch (err) {
             return res.status(400).json({
                 error: "Invalid URL format"
@@ -911,9 +1063,27 @@ router.post("/sdk/crawl", requireAPIKey, async (req: AuthenticatedRequest, res: 
             ? requestedFormats 
             : [...DEFAULT_OUTPUT_FORMATS];
 
-        const robotName = name || `Crawl Robot - ${new URL(url).hostname}`;
+        const robotName = name || `Crawl Robot - ${new URL(normalizedUrl).hostname}`;
         const robotId = uuid();
         const metaId = uuid();
+
+        const existingRobot = await findExistingRobotByName(robotName, user.id);
+        if (existingRobot) {
+            const existingCrawlArgs = existingRobot.recording?.workflow?.[0]?.what?.[0]?.args?.[0] || {};
+            const sameUrl = normalizeUrl(existingRobot.recording_meta?.url || '') === normalizeUrl(normalizedUrl);
+            const sameConfig = stableStringify(existingCrawlArgs) === stableStringify(crawlConfig);
+
+            if (sameUrl && sameConfig) {
+                return res.status(200).json({
+                    data: existingRobot,
+                    message: "Existing robot returned",
+                    existing: true
+                });
+            }
+            return res.status(409).json({
+                error: `A robot named "${robotName}" already exists with a different configuration. Please choose a different name.`
+            });
+        }
 
         const robot = await Robot.create({
             id: robotId,
@@ -926,13 +1096,13 @@ router.post("/sdk/crawl", requireAPIKey, async (req: AuthenticatedRequest, res: 
                 pairs: 1,
                 params: [],
                 type: 'crawl',
-                url: url,
+                url: normalizedUrl,
                 formats: crawlFormats,
             },
             recording: {
                 workflow: [
                     {
-                        where: { url },
+                        where: { url: normalizedUrl },
                         what: [
                             {
                                 action: 'crawl',
@@ -946,7 +1116,7 @@ router.post("/sdk/crawl", requireAPIKey, async (req: AuthenticatedRequest, res: 
                         what: [
                             {
                                 action: 'goto',
-                                args: [url]
+                                args: [normalizedUrl]
                             },
                             {
                                 action: 'waitForLoadState',
@@ -964,7 +1134,7 @@ router.post("/sdk/crawl", requireAPIKey, async (req: AuthenticatedRequest, res: 
             userId: user.id.toString(),
             robotId: metaId,
             robotName: robotName,
-            url: url,
+            url: normalizedUrl,
             robotType: 'crawl',
             crawlConfig: crawlConfig,
             source: 'sdk',
@@ -1116,7 +1286,7 @@ router.post("/sdk/extract/llm", requireAPIKey, async (req: AuthenticatedRequest,
 
         if (url) {
             try {
-                new URL(url);
+                normalizeRobotUrl(url);
             } catch (err) {
                 return res.status(400).json({
                     error: "Invalid URL format"
@@ -1152,12 +1322,42 @@ router.post("/sdk/extract/llm", requireAPIKey, async (req: AuthenticatedRequest,
         const robotId = uuid();
         const metaId = uuid();
 
+        if (finalUrl) {
+            finalUrl = normalizeRobotUrl(finalUrl);
+        }
+
+        const finalRobotName = robotName || `LLM Extract: ${prompt.substring(0, 50)}`;
+
+        const existingRobot = await findExistingRobotByName(finalRobotName, user.id);
+        if (existingRobot) {
+            const meta = existingRobot.recording_meta;
+            const samePrompt = (meta.description || '') === prompt;
+            const sameUrl = normalizeUrl(meta.url || '') === normalizeUrl(finalUrl);
+
+            if (samePrompt && sameUrl) {
+                return res.status(200).json({
+                    success: true,
+                    data: {
+                        robotId: meta.id,
+                        name: meta.name,
+                        description: meta.description,
+                        url: meta.url,
+                        workflow: existingRobot.recording?.workflow || []
+                    },
+                    existing: true
+                });
+            }
+            return res.status(409).json({
+                error: `A robot named "${finalRobotName}" already exists with a different configuration. Please choose a different name.`
+            });
+        }
+
         const robotMeta: any = {
             name: robotName || `LLM Extract: ${prompt.substring(0, 50)}`,
             id: metaId,
             createdAt: new Date().toISOString(),
             updatedAt: new Date().toISOString(),
-            pairs: workflowResult.workflow.length,
+            pairs: normalizeWorkflowUrls(workflowResult.workflow).length,
             params: [],
             type: 'extract',
             url: finalUrl,
@@ -1169,7 +1369,7 @@ router.post("/sdk/extract/llm", requireAPIKey, async (req: AuthenticatedRequest,
             userId: user.id,
             recording_meta: robotMeta,
             recording: {
-                workflow: workflowResult.workflow
+                workflow: normalizeWorkflowUrls(workflowResult.workflow)
             },
         });
 

--- a/server/src/api/sdk.ts
+++ b/server/src/api/sdk.ts
@@ -23,6 +23,8 @@ import {
     OutputFormat,
     SCRAPE_OUTPUT_FORMAT_OPTIONS,
 } from '../constants/output-formats';
+import sequelizeInstance from '../storage/db';
+import { Op } from 'sequelize';
 
 const router = Router();
 
@@ -37,8 +39,16 @@ const findExistingRobotByName = async (
     name: string,
     userId: number
 ): Promise<any | null> => {
-    const where: any = { 'recording_meta.name': name, userId };
-    return Robot.findOne({ where });
+    const trimmed = name.trim();
+    return Robot.findOne({
+        where: {
+            userId,
+            [Op.and]: sequelizeInstance.where(
+                sequelizeInstance.fn('trim', sequelizeInstance.literal("recording_meta->>'name'")),
+                trimmed
+            ),
+        } as any,
+    });
 };
 
 /**
@@ -382,9 +392,13 @@ router.put("/sdk/robots/:id", requireAPIKey, async (req: AuthenticatedRequest, r
         const updateData: any = {};
 
         if (updates.workflow) {
-            updateData.recording = {
-                workflow: normalizeWorkflowUrls(updates.workflow)
-            };
+            try {
+                updateData.recording = {
+                    workflow: normalizeWorkflowUrls(updates.workflow)
+                };
+            } catch {
+                return res.status(400).json({ error: "Invalid URL in workflow" });
+            }
         }
 
         if (updates.meta) {
@@ -399,7 +413,12 @@ router.put("/sdk/robots/:id", requireAPIKey, async (req: AuthenticatedRequest, r
                 }
             }
 
-            const workflow = updates.workflow ? normalizeWorkflowUrls(updates.workflow) : JSON.parse(JSON.stringify(robot.recording?.workflow || []));
+            let workflow: any[];
+            try {
+                workflow = updates.workflow ? normalizeWorkflowUrls(updates.workflow) : JSON.parse(JSON.stringify(robot.recording?.workflow || []));
+            } catch {
+                return res.status(400).json({ error: "Invalid URL in workflow" });
+            }
             if (normalizedMetaUrl) {
                 workflow.forEach((pair: any) => {
                     let stepUpdate = false;
@@ -1080,10 +1099,12 @@ router.post("/sdk/crawl", requireAPIKey, async (req: AuthenticatedRequest, res: 
         const existingRobot = await findExistingRobotByName(robotName, user.id);
         if (existingRobot) {
             const existingCrawlArgs = existingRobot.recording?.workflow?.[0]?.what?.[0]?.args?.[0] || {};
+            const sameType = existingRobot.recording_meta?.type === 'crawl';
             const sameUrl = normalizeUrl(existingRobot.recording_meta?.url || '') === normalizeUrl(normalizedUrl);
             const sameConfig = stableStringify(existingCrawlArgs) === stableStringify(crawlConfig);
+            const sameFormats = JSON.stringify([...(existingRobot.recording_meta?.formats || [])].sort()) === JSON.stringify([...crawlFormats].sort());
 
-            if (sameUrl && sameConfig) {
+            if (sameType && sameUrl && sameConfig && sameFormats) {
                 return res.status(200).json({
                     data: existingRobot,
                     message: "Existing robot returned",

--- a/server/src/api/sdk.ts
+++ b/server/src/api/sdk.ts
@@ -135,11 +135,16 @@ router.get("/sdk/status", requireAPIKey, async (req: AuthenticatedRequest, res: 
     }
 });
 
-/**
- * Shallow sort-stable JSON stringify for config comparison.
- */
-const stableStringify = (obj: any): string =>
-    JSON.stringify(obj, Object.keys(obj ?? {}).sort());
+const sortDeep = (val: any): any => {
+    if (Array.isArray(val)) return val.map(sortDeep);
+    if (val !== null && typeof val === 'object')
+        return Object.fromEntries(
+            Object.entries(val).sort(([a], [b]) => a.localeCompare(b)).map(([k, v]) => [k, sortDeep(v)])
+        );
+    return val;
+};
+
+const stableStringify = (obj: any): string => JSON.stringify(sortDeep(obj));
 
 /**
  * Create a new robot programmatically
@@ -970,6 +975,11 @@ router.post("/sdk/robots/:id/duplicate", requireAPIKey, async (req: Authenticate
                 if (!gotoUpdated && action.action === 'goto' && action.args?.[0] === originalEntryUrl) {
                     gotoUpdated = true;
                     return { ...action, args: [normalizedTargetUrl, ...action.args.slice(1)] };
+                }
+                if ((action.action === 'scrape' || action.action === 'crawl') &&
+                    action.args?.[0] && typeof action.args[0] === 'object' &&
+                    action.args[0].url === originalEntryUrl) {
+                    return { ...action, args: [{ ...action.args[0], url: normalizedTargetUrl }, ...action.args.slice(1)] };
                 }
                 return action;
             });

--- a/server/src/pgboss-worker.ts
+++ b/server/src/pgboss-worker.ts
@@ -85,14 +85,14 @@ const getRobotTargetUrl = (recording: any): string => {
 
   const workflow = recording?.recording?.workflow || [];
   const entryPair = [...workflow].reverse().find((pair: any) =>
-    pair?.what?.some((action: any) => action.action === 'goto' && action.args?.[0]),
+    pair?.what?.some((action: any) => action.action === 'goto' && typeof action.args?.[0] === 'string' && action.args[0] !== 'about:blank'),
   );
-  const gotoUrl = entryPair?.what?.find((action: any) => action.action === 'goto')?.args?.[0]?.trim();
+  const gotoUrl = entryPair?.what?.find((action: any) => action.action === 'goto' && typeof action.args?.[0] === 'string')?.args?.[0]?.trim();
   if (gotoUrl) {
     return gotoUrl;
   }
 
-  const firstWorkflowUrl = workflow.find((pair: any) => pair?.where?.url && pair.where.url !== 'about:blank')?.where?.url?.trim();
+  const firstWorkflowUrl = workflow.find((pair: any) => typeof pair?.where?.url === 'string' && pair.where.url !== 'about:blank')?.where?.url?.trim();
   return firstWorkflowUrl || '';
 };
 

--- a/server/src/pgboss-worker.ts
+++ b/server/src/pgboss-worker.ts
@@ -77,6 +77,25 @@ function extractJobData<T>(job: Job<T> | Job<T>[]): T {
   return job.data;
 }
 
+const getRobotTargetUrl = (recording: any): string => {
+  const metaUrl = recording?.recording_meta?.url?.trim();
+  if (metaUrl) {
+    return metaUrl;
+  }
+
+  const workflow = recording?.recording?.workflow || [];
+  const entryPair = [...workflow].reverse().find((pair: any) =>
+    pair?.what?.some((action: any) => action.action === 'goto' && action.args?.[0]),
+  );
+  const gotoUrl = entryPair?.what?.find((action: any) => action.action === 'goto')?.args?.[0]?.trim();
+  if (gotoUrl) {
+    return gotoUrl;
+  }
+
+  const firstWorkflowUrl = workflow.find((pair: any) => pair?.where?.url && pair.where.url !== 'about:blank')?.where?.url?.trim();
+  return firstWorkflowUrl || '';
+};
+
 function AddGeneratedFlags(workflow: WorkflowFile) {
   const copy = JSON.parse(JSON.stringify(workflow));
   for (let i = 0; i < workflow.workflow.length; i++) {
@@ -235,7 +254,7 @@ async function processRunExecution(job: Job<ExecuteRunData>) {
         });
 
         try {
-          const url = recording.recording_meta.url;
+          const url = getRobotTargetUrl(recording);
 
           if (!url) {
             throw new Error('No URL specified for markdown robot');

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -396,6 +396,11 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
               gotoUpdated = true;
               return { ...action, args: [normalizeRobotUrl(targetUrl), ...action.args.slice(1)] };
             }
+            if ((action.action === 'scrape' || action.action === 'crawl') &&
+                action.args?.[0] && typeof action.args[0] === 'object' &&
+                action.args[0].url === originalEntryUrl) {
+              return { ...action, args: [{ ...action.args[0], url: normalizeRobotUrl(targetUrl) }, ...action.args.slice(1)] };
+            }
             return action;
           });
 
@@ -827,6 +832,11 @@ router.post('/recordings/:id/duplicate', requireSignIn, async (req: Authenticate
         if (!gotoUpdated && action.action === 'goto' && action.args?.[0] === originalEntryUrl) {
           gotoUpdated = true;
           return { ...action, args: [normalizeRobotUrl(targetUrl), ...action.args.slice(1)] };
+        }
+        if ((action.action === 'scrape' || action.action === 'crawl') &&
+            action.args?.[0] && typeof action.args[0] === 'object' &&
+            action.args[0].url === originalEntryUrl) {
+          return { ...action, args: [{ ...action.args[0], url: normalizeRobotUrl(targetUrl) }, ...action.args.slice(1)] };
         }
         return action;
       });

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -28,6 +28,66 @@ import {
 
 export const router = Router();
 
+const normalizeRobotUrl = (rawUrl: string): string => {
+  const normalizedUrl = new URL(rawUrl.trim());
+  if (!['http:', 'https:'].includes(normalizedUrl.protocol)) {
+    throw new Error('Invalid URL protocol');
+  }
+
+  normalizedUrl.search = normalizedUrl.searchParams.toString();
+  return normalizedUrl.toString();
+};
+
+const normalizeWorkflowUrls = (workflow: any[] = []): any[] =>
+  workflow.map((pair: any) => ({
+    ...pair,
+    where: pair?.where
+      ? {
+          ...pair.where,
+          ...(typeof pair.where.url === 'string' && pair.where.url !== 'about:blank'
+            ? { url: normalizeRobotUrl(pair.where.url) }
+            : {}),
+        }
+      : pair?.where,
+    what: Array.isArray(pair?.what)
+      ? pair.what.map((action: any) => {
+          if (
+            action.action === 'goto' &&
+            Array.isArray(action.args) &&
+            typeof action.args[0] === 'string' &&
+            action.args[0] !== 'about:blank'
+          ) {
+            return {
+              ...action,
+              args: [normalizeRobotUrl(action.args[0]), ...action.args.slice(1)],
+            };
+          }
+
+          if (
+            (action.action === 'scrape' || action.action === 'crawl') &&
+            Array.isArray(action.args) &&
+            action.args[0] &&
+            typeof action.args[0] === 'object' &&
+            typeof action.args[0].url === 'string' &&
+            action.args[0].url !== 'about:blank'
+          ) {
+            return {
+              ...action,
+              args: [
+                {
+                  ...action.args[0],
+                  url: normalizeRobotUrl(action.args[0].url),
+                },
+                ...action.args.slice(1),
+              ],
+            };
+          }
+
+          return action;
+        })
+      : pair?.what,
+  }));
+
 async function isRobotNameTaken(name: string, userId: number, excludeId?: string): Promise<boolean> {
   const normalised = name.trim().toLowerCase();
   const robots = await Robot.findAll({
@@ -297,15 +357,15 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
       if (robot.recording_meta?.type === 'scrape') {
         workflow = workflow.map((step: any) => {
           const updatedWhere = step.where?.url && step.where.url !== 'about:blank'
-            ? { ...step.where, url: targetUrl }
+            ? { ...step.where, url: normalizeRobotUrl(targetUrl) }
             : step.where;
 
           const updatedWhat = (step.what || []).map((action: any) => {
             if (action.action === 'goto' && action.args?.length) {
-              return { ...action, args: [targetUrl, ...action.args.slice(1)] };
+              return { ...action, args: [normalizeRobotUrl(targetUrl), ...action.args.slice(1)] };
             }
             if (action.action === 'scrape' && action.args?.[0] && typeof action.args[0] === 'object') {
-              return { ...action, args: [{ ...action.args[0], url: targetUrl }, ...action.args.slice(1)] };
+              return { ...action, args: [{ ...action.args[0], url: normalizeRobotUrl(targetUrl) }, ...action.args.slice(1)] };
             }
             return action;
           });
@@ -325,7 +385,7 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
           let updatedWhere = step.where;
           if (originalEntryUrl && step.where?.url !== 'about:blank' && !whereUpdateStopped) {
             if (step.where?.url === originalEntryUrl) {
-              updatedWhere = { ...step.where, url: targetUrl };
+              updatedWhere = { ...step.where, url: normalizeRobotUrl(targetUrl) };
             } else {
               whereUpdateStopped = true;
             }
@@ -334,7 +394,7 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
           const updatedWhat = (step.what || []).map((action: any) => {
             if (!gotoUpdated && action.action === 'goto' && action.args?.[0] === originalEntryUrl) {
               gotoUpdated = true;
-              return { ...action, args: [targetUrl, ...action.args.slice(1)] };
+              return { ...action, args: [normalizeRobotUrl(targetUrl), ...action.args.slice(1)] };
             }
             return action;
           });
@@ -425,11 +485,11 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
 
     let updatedMeta = { ...robot.recording_meta };
     if (trimmedName) updatedMeta.name = trimmedName;
-    if (targetUrl) updatedMeta.url = targetUrl;
+    if (targetUrl) updatedMeta.url = normalizeRobotUrl(targetUrl);
     if (normalizedFormats !== undefined) updatedMeta.formats = normalizedFormats;
 
     const updates: any = {
-      recording: { ...robot.recording, workflow },
+      recording: { ...robot.recording, workflow: normalizeWorkflowUrls(workflow) },
       recording_meta: updatedMeta,
     };
 
@@ -470,9 +530,9 @@ router.post('/recordings/scrape', requireSignIn, async (req: AuthenticatedReques
       return res.status(401).send({ error: 'Unauthorized' });
     }
 
-    // Validate URL format
+    let normalizedUrl: string;
     try {
-      new URL(url);
+      normalizedUrl = normalizeRobotUrl(url);
     } catch (err) {
       return res.status(400).json({ error: 'Invalid URL format' });
     }
@@ -490,7 +550,7 @@ router.post('/recordings/scrape', requireSignIn, async (req: AuthenticatedReques
 
     const finalFormats = scrapeFormats.length > 0 ? scrapeFormats : DEFAULT_OUTPUT_FORMATS;
 
-    const robotName = (typeof name === 'string' ? name.trim() : '') || `Markdown Robot - ${new URL(url).hostname}`;
+    const robotName = (typeof name === 'string' ? name.trim() : '') || `Markdown Robot - ${new URL(normalizedUrl).hostname}`;
     if (!robotName) {
       return res.status(400).json({ error: 'Robot name cannot be empty.' });
     }
@@ -517,7 +577,7 @@ router.post('/recordings/scrape', requireSignIn, async (req: AuthenticatedReques
         pairs: 0,
         params: [],
         type: 'scrape',
-        url: url,
+        url: normalizedUrl,
         formats: finalFormats,
       },
       recording: { workflow: [] },
@@ -575,7 +635,7 @@ router.post('/recordings/llm', requireSignIn, async (req: AuthenticatedRequest, 
     // Validate URL format if provided
     if (url) {
       try {
-        new URL(url);
+        normalizeRobotUrl(url);
       } catch (err) {
         return res.status(400).json({ error: 'Invalid URL format' });
       }
@@ -613,6 +673,10 @@ router.post('/recordings/llm', requireSignIn, async (req: AuthenticatedRequest, 
       }
     }
 
+    if (finalUrl) {
+      finalUrl = normalizeRobotUrl(finalUrl);
+    }
+
     if (!workflowResult.success || !workflowResult.workflow) {
       logger.log('error', `Failed to generate workflow: ${JSON.stringify(workflowResult.errors)}`);
       return res.status(400).json({
@@ -632,13 +696,13 @@ router.post('/recordings/llm', requireSignIn, async (req: AuthenticatedRequest, 
         id: robotId,
         createdAt: currentTimestamp,
         updatedAt: currentTimestamp,
-        pairs: workflowResult.workflow.length,
+        pairs: normalizeWorkflowUrls(workflowResult.workflow).length,
         params: [],
         type: 'extract',
         url: finalUrl,
         isLLM: true,
       },
-      recording: { workflow: workflowResult.workflow },
+      recording: { workflow: normalizeWorkflowUrls(workflowResult.workflow) },
       google_sheet_email: null,
       google_sheet_name: null,
       google_sheet_id: null,
@@ -713,8 +777,10 @@ router.post('/recordings/:id/duplicate', requireSignIn, async (req: Authenticate
       return res.status(400).json({ error: 'The "targetUrl" field is required.' });
     }
 
+    let normalizedTargetUrl: string;
     try {
-      const parsed = new URL(targetUrl);
+      normalizedTargetUrl = normalizeRobotUrl(targetUrl);
+      const parsed = new URL(normalizedTargetUrl);
       if (!['http:', 'https:'].includes(parsed.protocol)) {
         return res.status(400).json({ error: 'The "targetUrl" must use http or https protocol.' });
       }
@@ -751,7 +817,7 @@ router.post('/recordings/:id/duplicate', requireSignIn, async (req: Authenticate
 
       if (originalEntryUrl && step.where?.url !== 'about:blank' && !whereUpdateStopped) {
         if (step.where?.url === originalEntryUrl) {
-          updatedWhere = { ...step.where, url: targetUrl };
+          updatedWhere = { ...step.where, url: normalizedTargetUrl };
         } else {
           whereUpdateStopped = true;
         }
@@ -760,7 +826,7 @@ router.post('/recordings/:id/duplicate', requireSignIn, async (req: Authenticate
       const updatedWhat = step.what.map((action: any) => {
         if (!gotoUpdated && action.action === 'goto' && action.args?.[0] === originalEntryUrl) {
           gotoUpdated = true;
-          return { ...action, args: [targetUrl, ...action.args.slice(1)] };
+          return { ...action, args: [normalizeRobotUrl(targetUrl), ...action.args.slice(1)] };
         }
         return action;
       });
@@ -777,7 +843,7 @@ router.post('/recordings/:id/duplicate', requireSignIn, async (req: Authenticate
         ...originalRobot.recording_meta,
         id: uuid(),
         name: duplicateName,
-        url: targetUrl,
+        url: normalizedTargetUrl,
         createdAt: currentTimestamp,
         updatedAt: currentTimestamp,
       },
@@ -1521,13 +1587,14 @@ router.post('/recordings/crawl', requireSignIn, async (req: AuthenticatedRequest
       return res.status(401).send({ error: 'Unauthorized' });
     }
 
+    let normalizedUrl: string;
     try {
-      new URL(url);
+      normalizedUrl = normalizeRobotUrl(url);
     } catch (err) {
       return res.status(400).json({ error: 'Invalid URL format' });
     }
 
-    const robotName = (typeof name === 'string' ? name.trim() : '') || `Crawl Robot - ${new URL(url).hostname}`;
+    const robotName = (typeof name === 'string' ? name.trim() : '') || `Crawl Robot - ${new URL(normalizedUrl).hostname}`;
     if (!robotName) {
       return res.status(400).json({ error: 'Robot name cannot be empty.' });
     }
@@ -1562,13 +1629,13 @@ router.post('/recordings/crawl', requireSignIn, async (req: AuthenticatedRequest
         pairs: 1,
         params: [],
         type: 'crawl',
-        url: url,
+        url: normalizedUrl,
         formats: crawlFormats,
       },
       recording: {
         workflow: [
           {
-            where: { url },
+            where: { url: normalizedUrl },
             what: [
               { action: 'flag', args: ['generated'] },
               {
@@ -1583,7 +1650,7 @@ router.post('/recordings/crawl', requireSignIn, async (req: AuthenticatedRequest
             what: [
               {
                 action: 'goto',
-                args: [url]
+                args: [normalizedUrl]
               },
               {
                 action: 'waitForLoadState',
@@ -1613,7 +1680,7 @@ router.post('/recordings/crawl', requireSignIn, async (req: AuthenticatedRequest
       userId: req.user.id.toString(),
       robotId: robotId,
       robotName: robotName,
-      url: url,
+      url: normalizedUrl,
       robotType: 'crawl',
       crawlConfig: crawlConfig,
       robot_meta: newRobot.recording_meta,

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -89,13 +89,13 @@ const normalizeWorkflowUrls = (workflow: any[] = []): any[] =>
   }));
 
 async function isRobotNameTaken(name: string, userId: number, excludeId?: string): Promise<boolean> {
-  const normalised = name.trim().toLowerCase();
+  const trimmed = name.trim();
   const robots = await Robot.findAll({
     where: {
       userId,
       [Op.and]: sequelizeInstance.where(
-        sequelizeInstance.fn('lower', sequelizeInstance.fn('trim', sequelizeInstance.literal("recording_meta->>'name'"))),
-        normalised
+        sequelizeInstance.fn('trim', sequelizeInstance.literal("recording_meta->>'name'")),
+        trimmed
       ),
     } as any,
   });

--- a/server/src/workflow-management/classes/Generator.ts
+++ b/server/src/workflow-management/classes/Generator.ts
@@ -19,6 +19,66 @@ import { v4 as uuid } from "uuid";
 import { capture } from "../../utils/analytics"
 import { decrypt, encrypt } from "../../utils/auth";
 
+const normalizeRobotUrl = (rawUrl: string): string => {
+  const normalizedUrl = new URL(rawUrl.trim());
+  if (!['http:', 'https:'].includes(normalizedUrl.protocol)) {
+    throw new Error('Invalid URL protocol');
+  }
+
+  normalizedUrl.search = normalizedUrl.searchParams.toString();
+  return normalizedUrl.toString();
+};
+
+const normalizeWorkflowUrls = (workflow: any[] = []): any[] =>
+  workflow.map((pair: any) => ({
+    ...pair,
+    where: pair?.where
+      ? {
+          ...pair.where,
+          ...(typeof pair.where.url === 'string' && pair.where.url !== 'about:blank'
+            ? { url: normalizeRobotUrl(pair.where.url) }
+            : {}),
+        }
+      : pair?.where,
+    what: Array.isArray(pair?.what)
+      ? pair.what.map((action: any) => {
+          if (
+            action.action === 'goto' &&
+            Array.isArray(action.args) &&
+            typeof action.args[0] === 'string' &&
+            action.args[0] !== 'about:blank'
+          ) {
+            return {
+              ...action,
+              args: [normalizeRobotUrl(action.args[0]), ...action.args.slice(1)],
+            };
+          }
+
+          if (
+            (action.action === 'scrape' || action.action === 'crawl') &&
+            Array.isArray(action.args) &&
+            action.args[0] &&
+            typeof action.args[0] === 'object' &&
+            typeof action.args[0].url === 'string' &&
+            action.args[0].url !== 'about:blank'
+          ) {
+            return {
+              ...action,
+              args: [
+                {
+                  ...action.args[0],
+                  url: normalizeRobotUrl(action.args[0].url),
+                },
+                ...action.args.slice(1),
+              ],
+            };
+          }
+
+          return action;
+        })
+      : pair?.what,
+  }));
+
 interface PersistedGeneratedData {
   lastUsedSelector: string;
   lastIndex: number | null;
@@ -990,11 +1050,15 @@ export class WorkflowGenerator {
         const robot = await Robot.findOne({ where: { 'recording_meta.id': robotId }});
 
         if (robot) {
+          const normalizedRecording = {
+            ...recording,
+            workflow: normalizeWorkflowUrls(recording.workflow),
+          };
           await robot.update({
-            recording: recording,
+            recording: normalizedRecording,
             recording_meta: {
               ...robot.recording_meta,
-              pairs: recording.workflow.length,
+              pairs: normalizedRecording.workflow.length,
               params: this.getParams() || [],
               updatedAt: new Date().toLocaleString(),
             },
@@ -1004,6 +1068,10 @@ export class WorkflowGenerator {
           logger.log('info', `Robot retrained with id: ${robot.id}`);
         }
       } else {
+        const normalizedRecording = {
+          ...recording,
+          workflow: normalizeWorkflowUrls(recording.workflow),
+        };
         const trimmedFileName = fileName.trim();
         if (!trimmedFileName) {
           this.socket.emit('fileSaved', { actionType: 'error' });
@@ -1024,7 +1092,7 @@ export class WorkflowGenerator {
           name: trimmedFileName,
           id: uuid(),
           createdAt: this.recordingMeta.createdAt || new Date().toLocaleString(),
-          pairs: recording.workflow.length,
+          pairs: normalizedRecording.workflow.length,
           updatedAt: new Date().toLocaleString(),
           params: this.getParams() || [],
           type: this.recordingMeta.type || 'extract',
@@ -1033,7 +1101,7 @@ export class WorkflowGenerator {
         const robot = await Robot.create({
           userId,
           recording_meta: this.recordingMeta,
-          recording: recording,
+          recording: normalizedRecording,
         });
         capture(
           'maxun-oss-robot-created',

--- a/server/src/workflow-management/scheduler/index.ts
+++ b/server/src/workflow-management/scheduler/index.ts
@@ -17,6 +17,25 @@ import { convertPageToMarkdown, convertPageToHTML, convertPageToScreenshot } fro
 import { processRobotOutputFormats } from "../../utils/output-post-processor";
 import { getInterpretationFailureReason, hasExpectedRobotOutput } from "../../utils/output-validation";
 
+const getRobotTargetUrl = (recording: any): string => {
+  const metaUrl = recording?.recording_meta?.url?.trim();
+  if (metaUrl) {
+    return metaUrl;
+  }
+
+  const workflow = recording?.recording?.workflow || [];
+  const entryPair = [...workflow].reverse().find((pair: any) =>
+    pair?.what?.some((action: any) => action.action === 'goto' && action.args?.[0]),
+  );
+  const gotoUrl = entryPair?.what?.find((action: any) => action.action === 'goto')?.args?.[0]?.trim();
+  if (gotoUrl) {
+    return gotoUrl;
+  }
+
+  const firstWorkflowUrl = workflow.find((pair: any) => pair?.where?.url && pair.where.url !== 'about:blank')?.where?.url?.trim();
+  return firstWorkflowUrl || '';
+};
+
 async function createWorkflowAndStoreMetadata(id: string, userId: string) {
   try {
     const recording = await Robot.findOne({
@@ -261,8 +280,7 @@ async function executeRun(id: string, userId: string) {
       }
 
       try {
-        const url = recording.recording_meta.url;
-
+        const url = getRobotTargetUrl(recording);
         if (!url) {
           throw new Error('No URL specified for markdown robot');
         }

--- a/server/src/workflow-management/scheduler/index.ts
+++ b/server/src/workflow-management/scheduler/index.ts
@@ -25,14 +25,14 @@ const getRobotTargetUrl = (recording: any): string => {
 
   const workflow = recording?.recording?.workflow || [];
   const entryPair = [...workflow].reverse().find((pair: any) =>
-    pair?.what?.some((action: any) => action.action === 'goto' && action.args?.[0]),
+    pair?.what?.some((action: any) => action.action === 'goto' && typeof action.args?.[0] === 'string' && action.args[0] !== 'about:blank'),
   );
-  const gotoUrl = entryPair?.what?.find((action: any) => action.action === 'goto')?.args?.[0]?.trim();
+  const gotoUrl = entryPair?.what?.find((action: any) => action.action === 'goto' && typeof action.args?.[0] === 'string')?.args?.[0]?.trim();
   if (gotoUrl) {
     return gotoUrl;
   }
 
-  const firstWorkflowUrl = workflow.find((pair: any) => pair?.where?.url && pair.where.url !== 'about:blank')?.where?.url?.trim();
+  const firstWorkflowUrl = workflow.find((pair: any) => typeof pair?.where?.url === 'string' && pair.where.url !== 'about:blank')?.where?.url?.trim();
   return firstWorkflowUrl || '';
 };
 


### PR DESCRIPTION
What this PR does?

1. It was noticed that the actual run preprocessing had stricter URL validation checks which failed the entire run. This PR fixes the bug.
2. Brings in existing robot check routes for SDK so no new robot creation happens if a robot with same name already exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent URL validation and canonicalization across robots, recordings, and workflows; invalid protocols are rejected.
  * Scrape/export flows now reliably derive and use the correct target URL when converting runs.
  * Duplication and update flows now correctly rewrite nested scrape/crawl entry URLs when a target URL changes.

* **New Features**
  * Creation/duplication endpoints are idempotent: identical normalized robots return existing entries instead of creating duplicates.
  * Workflow URLs (including embedded step args) are automatically normalized and rewritten during save/duplicate operations.

* **Refactor**
  * Centralized URL normalization and workflow URL rewriting for consistent persisted data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->