### PR TITLE
feat: add text content support for scrape

### DIFF
--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -16,7 +16,7 @@ import { WorkflowFile } from "maxun-core";
 import { addGoogleSheetUpdateTask, processGoogleSheetUpdates } from "../workflow-management/integrations/gsheet";
 import { addAirtableUpdateTask, processAirtableUpdates } from "../workflow-management/integrations/airtable";
 import { sendWebhook } from "../routes/webhook";
-import { convertPageToHTML, convertPageToMarkdown, convertPageToScreenshot } from '../markdownify/scrape';
+import { convertPageToHTML, convertPageToMarkdown, convertPageToScreenshot, convertPageToText } from '../markdownify/scrape';
 
 const router = Router();
 
@@ -726,10 +726,26 @@ async function executeRun(id: string, userId: string, requestedFormats?: string[
 
                 let markdown = '';
                 let html = '';
+                let text = '';
                 const serializableOutput: any = {};
                 const binaryOutput: any = {};
 
                 const SCRAPE_TIMEOUT = 120000;
+
+                if (formats.includes('text')) {
+                    try {
+                        const textPromise = convertPageToText(url, currentPage);
+                        const timeoutPromise = new Promise<never>((_, reject) => {
+                            setTimeout(() => reject(new Error(`Text conversion timed out after ${SCRAPE_TIMEOUT / 1000}s`)), SCRAPE_TIMEOUT);
+                        });
+                        text = await Promise.race([textPromise, timeoutPromise]);
+                        if (text && text.trim().length > 0) {
+                            serializableOutput.text = [{ content: text }];
+                        }
+                    } catch (error: any) {
+                        logger.log('warn', `Text conversion failed for API run ${plainRun.runId}: ${error.message}`);
+                    }
+                }
 
                 if (formats.includes('markdown')) {
                     try {

--- a/server/src/constants/output-formats.ts
+++ b/server/src/constants/output-formats.ts
@@ -11,6 +11,7 @@ export type OutputFormat = (typeof OUTPUT_FORMAT_OPTIONS)[number];
 export const SCRAPE_OUTPUT_FORMAT_OPTIONS: OutputFormat[] = [
   'markdown',
   'html',
+  'text',
   'screenshot-visible',
   'screenshot-fullpage',
 ];

--- a/server/src/markdownify/scrape.ts
+++ b/server/src/markdownify/scrape.ts
@@ -124,6 +124,25 @@ export async function convertPageToHTML(url: string, page: Page): Promise<string
   }
 }
 
+export async function convertPageToText(url: string, page: Page): Promise<string> {
+  try {
+    logger.log('info', `[Scrape] Using existing page instance for text conversion of ${url}`);
+
+    await gotoWithFallback(page, url);
+
+    const text = await page.evaluate(() => {
+      const body = document.body;
+      if (!body) return '';
+      return body.innerText || body.textContent || '';
+    });
+
+    return text ? text.trim() : '';
+  } catch (error: any) {
+    logger.error(`[Scrape] Error during text conversion: ${error.message}`);
+    throw error;
+  }
+}
+
 /**
  * Takes a screenshot of the page
  * @param url - The URL to screenshot

--- a/server/src/pgboss-worker.ts
+++ b/server/src/pgboss-worker.ts
@@ -20,7 +20,7 @@ import { addAirtableUpdateTask, airtableUpdateTasks, processAirtableUpdates } fr
 import { io as serverIo } from "./server";
 import { sendWebhook } from './routes/webhook';
 import { BinaryOutputService } from './storage/mino';
-import { convertPageToMarkdown, convertPageToHTML, convertPageToScreenshot } from './markdownify/scrape';
+import { convertPageToMarkdown, convertPageToHTML, convertPageToScreenshot, convertPageToText } from './markdownify/scrape';
 import { processRobotOutputFormats } from './utils/output-post-processor';
 import { getInterpretationFailureReason, hasExpectedRobotOutput } from './utils/output-validation';
 
@@ -243,10 +243,20 @@ async function processRunExecution(job: Job<ExecuteRunData>) {
 
           let markdown = '';
           let html = '';
+          let text = '';
           const serializableOutput: any = {};
           const binaryOutput: any = {};
 
           const SCRAPE_TIMEOUT = 120000;
+
+          if (formats.includes('text')) {
+            const textPromise = convertPageToText(url, currentPage);
+            const timeoutPromise = new Promise<never>((_, reject) => {
+              setTimeout(() => reject(new Error(`Text conversion timed out after ${SCRAPE_TIMEOUT/1000}s`)), SCRAPE_TIMEOUT);
+            });
+            text = await Promise.race([textPromise, timeoutPromise]);
+            if (text) serializableOutput.text = [{ content: text }];
+          }
 
           if (formats.includes('markdown')) {
             const markdownPromise = convertPageToMarkdown(url, currentPage);

--- a/server/src/workflow-management/scheduler/index.ts
+++ b/server/src/workflow-management/scheduler/index.ts
@@ -13,7 +13,7 @@ import { WorkflowFile } from "maxun-core";
 import { Page } from "playwright-core";
 import { sendWebhook } from "../../routes/webhook";
 import { addAirtableUpdateTask, airtableUpdateTasks, processAirtableUpdates } from "../integrations/airtable";
-import { convertPageToMarkdown, convertPageToHTML, convertPageToScreenshot } from "../../markdownify/scrape";
+import { convertPageToMarkdown, convertPageToHTML, convertPageToScreenshot, convertPageToText } from "../../markdownify/scrape";
 import { processRobotOutputFormats } from "../../utils/output-post-processor";
 import { getInterpretationFailureReason, hasExpectedRobotOutput } from "../../utils/output-validation";
 
@@ -269,12 +269,21 @@ async function executeRun(id: string, userId: string) {
 
         let markdown = '';
         let html = '';
+        let text = '';
         const serializableOutput: any = {};
         const binaryOutput: any = {};
 
         const SCRAPE_TIMEOUT = 120000;
 
-        // Markdown conversion
+        if (formats.includes("text")) {
+          const textPromise = convertPageToText(url, currentPage);
+          const timeoutPromise = new Promise<never>((_, reject) => {
+            setTimeout(() => reject(new Error(`Text conversion timed out after ${SCRAPE_TIMEOUT/1000}s`)), SCRAPE_TIMEOUT);
+          });
+          text = await Promise.race([textPromise, timeoutPromise]);
+          if (text) serializableOutput.text = [{ content: text }];
+        }
+
         if (formats.includes("markdown")) {
           const markdownPromise = convertPageToMarkdown(url, currentPage);
           const timeoutPromise = new Promise<never>((_, reject) => {

--- a/src/components/robot/pages/RobotCreate.tsx
+++ b/src/components/robot/pages/RobotCreate.tsx
@@ -763,6 +763,7 @@ const RobotCreate: React.FC = () => {
                         const OUTPUT_FORMAT_LABELS: Record<string, string> = {
                           markdown: 'Markdown',
                           html: 'HTML',
+                          text: 'Text Content',
                           'screenshot-visible': 'Screenshot (Visible)',
                           'screenshot-fullpage': 'Screenshot (Full Page)',
                         };
@@ -805,6 +806,10 @@ const RobotCreate: React.FC = () => {
                       <MenuItem value="html">
                         <Checkbox checked={outputFormats.includes('html')} />
                         HTML
+                      </MenuItem>
+                      <MenuItem value="text">
+                        <Checkbox checked={outputFormats.includes('text')} />
+                        Text Content
                       </MenuItem>
                       <MenuItem value="screenshot-visible">
                         <Checkbox checked={outputFormats.includes('screenshot-visible')} />

--- a/src/components/run/RunContent.tsx
+++ b/src/components/run/RunContent.tsx
@@ -45,6 +45,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
   const [tab, setTab] = React.useState<string>('output');
   const [markdownContent, setMarkdownContent] = useState<string>('');
   const [htmlContent, setHtmlContent] = useState<string>('');
+  const [textContent, setTextContent] = useState<string>('');
 
   const [schemaData, setSchemaData] = useState<any[]>([]);
   const [schemaColumns, setSchemaColumns] = useState<string[]>([]);
@@ -94,19 +95,42 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
   useEffect(() => {
     setMarkdownContent('');
     setHtmlContent('');
+    setTextContent('');
 
-    if (row.serializableOutput?.markdown && Array.isArray(row.serializableOutput.markdown)) {
-      const markdownData = row.serializableOutput.markdown[0];
-      if (markdownData?.content) {
-        setMarkdownContent(markdownData.content);
-      }
-    }
+    if (!row.serializableOutput) return;
 
-    if (row.serializableOutput?.html && Array.isArray(row.serializableOutput.html)) {
-      const htmlData = row.serializableOutput.html[0];
-      if (htmlData?.content) {
-        setHtmlContent(htmlData.content);
+    const extractFromOutput = (output: any) => {
+      if (output?.markdown && Array.isArray(output.markdown)) {
+        const markdownData = output.markdown[0];
+        if (markdownData?.content) setMarkdownContent(markdownData.content);
       }
+
+      if (output?.html && Array.isArray(output.html)) {
+        const htmlData = output.html[0];
+        if (htmlData?.content) setHtmlContent(htmlData.content);
+      }
+
+      const textOutput = output?.textContent || output?.text;
+      if (textOutput) {
+        if (Array.isArray(textOutput)) {
+          const textData = textOutput[0];
+          if (typeof textData === 'string') {
+            setTextContent(textData);
+          } else if (textData && typeof textData === 'object' && textData.content) {
+            setTextContent(textData.content);
+          } else if (textData && typeof textData === 'object' && textData.text) {
+            setTextContent(textData.text);
+          }
+        } else if (typeof textOutput === 'string') {
+          setTextContent(textOutput);
+        }
+      }
+    };
+
+    extractFromOutput(row.serializableOutput);
+
+    if (row.serializableOutput.scrape) {
+      extractFromOutput(row.serializableOutput.scrape);
     }
   }, [row.serializableOutput]);
 
@@ -1070,6 +1094,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
   const hasScreenshots = row.binaryOutput && Object.keys(row.binaryOutput).length > 0;
   const hasMarkdown = markdownContent.length > 0;
   const hasHTML = htmlContent.length > 0;
+  const hasTextFormat = textContent.length > 0;
   const hasCrawlPageScreenshots = crawlData.some(group => Array.isArray(group) && group.some((item: any) => item?.screenshotVisible || item?.screenshotFullpage));
   const hasSearchResultScreenshots = searchData.some((item: any) => item?.screenshotVisible || item?.screenshotFullpage);
   const showCapturedScreenshotSection = hasScreenshots && !hasCrawlPageScreenshots && !hasSearchResultScreenshots;
@@ -1078,7 +1103,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
     <Box sx={{ width: '100%' }}>
       <TabContext value={tab}>
         <TabPanel value='output' sx={{ width: '100%', maxWidth: '900px' }}>
-          {hasMarkdown || hasHTML ? (
+          {hasMarkdown || hasHTML || hasTextFormat ? (
             <>
               {hasMarkdown && (
                 <Accordion defaultExpanded sx={{ mb: 2 }}>
@@ -1133,6 +1158,39 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                         sx={{ color: '#FF00C3', textTransform: 'none' }}
                       >
                         Download HTML
+                      </Button>
+                    </Box>
+                  </AccordionDetails>
+                </Accordion>
+              )}
+
+              {hasTextFormat && (
+                <Accordion defaultExpanded sx={{ mb: 2 }}>
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                    <Typography variant='h6'>Text Content</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <Paper sx={{ p: 2, maxHeight: '500px', overflow: 'auto', backgroundColor: darkMode ? '#1e1e1e' : '#f5f5f5' }}>
+                      <Typography component="pre" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontFamily: 'monospace', fontSize: '0.875rem', m: 0 }}>
+                        {textContent}
+                      </Typography>
+                    </Paper>
+                    <Box sx={{ mt: 2 }}>
+                      <Button
+                        onClick={() => {
+                          const blob = new Blob([textContent], { type: 'text/plain;charset=utf-8;' });
+                          const url = URL.createObjectURL(blob);
+                          const a = document.createElement('a');
+                          a.href = url;
+                          a.download = 'output.txt';
+                          document.body.appendChild(a);
+                          a.click();
+                          document.body.removeChild(a);
+                          setTimeout(() => URL.revokeObjectURL(url), 100);
+                        }}
+                        sx={{ color: '#FF00C3', textTransform: 'none' }}
+                      >
+                        Download Text
                       </Button>
                     </Box>
                   </AccordionDetails>


### PR DESCRIPTION
What this PR does?

Adds the text content format for scrape robot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Text" as a selectable output format for scrape robots to extract plain page text.
  * Run results now include a Text Content view with a preformatted display and a "Download Text" button to save as .txt.
  * Text extraction is subject to the same timeout protection as other scrape output formats to maintain reliable execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->