### PR TITLE
fix: add texts on confirm capture

### DIFF
--- a/src/components/run/InterpretationLog.tsx
+++ b/src/components/run/InterpretationLog.tsx
@@ -15,11 +15,10 @@ import StorageIcon from '@mui/icons-material/Storage';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import CloseIcon from '@mui/icons-material/Close';
 import CheckIcon from '@mui/icons-material/Check';
-import { SidePanelHeader } from '../recorder/SidePanelHeader';
 import { useGlobalInfoStore } from '../../context/globalInfo';
 import { useThemeMode } from '../../context/theme-provider';
 import { useTranslation } from 'react-i18next';
-import { useBrowserSteps } from '../../context/browserSteps';
+import { useBrowserSteps, ListStep, TextStep, ScreenshotStep } from '../../context/browserSteps';
 import { useActionContext } from '../../context/browserActions';
 import { useSocketStore } from '../../context/socket';
 
@@ -31,9 +30,11 @@ interface InterpretationLogProps {
 export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, setIsOpen }) => {
   const { t } = useTranslation();
 
-  const [captureListData, setCaptureListData] = useState<any[]>([]);
-  const [captureTextData, setCaptureTextData] = useState<any[]>([]);
-  const [screenshotData, setScreenshotData] = useState<string[]>([]);
+  const { browserSteps, updateListTextFieldLabel, removeListTextField, updateListStepName, updateScreenshotStepName, updateBrowserTextStepLabel, deleteBrowserStep, deleteStepsByActionId, emitForStepId } = useBrowserSteps();
+  const { captureStage, getText, stopGetList, stopPaginationMode, stopLimitMode, setShowPaginationOptions, setShowLimitOptions, setCaptureStage } = useActionContext();
+  const { socket } = useSocketStore();
+  const { browserWidth, outputPreviewWidth } = useBrowserDimensionsStore();
+  const { currentWorkflowActionsState, shouldResetInterpretationLog, currentTextGroupName, setCurrentTextGroupName, notify, currentTextActionId, currentListActionId, setCurrentListActionId } = useGlobalInfoStore();
 
   const [activeTab, setActiveTab] = useState(0);
   const [activeListTab, setActiveListTab] = useState(0);
@@ -58,18 +59,31 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
   const previousGetText = useRef<boolean>(false);
   const autoFocusedScreenshotIndices = useRef<Set<number>>(new Set());
 
-  const { browserSteps, updateListTextFieldLabel, removeListTextField, updateListStepName, updateScreenshotStepName, updateBrowserTextStepLabel, deleteBrowserStep, deleteStepsByActionId, emitForStepId } = useBrowserSteps();
-  const { captureStage, getText } = useActionContext();
-  const { socket } = useSocketStore();
-
-  const { browserWidth, outputPreviewHeight, outputPreviewWidth } = useBrowserDimensionsStore();
-  const { currentWorkflowActionsState, shouldResetInterpretationLog, currentTextGroupName, setCurrentTextGroupName, notify } = useGlobalInfoStore();
-
   const [showPreviewData, setShowPreviewData] = useState<boolean>(false);
   const userClosedDrawer = useRef<boolean>(false);
   const lastListDataLength = useRef<number>(0);
   const lastTextDataLength = useRef<number>(0);
   const lastScreenshotDataLength = useRef<number>(0);
+
+  const captureListData = React.useMemo(() => 
+    browserSteps.filter((step): step is ListStep => step.type === 'list')
+  , [browserSteps]);
+
+  const browserStepsRef = useRef(browserSteps);
+
+  const captureTextData = React.useMemo(() =>
+    browserSteps.filter((step): step is TextStep =>
+      step.type === 'text' && !(getText && step.actionId === currentTextActionId)
+    )
+  , [browserSteps, getText, currentTextActionId]);
+
+  const screenshotData = React.useMemo(() => {
+    const screenshotSteps = browserSteps.filter((step): step is ScreenshotStep =>
+      step.type === 'screenshot'
+    );
+
+    return screenshotSteps.filter(step => step.screenshotData).map(step => step.screenshotData!);
+  }, [browserSteps]);
 
   const toggleDrawer = (newOpen: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {
     if (
@@ -92,7 +106,7 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
 
   const handleSaveEdit = () => {
     if (editingField && editingValue.trim()) {
-      const listStep = browserSteps.find(step => step.id === editingField.listId);
+      const listStep = browserStepsRef.current.find(step => step.id === editingField.listId);
       const actionId = listStep?.actionId;
 
       if (listStep && listStep.type === 'list') {
@@ -108,7 +122,6 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
 
       updateListTextFieldLabel(editingField.listId, editingField.fieldKey, editingValue.trim());
 
-      // Emit updated action to backend after state update completes
       if (actionId) {
         setTimeout(() => emitForStepId(actionId), 0);
       }
@@ -129,10 +142,74 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
 
     removeListTextField(listId, fieldKey);
 
-    // Emit updated action to backend after state update completes
     if (actionId) {
       setTimeout(() => emitForStepId(actionId), 0);
     }
+  };
+
+  const checkForDuplicateName = (stepId: number, type: 'list' | 'text' | 'screenshot', newName: string): boolean => {
+    const trimmedName = newName.trim();
+
+    if (type === 'list') {
+      const listSteps = browserSteps.filter(step => step.type === 'list' && step.id !== stepId);
+      const duplicate = listSteps.find(step => step.name === trimmedName);
+      if (duplicate) {
+        notify('error', `A list with the name "${trimmedName}" already exists. Please choose a different name.`);
+        return true;
+      }
+    } else if (type === 'screenshot') {
+      const screenshotSteps = browserSteps.filter(step => step.type === 'screenshot' && step.id !== stepId);
+      const duplicate = screenshotSteps.find(step => step.name === trimmedName);
+      if (duplicate) {
+        notify('error', `A screenshot with the name "${trimmedName}" already exists. Please choose a different name.`);
+        return true;
+      }
+    } else if (type === 'text') {
+      const textSteps = browserSteps.filter(step => step.type === 'text' && step.id !== stepId);
+      const duplicate = textSteps.find((step: any) => step.label === trimmedName);
+      if (duplicate) {
+        notify('error', `A field with the name "${trimmedName}" already exists. Please choose a different name.`);
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  const startEdit = (stepId: number, type: 'list' | 'text' | 'screenshot', currentValue: string) => {
+    setEditing({ stepId, type, value: currentValue });
+  };
+
+  const saveEdit = () => {
+    const { stepId, type, value } = editing;
+    if (stepId == null || !type) return;
+
+    const finalValue = value.trim();
+    if (!finalValue) {
+      setEditing({ stepId: null, type: null, value: '' });
+      return;
+    }
+
+    if (checkForDuplicateName(stepId, type, finalValue)) {
+      return;
+    }
+
+    if (type === 'list') {
+      updateListStepName(stepId, finalValue);
+    } else if (type === 'text') {
+      updateBrowserTextStepLabel(stepId, finalValue);
+    } else if (type === 'screenshot') {
+      updateScreenshotStepName(stepId, finalValue);
+    }
+
+    const step = browserSteps.find(s => s.id === stepId);
+    if (step?.actionId) setTimeout(() => emitForStepId(step.actionId!), 0);
+
+    setEditing({ stepId: null, type: null, value: '' });
+  };
+
+  const cancelEdit = () => {
+    setEditing({ stepId: null, type: null, value: '' });
   };
 
   const handleStartEditTextGroupName = () => {
@@ -147,7 +224,6 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
     setCurrentTextGroupName(finalName);
     setEditingTextGroupName(false);
 
-    // Emit after React updates global state
     setTimeout(() => {
       const activeTextStep = captureTextData.find(step => step.actionId);
       if (activeTextStep?.actionId) emitForStepId(activeTextStep.actionId);
@@ -160,9 +236,7 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
 
     deleteBrowserStep(textId);
 
-    // Emit updated action to backend after deletion
     if (actionId) {
-      // Small delay to ensure state update completes
       setTimeout(() => emitForStepId(actionId), 0);
     }
   };
@@ -236,72 +310,6 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
 
     notify('error', `Text data "${currentTextGroupName}" discarded`);
   };
-  
-  const checkForDuplicateName = (stepId: number, type: 'list' | 'text' | 'screenshot', newName: string): boolean => {
-    const trimmedName = newName.trim();
-
-    if (type === 'list') {
-      const listSteps = browserSteps.filter(step => step.type === 'list' && step.id !== stepId);
-      const duplicate = listSteps.find(step => step.name === trimmedName);
-      if (duplicate) {
-        notify('error', `A list with the name "${trimmedName}" already exists. Please choose a different name.`);
-        return true;
-      }
-    } else if (type === 'screenshot') {
-      const screenshotSteps = browserSteps.filter(step => step.type === 'screenshot' && step.id !== stepId);
-      const duplicate = screenshotSteps.find(step => step.name === trimmedName);
-      if (duplicate) {
-        notify('error', `A screenshot with the name "${trimmedName}" already exists. Please choose a different name.`);
-        return true;
-      }
-    } else if (type === 'text') {
-      const textSteps = browserSteps.filter(step => step.type === 'text' && step.id !== stepId);
-      const duplicate = textSteps.find((step: any) => step.label === trimmedName);
-      if (duplicate) {
-        notify('error', `A field with the name "${trimmedName}" already exists. Please choose a different name.`);
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  const startEdit = (stepId: number, type: 'list' | 'text' | 'screenshot', currentValue: string) => {
-    setEditing({ stepId, type, value: currentValue });
-  };
-
-  const saveEdit = () => {
-    const { stepId, type, value } = editing;
-    if (stepId == null || !type) return;
-
-    const finalValue = value.trim();
-    if (!finalValue) {
-      setEditing({ stepId: null, type: null, value: '' });
-      return;
-    }
-
-    if (checkForDuplicateName(stepId, type, finalValue)) {
-      return;
-    }
-
-    if (type === 'list') {
-      updateListStepName(stepId, finalValue);
-    } else if (type === 'text') {
-      updateBrowserTextStepLabel(stepId, finalValue);
-    } else if (type === 'screenshot') {
-      updateScreenshotStepName(stepId, finalValue);
-    }
-
-    const step = browserSteps.find(s => s.id === stepId);
-    if (step?.actionId) setTimeout(() => emitForStepId(step.actionId!), 0);
-
-    setEditing({ stepId: null, type: null, value: '' });
-  };
-
-  const cancelEdit = () => {
-    setEditing({ stepId: null, type: null, value: '' });
-  };
-
 
   const previousTabsCount = useRef({ lists: 0, texts: 0, screenshots: 0 });
 
@@ -328,12 +336,18 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
     }
   }, [captureListData.length, captureTextData.length, screenshotData.length]);
 
+  useEffect(() => {
+    browserStepsRef.current = browserSteps;
+  }, [browserSteps]);
 
   useEffect(() => {
-    const textSteps = browserSteps.filter(step => step.type === 'text');
-    setCaptureTextData(textSteps);
+    if (captureListData.length > 0 || captureTextData.length > 0 || screenshotData.length > 0) {
+      setShowPreviewData(true);
+    } else {
+      setShowPreviewData(false);
+    }
 
-    if (!getText && previousGetText.current && textSteps.length > 0) {
+    if (!getText && previousGetText.current && captureTextData.length > 0) {
       if (!hasAutoFocusedTextTab.current) {
         hasAutoFocusedTextTab.current = true;
         setTimeout(() => {
@@ -343,32 +357,11 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
     }
 
     previousGetText.current = getText;
-
-    const listSteps = browserSteps.filter(step => step.type === 'list');
-    setCaptureListData(listSteps);
-
-    const screenshotSteps = browserSteps.filter(step =>
-      step.type === 'screenshot'
-    ) as Array<{ type: 'screenshot'; id: number; name?: string; fullPage: boolean; actionId?: string; screenshotData?: string }>;
-
-    const screenshotsWithData = screenshotSteps.filter(step => step.screenshotData);
-    const screenshots = screenshotsWithData.map(step => step.screenshotData!);
-    setScreenshotData(screenshots);
-
-    if (textSteps.length > 0 || listSteps.length > 0 || screenshots.length > 0) {
-      setShowPreviewData(true);
-    } else {
-      setShowPreviewData(false);
-    }
-
     updateActiveTab();
-  }, [browserSteps, updateActiveTab, getText]);
+  }, [captureListData.length, captureTextData.length, screenshotData.length, updateActiveTab, getText]);
 
   useEffect(() => {
     if (shouldResetInterpretationLog) {
-      setCaptureListData([]);
-      setCaptureTextData([]);
-      setScreenshotData([]);
       setActiveTab(0);
       setShowPreviewData(false);
       autoFocusedListIds.current.clear();
@@ -415,7 +408,8 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
   useEffect(() => {
     let shouldOpenDrawer = false;
 
-    if (hasScrapeListAction && captureListData.length > 0 && captureListData[0]?.data?.length > 0) {
+    const firstListStep = captureListData[0];
+    if (hasScrapeListAction && firstListStep && firstListStep.data && firstListStep.data.length > 0) {
       setShowPreviewData(true);
       if (captureListData.length > lastListDataLength.current) {
         userClosedDrawer.current = false;
@@ -499,7 +493,7 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
     if (captureListData.length > 0 && isOpen && captureStage === 'initial') {
       const latestListIndex = captureListData.length - 1;
       const latestList = captureListData[latestListIndex];
-      if (latestList && latestList.data && latestList.data.length > 0  && editing.type !== 'list') {
+      if (latestList && latestList.data && latestList.data.length > 0 && editing.type !== 'list') {
         const previousLength = previousDataLengths.current.get(latestList.id) || 0;
         const currentLength = latestList.data.length;
 
@@ -575,7 +569,7 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
               background: `${darkMode ? '#1d1c1cff' : 'white'}`,
               color: `${darkMode ? 'white' : 'black'}`,
               padding: '10px',
-              height: outputPreviewHeight,
+              height: "calc(100% - 140px)",
               width: outputPreviewWidth,
               display: 'flex',
               flexDirection: 'column',
@@ -659,13 +653,13 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
 
                           return (
                             <Tooltip
+                              key={listItem.id}
                               title="Double click to edit captured list name"
                               arrow
                               placement="top"
                             >
                               <Box
                                 id={index === captureListData.length - 1 ? "list-name-tab" : undefined}
-                                key={listItem.id}
                                 onClick={() => {
                                   if (!isEditing) {
                                     setActiveListTab(index);
@@ -1194,6 +1188,10 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
                                 backgroundColor: `${darkMode ? '#080808ff' : '#f8f9fa'} !important`,
                                 position: 'sticky',
                                 top: 0,
+                                width: '10%',
+                                minWidth: '150px',
+                                whiteSpace: 'normal',
+                                wordWrap: 'break-word',
                               }}
                             >
                               Label
@@ -1205,6 +1203,7 @@ export const InterpretationLog: React.FC<InterpretationLogProps> = ({ isOpen, se
                                 backgroundColor: `${darkMode ? '#080808ff' : '#f8f9fa'} !important`,
                                 position: 'sticky',
                                 top: 0,
+                                width: '90%',
                               }}
                             >
                               Value


### PR DESCRIPTION
What this PR does?

When users are capturing and then open the drawer before even confirming it shows the default label 1, label 2 etc. This PRs adds the specific selected batch of captured texts and allow them to be displayed in the drawer output preview data only after the confirm capture is clicked.

<img width="1074" height="496" alt="Screenshot 2026-04-30 at 10 08 05 PM" src="https://github.com/user-attachments/assets/155f6b48-e2ff-465a-ba8e-0b0d346e20c7" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized duplicate-name validation across all step types.
  * More reliable edit/save behavior using the latest step state to prevent stale edits.
  * Preview display now toggles correctly based on captured content; reset behavior no longer disrupts UI focus tracking.

* **Style**
  * Adjusted drawer height and improved table cell sizing/wrapping for clearer layout.
  * Minor list/tab wrapper tweaks for better tooltip and focus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->