### PR TITLE
feat: add support for links format

### DIFF
--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -16,8 +16,9 @@ import { WorkflowFile } from "maxun-core";
 import { addGoogleSheetUpdateTask, processGoogleSheetUpdates } from "../workflow-management/integrations/gsheet";
 import { addAirtableUpdateTask, processAirtableUpdates } from "../workflow-management/integrations/airtable";
 import { sendWebhook } from "../routes/webhook";
-import { convertPageToHTML, convertPageToMarkdown, convertPageToScreenshot, convertPageToText } from '../markdownify/scrape';
+import { convertPageToHTML, convertPageToLinks, convertPageToMarkdown, convertPageToScreenshot, convertPageToText } from '../markdownify/scrape';
 import { executeBrowserAgent } from '../sdk/browserAgent';
+import { OutputFormats } from '../constants/output-formats';
 
 const router = Router();
 
@@ -514,7 +515,7 @@ router.get("/robots/:id/runs/:runId", requireAPIKey, async (req: Request, res: R
     }
 });
 
-async function createWorkflowAndStoreMetadata(id: string, userId: string, runSource: 'api' | 'sdk' | 'mcp' | 'cli', requestedFormats?: string[], promptInstructions?: string) {
+async function createWorkflowAndStoreMetadata(id: string, userId: string, runSource: 'api' | 'sdk' | 'mcp' | 'cli', requestedFormats?: OutputFormats[], promptInstructions?: string) {
     try {
         const recording = await Robot.findOne({
             where: {
@@ -741,11 +742,12 @@ async function executeRun(id: string, userId: string) {
         if (robotType === 'scrape') {
             logger.log('info', `Executing scrape robot for API run ${id}`);
 
-            let formats = recording.recording_meta.formats || ['markdown'];
+            const rawFormats = recording.recording_meta.formats;
+            let formats = rawFormats && rawFormats.length > 0 ? rawFormats : ['markdown'];
 
             if (requestedFormats && Array.isArray(requestedFormats) && requestedFormats.length > 0) {
-                formats = requestedFormats.filter((f): f is 'markdown' | 'html' | 'screenshot-visible' | 'screenshot-fullpage' =>
-                    ['markdown', 'html', 'screenshot-visible', 'screenshot-fullpage'].includes(f)
+                formats = requestedFormats.filter((f): f is 'text' | 'markdown' | 'html' | 'links' | 'screenshot-visible' | 'screenshot-fullpage' =>
+                    ['text', 'markdown', 'html', 'links', 'screenshot-visible', 'screenshot-fullpage'].includes(f)
                 );
             }
 
@@ -848,6 +850,20 @@ async function executeRun(id: string, userId: string) {
                         }
                     } catch (error: any) {
                         logger.log('warn', `HTML conversion failed for API run ${plainRun.runId}: ${error.message}`);
+                    }
+                }
+
+                if (formats.includes('links')) {
+                    try {
+                        const links = await Promise.race([
+                            convertPageToLinks(url, currentPage),
+                            new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`Links extraction timed out`)), SCRAPE_TIMEOUT))
+                        ]);
+                        if (links && links.length > 0) {
+                            serializableOutput.links = links.map((link: string) => ({ url: link }));
+                        }
+                    } catch (error: any) {
+                        logger.log('warn', `Links extraction failed for API run ${plainRun.runId}: ${error.message}`);
                     }
                 }
               
@@ -1269,7 +1285,7 @@ async function executeRun(id: string, userId: string) {
     }
 }
 
-export async function handleRunRecording(id: string, userId: string, runSource: 'api' | 'sdk' | 'mcp' | 'cli' = 'api', requestedFormats?: string[], promptInstructions?: string) {
+export async function handleRunRecording(id: string, userId: string, runSource: 'api' | 'sdk' | 'mcp' | 'cli' = 'api', requestedFormats?: OutputFormats[], promptInstructions?: string) {
     let socket: Socket | null = null;
 
     try {
@@ -1452,7 +1468,7 @@ router.post("/robots/:id/runs", requireAPIKey, async (req: AuthenticatedRequest,
             return res.status(401).json({ ok: false, error: 'Unauthorized' });
         }
 
-        const requestedFormats = req.body?.formats;
+        const requestedFormats = req.body?.formats as OutputFormats[] | undefined;
         const promptInstructions = req.body?.promptInstructions;
         const runSource = req.headers['x-run-source'] === 'mcp' ? 'mcp' : 'api';
         const runId = await handleRunRecording(req.params.id, req.user.id, runSource, requestedFormats, promptInstructions);

--- a/server/src/api/sdk.ts
+++ b/server/src/api/sdk.ts
@@ -20,7 +20,7 @@ import moment from 'moment-timezone';
 import {
     DEFAULT_OUTPUT_FORMATS,
     parseOutputFormats,
-    OutputFormat,
+    OutputFormats,
     SCRAPE_OUTPUT_FORMAT_OPTIONS,
 } from '../constants/output-formats';
 import sequelizeInstance from '../storage/db';
@@ -227,7 +227,7 @@ router.post("/sdk/robots", requireAPIKey, async (req: AuthenticatedRequest, res:
             });
         }
 
-        let normalizedFormats: OutputFormat[] = validFormats;
+        let normalizedFormats: OutputFormats[] = validFormats;
 
         if (type === 'search') {
             const searchAction = enrichedWorkflow
@@ -673,7 +673,7 @@ router.post("/sdk/robots/:id/execute", requireAPIKey, async (req: AuthenticatedR
 
         const runSource = req.headers['x-run-source'] === 'cli' ? 'cli' : 'sdk';
         const promptInstructions = req.body?.promptInstructions;
-        const requestedFormats = req.body?.formats;
+        const requestedFormats = req.body?.formats as OutputFormats[] | undefined;
         
         const runId = await handleRunRecording(robotId, user.id.toString(), runSource, requestedFormats, promptInstructions);
         if (!runId) {
@@ -745,6 +745,11 @@ router.post("/sdk/robots/:id/execute", requireAPIKey, async (req: AuthenticatedR
             html = scrapeOutput.html[0]?.content || undefined;
         }
 
+        const promptResultRaw = run.serializableOutput?.promptResult;
+        const promptResult = Array.isArray(promptResultRaw) && promptResultRaw.length > 0
+            ? (promptResultRaw[0]?.content || null)
+            : null;
+
         return res.status(200).json({
             data: {
                 runId: run.runId,
@@ -757,7 +762,7 @@ router.post("/sdk/robots/:id/execute", requireAPIKey, async (req: AuthenticatedR
                     text: text,
                     markdown: markdown,
                     html: html,
-                    promptResult: run.serializableOutput?.promptResult?.[0]?.content || null
+                    promptResult: promptResult
                 },
                 screenshots: Object.values(run.binaryOutput || {})
             }
@@ -1101,7 +1106,7 @@ router.post("/sdk/crawl", requireAPIKey, async (req: AuthenticatedRequest, res: 
         }
 
         // Crawl always needs formats; use defaults even if explicit empty array is provided
-        const crawlFormats: OutputFormat[] = requestedFormats.length > 0 
+        const crawlFormats: OutputFormats[] = requestedFormats.length > 0 
             ? requestedFormats 
             : [...DEFAULT_OUTPUT_FORMATS];
 
@@ -1240,7 +1245,7 @@ router.post("/sdk/search", requireAPIKey, async (req: AuthenticatedRequest, res:
             });
         }
 
-        const searchFormats: OutputFormat[] = searchConfig.mode === 'discover'
+        const searchFormats: OutputFormats[] = searchConfig.mode === 'discover'
             ? (requestedFormats.length > 0 ? requestedFormats : [])
             : (requestedFormats.length > 0 ? requestedFormats : [...DEFAULT_OUTPUT_FORMATS]);
 

--- a/server/src/constants/output-formats.ts
+++ b/server/src/constants/output-formats.ts
@@ -2,47 +2,50 @@ export const OUTPUT_FORMAT_OPTIONS = [
   'markdown',
   'html',
   'text',
+  'links',
   'screenshot-visible',
   'screenshot-fullpage',
 ] as const;
 
-export type OutputFormat = (typeof OUTPUT_FORMAT_OPTIONS)[number];
+export type OutputFormats = (typeof OUTPUT_FORMAT_OPTIONS)[number];
 
-export const SCRAPE_OUTPUT_FORMAT_OPTIONS: OutputFormat[] = [
+export const SCRAPE_OUTPUT_FORMAT_OPTIONS: OutputFormats[] = [
   'markdown',
   'html',
   'text',
+  'links',
   'screenshot-visible',
   'screenshot-fullpage',
 ];
 
-export const SEARCH_SCRAPE_OUTPUT_FORMAT_OPTIONS: OutputFormat[] = [
+export const SEARCH_SCRAPE_OUTPUT_FORMAT_OPTIONS: OutputFormats[] = [
   'markdown',
   'html',
   'text',
+  'links',
   'screenshot-visible',
   'screenshot-fullpage',
 ];
 
 const OUTPUT_FORMAT_SET = new Set<string>(OUTPUT_FORMAT_OPTIONS as readonly string[]);
 
-export const DEFAULT_OUTPUT_FORMATS: OutputFormat[] = ['markdown'];
+export const DEFAULT_OUTPUT_FORMATS: OutputFormats[] = ['markdown'];
 
-export function isOutputFormat(value: unknown): value is OutputFormat {
+export function isOutputFormat(value: unknown): value is OutputFormats {
   return typeof value === 'string' && OUTPUT_FORMAT_SET.has(value);
 }
 
 export function parseOutputFormats(
   formats: unknown,
-  allowedFormats: readonly OutputFormat[] = OUTPUT_FORMAT_OPTIONS
+  allowedFormats: readonly OutputFormats[] = OUTPUT_FORMAT_OPTIONS
 ): {
-  validFormats: OutputFormat[];
+  validFormats: OutputFormats[];
   invalidFormats: unknown[];
   wasProvided: boolean;
 } {
   const wasProvided = formats !== undefined;
   const requestedFormats = Array.isArray(formats) ? formats : [];
-  const validFormats: OutputFormat[] = [];
+  const validFormats: OutputFormats[] = [];
   const invalidFormats: unknown[] = [];
   const allowedSet = new Set<string>(allowedFormats as readonly string[]);
 

--- a/server/src/markdownify/scrape.ts
+++ b/server/src/markdownify/scrape.ts
@@ -265,6 +265,31 @@ export async function convertPageToText(url: string, page: Page): Promise<string
 }
 
 /**
+ * Extracts all HTTP/HTTPS links from the page.
+ * @param url - The URL to extract links from
+ * @param page - Existing Playwright page instance to use
+ */
+export async function convertPageToLinks(url: string, page: Page): Promise<string[]> {
+  try {
+    logger.log('info', `Extracting links from ${url}`);
+
+    await gotoWithFallback(page, url);
+    await waitForStability(page);
+
+    const links = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('a'))
+        .map((a) => (a as HTMLAnchorElement).href)
+        .filter((href) => href.startsWith('http'))
+    );
+
+    return links;
+  } catch (error: any) {
+    logger.error(`Error during links extraction: ${error.message}`);
+    throw error;
+  }
+}
+
+/**
  * Takes a screenshot of the page
  * @param url - The URL to screenshot
  * @param page - Existing Playwright page instance to use

--- a/server/src/models/Robot.ts
+++ b/server/src/models/Robot.ts
@@ -1,7 +1,7 @@
 import { Model, DataTypes, Optional } from 'sequelize';
 import sequelize from '../storage/db';
 import { WhereWhatPair } from 'maxun-core';
-import { OutputFormat } from '../constants/output-formats';
+import { OutputFormats } from '../constants/output-formats';
 
 interface RobotMeta {
   name: string;
@@ -12,7 +12,7 @@ interface RobotMeta {
   params: any[];
   type?: 'extract' | 'scrape' | 'crawl' | 'search';
   url?: string;
-  formats?: OutputFormat[];
+  formats?: OutputFormats[];
   isLLM?: boolean;
   promptInstructions?: string;
   promptLlmProvider?: 'anthropic' | 'openai' | 'ollama';

--- a/server/src/models/Run.ts
+++ b/server/src/models/Run.ts
@@ -1,12 +1,13 @@
 import { Model, DataTypes, Optional } from 'sequelize';
 import sequelize from '../storage/db';
 import Robot from './Robot';
+import { OutputFormats } from '../constants/output-formats';
 
 interface InterpreterSettings {
   maxConcurrency: number;
   maxRepeats: number;
   debug: boolean;
-  formats?: string[];
+  formats?: OutputFormats[];
   promptInstructions?: string;
 }
 

--- a/server/src/pgboss-worker.ts
+++ b/server/src/pgboss-worker.ts
@@ -20,7 +20,7 @@ import { addAirtableUpdateTask, airtableUpdateTasks, processAirtableUpdates } fr
 import { io as serverIo } from "./server";
 import { sendWebhook } from './routes/webhook';
 import { BinaryOutputService } from './storage/mino';
-import { convertPageToMarkdown, convertPageToHTML, convertPageToScreenshot, convertPageToText } from './markdownify/scrape';
+import { convertPageToMarkdown, convertPageToHTML, convertPageToLinks, convertPageToScreenshot, convertPageToText } from './markdownify/scrape';
 import { executeBrowserAgent } from './sdk/browserAgent';
 import { processRobotOutputFormats } from './utils/output-post-processor';
 import { getInterpretationFailureReason, hasExpectedRobotOutput } from './utils/output-validation';
@@ -248,7 +248,8 @@ async function processRunExecution(job: Job<ExecuteRunData>) {
       if (recording.recording_meta.type === 'scrape') {
         logger.log('info', `Executing scrape robot for run ${data.runId}`);
 
-        const formats = run.interpreterSettings?.formats || recording.recording_meta.formats || ['markdown'];
+        const rawFormats = run.interpreterSettings?.formats || recording.recording_meta.formats;
+        const formats = rawFormats && rawFormats.length > 0 ? rawFormats : ['markdown'];
 
         await run.update({
           status: 'running',
@@ -326,7 +327,21 @@ async function processRunExecution(job: Job<ExecuteRunData>) {
             html = await Promise.race([htmlPromise, timeoutPromise]);
             serializableOutput.html = [{ content: html }];
           }
-          
+
+          if (formats.includes('links')) {
+            try {
+              const links = await Promise.race([
+                convertPageToLinks(url, currentPage),
+                new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`Links extraction timed out`)), SCRAPE_TIMEOUT))
+              ]);
+              if (links && links.length > 0) {
+                serializableOutput.links = links.map((link: string) => ({ url: link }));
+              }
+            } catch (error: any) {
+              logger.log('warn', `Links extraction failed for run ${data.runId}: ${error.message}`);
+            }
+          }
+
           const promptInstructions = run.interpreterSettings?.promptInstructions || (recording.recording_meta as any).promptInstructions as string | undefined;
           if (promptInstructions) {
             try {

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -23,7 +23,7 @@ import {
   parseOutputFormats,
   SEARCH_SCRAPE_OUTPUT_FORMAT_OPTIONS,
   SCRAPE_OUTPUT_FORMAT_OPTIONS,
-  OutputFormat,
+  OutputFormats,
 } from '../constants/output-formats';
 
 export const router = Router();
@@ -430,7 +430,7 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
       }
     }
 
-    let normalizedFormats: OutputFormat[] | undefined;
+    let normalizedFormats: OutputFormats[] | undefined;
     
     let searchMode: string | undefined;
     if (robot.recording_meta?.type === 'search') {
@@ -441,7 +441,7 @@ router.put('/recordings/:id', requireSignIn, async (req: AuthenticatedRequest, r
     }
 
     if (formats !== undefined || (robot.recording_meta?.type === 'search' && searchMode === 'discover')) {
-      let allowedFormats: readonly OutputFormat[] | undefined;
+      let allowedFormats: readonly OutputFormats[] | undefined;
       if (robot.recording_meta?.type === 'scrape') {
         allowedFormats = SCRAPE_OUTPUT_FORMAT_OPTIONS;
       } else if (robot.recording_meta?.type === 'search' && searchMode === 'scrape') {
@@ -1626,7 +1626,7 @@ router.post('/recordings/crawl', requireSignIn, async (req: AuthenticatedRequest
     }
 
     // Crawl always needs formats; use defaults even if explicit empty array is provided
-    const crawlFormats: OutputFormat[] = requestedFormats.length > 0
+    const crawlFormats: OutputFormats[] = requestedFormats.length > 0
       ? requestedFormats
       : [...DEFAULT_OUTPUT_FORMATS];
 
@@ -1756,7 +1756,7 @@ router.post('/recordings/search', requireSignIn, async (req: AuthenticatedReques
       });
     }
 
-    let searchFormats: OutputFormat[];
+    let searchFormats: OutputFormats[];
     if (searchConfig.mode === 'discover') {
       // Discover-mode: always empty, ignore caller input
       searchFormats = [];

--- a/server/src/workflow-management/scheduler/index.ts
+++ b/server/src/workflow-management/scheduler/index.ts
@@ -13,7 +13,7 @@ import { WorkflowFile } from "maxun-core";
 import { Page } from "playwright-core";
 import { sendWebhook } from "../../routes/webhook";
 import { addAirtableUpdateTask, airtableUpdateTasks, processAirtableUpdates } from "../integrations/airtable";
-import { convertPageToMarkdown, convertPageToHTML, convertPageToScreenshot, convertPageToText } from "../../markdownify/scrape";
+import { convertPageToMarkdown, convertPageToHTML, convertPageToLinks, convertPageToScreenshot, convertPageToText } from "../../markdownify/scrape";
 import { executeBrowserAgent } from "../../sdk/browserAgent";
 import { processRobotOutputFormats } from "../../utils/output-post-processor";
 import { getInterpretationFailureReason, hasExpectedRobotOutput } from "../../utils/output-validation";
@@ -252,7 +252,8 @@ async function executeRun(id: string, userId: string) {
     if (recording.recording_meta.type === 'scrape') {
       logger.log('info', `Executing scrape robot for scheduled run ${id}`);
 
-      const formats = run.interpreterSettings?.formats || recording.recording_meta.formats || ['markdown'];
+      const rawFormats = run.interpreterSettings?.formats || recording.recording_meta.formats;
+      const formats = rawFormats && rawFormats.length > 0 ? rawFormats : ['markdown'];
 
       await run.update({
         status: 'running',
@@ -350,7 +351,21 @@ async function executeRun(id: string, userId: string) {
           html = await Promise.race([htmlPromise, timeoutPromise]);
           serializableOutput.html = [{ content: html }];
         }
-        
+
+        if (formats.includes('links')) {
+          try {
+            const links = await Promise.race([
+              convertPageToLinks(url, currentPage),
+              new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`Links extraction timed out`)), SCRAPE_TIMEOUT))
+            ]);
+            if (links && links.length > 0) {
+              serializableOutput.links = links.map((link: string) => ({ url: link }));
+            }
+          } catch (error: any) {
+            logger.log('warn', `Links extraction failed for run ${plainRun.runId}: ${error.message}`);
+          }
+        }
+
         const promptInstructions = (recording.recording_meta as any).promptInstructions as string | undefined;
         if (promptInstructions && currentPage) {
           try {

--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -4,6 +4,7 @@ import { RunSettings } from "../components/run/RunSettings";
 import { ScheduleSettings } from "../components/robot/pages/ScheduleSettingsPage";
 import { CreateRunResponse, ScheduleRunResponse } from "../pages/MainPage";
 import { apiUrl } from "../apiConfig";
+import { OutputFormats } from "../constants/outputFormats";
 
 interface CredentialInfo {
   value: string;
@@ -117,7 +118,7 @@ export const updateRecording = async (id: string, data: {
   credentials?: Credentials; 
   targetUrl?: string;
   workflow?: any[];
-  formats?: string[];
+  formats?: OutputFormats[];
 }): Promise<boolean> => {
   try {
     const response = await axios.put(`${apiUrl}/storage/recordings/${id}`, data);
@@ -418,7 +419,7 @@ export const createSearchRobot = async (
     };
     mode: 'discover' | 'scrape';
   },
-  formats?: string[]
+  formats?: OutputFormats[]
 ): Promise<any> => {
   try {
     const response = await axios.post(

--- a/src/components/robot/pages/RobotCreate.tsx
+++ b/src/components/robot/pages/RobotCreate.tsx
@@ -30,8 +30,7 @@ import { useGlobalInfoStore, useCacheInvalidation } from '../../../context/globa
 import { canCreateBrowserInState, getActiveBrowserId, stopRecording } from '../../../api/recording';
 import { createScrapeRobot, createLLMRobot, createAndRunRecording, createCrawlRobot, createSearchRobot } from "../../../api/storage";
 import { AuthContext } from '../../../context/auth';
-import { GenericModal } from '../../ui/GenericModal';
-import { DEFAULT_OUTPUT_FORMATS, OUTPUT_FORMAT_LABELS, OUTPUT_FORMAT_OPTIONS, OutputFormat } from '../../../constants/outputFormats';
+import { DEFAULT_OUTPUT_FORMATS, OUTPUT_FORMAT_LABELS, OUTPUT_FORMAT_OPTIONS, OutputFormats } from '../../../constants/outputFormats';
 
 
 interface TabPanelProps {
@@ -69,7 +68,7 @@ const RobotCreate: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isWarningModalOpen, setWarningModalOpen] = useState(false);
   const [activeBrowserId, setActiveBrowserId] = useState('');
-  const [outputFormats, setOutputFormats] = useState<string[]>([]);
+  const [outputFormats, setOutputFormats] = useState<OutputFormats[]>(DEFAULT_OUTPUT_FORMATS);
   const [generationMode, setGenerationMode] = useState<'agent' | 'recorder' | null>('recorder');
 
   const [aiPrompt, setAiPrompt] = useState('');
@@ -104,8 +103,8 @@ const RobotCreate: React.FC = () => {
   const [searchMode, setSearchMode] = useState<'discover' | 'scrape'>('discover');
   const [searchTimeRange, setSearchTimeRange] = useState<'day' | 'week' | 'month' | 'year' | ''>('');
 
-  const [crawlOutputFormats, setCrawlOutputFormats] = useState<OutputFormat[]>(DEFAULT_OUTPUT_FORMATS);
-  const [searchOutputFormats, setSearchOutputFormats] = useState<OutputFormat[]>(DEFAULT_OUTPUT_FORMATS);
+  const [crawlOutputFormats, setCrawlOutputFormats] = useState<OutputFormats[]>(DEFAULT_OUTPUT_FORMATS);
+  const [searchOutputFormats, setSearchOutputFormats] = useState<OutputFormats[]>(DEFAULT_OUTPUT_FORMATS);
 
   const { state } = React.useContext(AuthContext);
   const { user } = state;
@@ -743,47 +742,12 @@ const RobotCreate: React.FC = () => {
                       value={outputFormats}
                       label="Output Formats *"
                       onChange={(e) => {
-                        const value =
-                          typeof e.target.value === 'string'
-                            ? e.target.value.split(',')
-                            : e.target.value;
-                        setOutputFormats(value);
+                        const value = typeof e.target.value === 'string' ? e.target.value.split(',') : e.target.value;
+                        setOutputFormats(value as OutputFormats[]);
                       }}
                       renderValue={(selected) => {
-                        if (selected.length === 0) {
-                          return <em style={{ color: '#999' }}>Select formats</em>;
-                        }
-
-                        const OUTPUT_FORMAT_LABELS: Record<string, string> = {
-                          markdown: 'Markdown',
-                          html: 'HTML',
-                          text: 'Text Content',
-                          'screenshot-visible': 'Screenshot (Visible)',
-                          'screenshot-fullpage': 'Screenshot (Full Page)',
-                        };
-
-                        const labels = selected.map(
-                          (value) => OUTPUT_FORMAT_LABELS[value] ?? value
-                        );
-
-                        const MAX_ITEMS = 2; // Show only first 2, then ellipsis
-
-                        const display =
-                          labels.length > MAX_ITEMS
-                            ? `${labels.slice(0, MAX_ITEMS).join(', ')}…`
-                            : labels.join(', ');
-
-                        return (
-                          <Box
-                            sx={{
-                              whiteSpace: 'nowrap',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                            }}
-                          >
-                            {display}
-                          </Box>
-                        );
+                        const labels = selected.map(v => OUTPUT_FORMAT_LABELS[v] ?? v);
+                        return labels.length > 2 ? `${labels.slice(0, 2).join(', ')}…` : labels.join(', ');
                       }}
                       MenuProps={{
                         PaperProps: {
@@ -793,26 +757,12 @@ const RobotCreate: React.FC = () => {
                         },
                       }}
                     >
-                      <MenuItem value="markdown">
-                        <Checkbox checked={outputFormats.includes('markdown')} />
-                        Markdown
-                      </MenuItem>
-                      <MenuItem value="html">
-                        <Checkbox checked={outputFormats.includes('html')} />
-                        HTML
-                      </MenuItem>
-                      <MenuItem value="text">
-                        <Checkbox checked={outputFormats.includes('text')} />
-                        Text Content
-                      </MenuItem>
-                      <MenuItem value="screenshot-visible">
-                        <Checkbox checked={outputFormats.includes('screenshot-visible')} />
-                        Screenshot - Visible Viewport
-                      </MenuItem>
-                      <MenuItem value="screenshot-fullpage">
-                        <Checkbox checked={outputFormats.includes('screenshot-fullpage')} />
-                        Screenshot - Full Page
-                      </MenuItem>
+                      {OUTPUT_FORMAT_OPTIONS.map((format) => (
+                        <MenuItem key={format} value={format}>
+                          <Checkbox checked={outputFormats.includes(format)} />
+                          {OUTPUT_FORMAT_LABELS[format]}
+                        </MenuItem>
+                      ))}
                     </Select>
                   </FormControl>
                 </Box>
@@ -1011,7 +961,7 @@ const RobotCreate: React.FC = () => {
                       label="Output Formats *"
                       onChange={(e) => {
                         const value = typeof e.target.value === 'string' ? e.target.value.split(',') : e.target.value;
-                        setCrawlOutputFormats(value as OutputFormat[]);
+                        setCrawlOutputFormats(value as OutputFormats[]);
                       }}
                       renderValue={(selected) => {
                         const labels = selected.map(v => OUTPUT_FORMAT_LABELS[v] ?? v);
@@ -1236,7 +1186,7 @@ const RobotCreate: React.FC = () => {
                         label="Output Formats *"
                         onChange={(e) => {
                           const value = typeof e.target.value === 'string' ? e.target.value.split(',') : e.target.value;
-                          setSearchOutputFormats(value as OutputFormat[]);
+                          setSearchOutputFormats(value as OutputFormats[]);
                         }}
                         renderValue={(selected) => {
                           const labels = selected.map(v => OUTPUT_FORMAT_LABELS[v] ?? v);

--- a/src/components/robot/pages/RobotEditPage.tsx
+++ b/src/components/robot/pages/RobotEditPage.tsx
@@ -25,7 +25,7 @@ import {
   DEFAULT_OUTPUT_FORMATS,
   OUTPUT_FORMAT_LABELS,
   OUTPUT_FORMAT_OPTIONS,
-  OutputFormat,
+  OutputFormats,
 } from "../../../constants/outputFormats";
 
 interface RobotMeta {
@@ -38,7 +38,7 @@ interface RobotMeta {
   params: any[];
   type?: 'extract' | 'scrape' | 'crawl' | 'search';
   url?: string;
-  formats?: OutputFormat[];
+  formats?: OutputFormats[];
   isLLM?: boolean;
 }
 
@@ -148,9 +148,9 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const [crawlConfig, setCrawlConfig] = useState<CrawlConfig>({});
   const [searchConfig, setSearchConfig] = useState<SearchConfig>({});
-  const [crawlOutputFormats, setCrawlOutputFormats] = useState<OutputFormat[]>(DEFAULT_OUTPUT_FORMATS);
-  const [searchOutputFormats, setSearchOutputFormats] = useState<OutputFormat[]>(DEFAULT_OUTPUT_FORMATS);
-  const [scrapeOutputFormats, setScrapeOutputFormats] = useState<OutputFormat[]>(DEFAULT_OUTPUT_FORMATS);
+  const [crawlOutputFormats, setCrawlOutputFormats] = useState<OutputFormats[]>(DEFAULT_OUTPUT_FORMATS);
+  const [searchOutputFormats, setSearchOutputFormats] = useState<OutputFormats[]>(DEFAULT_OUTPUT_FORMATS);
+  const [scrapeOutputFormats, setScrapeOutputFormats] = useState<OutputFormats[]>(DEFAULT_OUTPUT_FORMATS);
   const [showCrawlAdvanced, setShowCrawlAdvanced] = useState(false);
 
   const isEmailPattern = (value: string): boolean => {
@@ -207,8 +207,8 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
         ? robot.recording_meta.formats
         : [];
 
-      const filteredFormats = rawFormats.filter((format): format is OutputFormat =>
-        OUTPUT_FORMAT_OPTIONS.includes(format as OutputFormat)
+      const filteredFormats = rawFormats.filter((format): format is OutputFormats =>
+        OUTPUT_FORMAT_OPTIONS.includes(format as OutputFormats)
       );
 
       if (robot.recording_meta?.type === 'crawl') {
@@ -839,10 +839,10 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
             label="Output Formats *"
             onChange={(e) => {
               const value = typeof e.target.value === 'string' ? e.target.value.split(',') : e.target.value;
-              setCrawlOutputFormats(value as OutputFormat[]);
+              setCrawlOutputFormats(value as OutputFormats[]);
             }}
             renderValue={(selected) => {
-              const labels = (selected as OutputFormat[]).map(v => OUTPUT_FORMAT_LABELS[v] ?? v);
+              const labels = (selected as OutputFormats[]).map(v => OUTPUT_FORMAT_LABELS[v] ?? v);
               return labels.length > 2 ? `${labels.slice(0, 2).join(', ')}...` : labels.join(', ');
             }}
           >
@@ -1036,10 +1036,10 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
               label="Output Formats *"
               onChange={(e) => {
                 const value = typeof e.target.value === 'string' ? e.target.value.split(',') : e.target.value;
-                setSearchOutputFormats(value as OutputFormat[]);
+                setSearchOutputFormats(value as OutputFormats[]);
               }}
               renderValue={(selected) => {
-                const labels = (selected as OutputFormat[]).map(v => OUTPUT_FORMAT_LABELS[v] ?? v);
+                const labels = (selected as OutputFormats[]).map(v => OUTPUT_FORMAT_LABELS[v] ?? v);
                 return labels.length > 2 ? `${labels.slice(0, 2).join(', ')}...` : labels.join(', ');
               }}
             >
@@ -1092,10 +1092,10 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
           label="Output Formats *"
           onChange={(e) => {
             const value = typeof e.target.value === 'string' ? e.target.value.split(',') : e.target.value;
-            setScrapeOutputFormats(value as OutputFormat[]);
+            setScrapeOutputFormats(value as OutputFormats[]);
           }}
           renderValue={(selected) => {
-            const labels = (selected as OutputFormat[]).map(v => OUTPUT_FORMAT_LABELS[v] ?? v);
+            const labels = (selected as OutputFormats[]).map(v => OUTPUT_FORMAT_LABELS[v] ?? v);
             return labels.length > 2 ? `${labels.slice(0, 2).join(', ')}...` : labels.join(', ');
           }}
         >

--- a/src/components/robot/pages/RobotSettingsPage.tsx
+++ b/src/components/robot/pages/RobotSettingsPage.tsx
@@ -7,6 +7,7 @@ import { WhereWhatPair } from "maxun-core";
 import { getUserById } from "../../../api/auth";
 import { RobotConfigPage } from "./RobotConfigPage";
 import { useNavigate, useLocation } from "react-router-dom";
+import { OutputFormats } from "../../../constants/outputFormats";
 
 interface RobotMeta {
   name: string;
@@ -17,7 +18,7 @@ interface RobotMeta {
   params: any[];
   type?: 'extract' | 'scrape' | 'crawl' | 'search';
   url?: string;
-  formats?: ('markdown' | 'html' | 'screenshot-visible' | 'screenshot-fullpage')[];
+  formats?: OutputFormats[];
   isLLM?: boolean;
 }
 

--- a/src/components/run/RunContent.tsx
+++ b/src/components/run/RunContent.tsx
@@ -47,6 +47,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
   const [markdownContent, setMarkdownContent] = useState<string>('');
   const [htmlContent, setHtmlContent] = useState<string>('');
   const [textContent, setTextContent] = useState<string>('');
+  const [linksContent, setLinksContent] = useState<string[]>([]);
   const [smartQueryResult, setSmartQueryResult] = useState<string>('');
 
   const [schemaData, setSchemaData] = useState<any[]>([]);
@@ -99,6 +100,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
     setHtmlContent('');
     setSmartQueryResult('');
     setTextContent('');
+    setLinksContent([]);
 
     if (!row.serializableOutput) return;
 
@@ -127,6 +129,13 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
         } else if (typeof textOutput === 'string') {
           setTextContent(textOutput);
         }
+      }
+
+      if (output?.links && Array.isArray(output.links) && output.links.length > 0) {
+        const urls: string[] = output.links.map((item: any) =>
+          typeof item === 'string' ? item : item?.url ?? ''
+        ).filter(Boolean);
+        if (urls.length > 0) setLinksContent(urls);
       }
     };
 
@@ -1123,7 +1132,9 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
   const hasMarkdown = markdownContent && markdownContent.length > 0;
   const hasHTML = htmlContent && htmlContent.length > 0;
   const hasTextFormat = textContent && textContent.length > 0;
-  const hasSmartQuery = smartQueryResult.length > 0;
+  const hasLinks = linksContent && linksContent.length > 0;
+  const promptResultData = smartQueryResult || null;
+  const hasPromptResult = !!promptResultData;
   const hasCrawlPageScreenshots = crawlData.some(group => Array.isArray(group) && group.some((item: any) => item?.screenshotVisible || item?.screenshotFullpage));
   const hasSearchResultScreenshots = searchData.some((item: any) => item?.screenshotVisible || item?.screenshotFullpage);
   const showCapturedScreenshotSection = hasScreenshots && !hasCrawlPageScreenshots && !hasSearchResultScreenshots;
@@ -1132,7 +1143,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
     <Box sx={{ width: '100%' }}>
       <TabContext value={tab}>
         <TabPanel value='output' sx={{ width: '100%', maxWidth: '900px' }}>
-          {hasMarkdown || hasHTML || hasTextFormat ? (
+          {hasMarkdown || hasHTML || hasTextFormat || hasLinks ? (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               {hasMarkdown && (
                 <Accordion defaultExpanded>
@@ -1230,6 +1241,47 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                 </Accordion>
               )}
 
+              {hasLinks && (
+                <Accordion defaultExpanded>
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                      <ArticleIcon sx={{ mr: 1 }} />
+                      <Typography variant='h6'>Links ({linksContent.length})</Typography>
+                    </Box>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <Paper sx={{ p: 2, maxHeight: 400, overflow: 'auto', backgroundColor: darkMode ? '#1e1e1e' : '#f5f5f5' }}>
+                      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                        {Array.from(new Set(linksContent)).map((link: string, idx: number) => (
+                          <Link key={idx} href={link} target="_blank" rel="noopener" sx={{ color: '#FF00C3', wordBreak: 'break-all', fontSize: '0.875rem' }}>
+                            {link}
+                          </Link>
+                        ))}
+                      </Box>
+                    </Paper>
+                    <Box sx={{ mt: 1 }}>
+                      <Button
+                        onClick={() => {
+                          const uniqueLinks = Array.from(new Set(linksContent));
+                          const blob = new Blob([uniqueLinks.join('\n')], { type: 'text/plain' });
+                          const url = URL.createObjectURL(blob);
+                          const a = document.createElement('a');
+                          a.href = url;
+                          a.download = `${row.name || 'links'}.txt`;
+                          document.body.appendChild(a);
+                          a.click();
+                          document.body.removeChild(a);
+                          URL.revokeObjectURL(url);
+                        }}
+                        sx={{ color: '#FF00C3', textTransform: 'none', p: 0, minWidth: 'auto', backgroundColor: 'transparent', '&:hover': { textDecoration: 'underline', backgroundColor: 'transparent' } }}
+                      >
+                        Download Links
+                      </Button>
+                    </Box>
+                  </AccordionDetails>
+                </Accordion>
+              )}
+
               {showCapturedScreenshotSection && renderCapturedScreenshotsAccordion(
                 t('run_content.captured_screenshot.title', 'Captured Screenshots'),
                 screenshotKeys.map((label, index) => ({ key: label, label, value: rawScreenshotKeys[index] })).filter(tab => tab.value),
@@ -1262,7 +1314,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                 {t('run_content.buttons.stop')}
               </Button>
             </>
-          ) : (!hasData && !hasScreenshots
+          ) : (!hasData && !hasScreenshots && !hasMarkdown && !hasHTML && !hasTextFormat && !hasLinks && !hasPromptResult
             ? (['failed', 'aborted', 'aborting'].includes(row.status)
               ? <Typography color='error'>{t('run_content.failed_no_output', 'Run failed before generating output. Check run logs for details.')}</Typography>
               : <Typography>{t('run_content.empty_output')}</Typography>)
@@ -2295,7 +2347,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
           </>
           )}
 
-          {hasSmartQuery && (
+          {hasPromptResult && promptResultData && (
             <Accordion defaultExpanded sx={{ mb: 2 }}>
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                 <Box sx={{ display: 'flex', alignItems: 'center' }}>
@@ -2306,13 +2358,13 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
               <AccordionDetails>
                 <Paper sx={{ p: 2, maxHeight: '500px', overflow: 'auto', backgroundColor: darkMode ? '#1e1e1e' : '#f5f5f5' }}>
                   <Box component="pre" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontFamily: 'monospace', fontSize: '13px', lineHeight: 1.6, m: 0, color: 'inherit' }}>
-                    {smartQueryResult}
+                    {promptResultData}
                   </Box>
                 </Paper>
                 <Box sx={{ mt: 2 }}>
                   <Button
                     onClick={() => {
-                      const blob = new Blob([smartQueryResult], { type: 'text/plain' });
+                      const blob = new Blob([promptResultData], { type: 'text/plain' });
                       const url = URL.createObjectURL(blob);
                       const a = document.createElement('a');
                       a.href = url;

--- a/src/constants/outputFormats.ts
+++ b/src/constants/outputFormats.ts
@@ -2,18 +2,20 @@ export const OUTPUT_FORMAT_OPTIONS = [
   'markdown',
   'html',
   'text',
+  'links',
   'screenshot-visible',
   'screenshot-fullpage',
 ] as const;
 
-export type OutputFormat = (typeof OUTPUT_FORMAT_OPTIONS)[number];
+export type OutputFormats = (typeof OUTPUT_FORMAT_OPTIONS)[number];
 
-export const DEFAULT_OUTPUT_FORMATS: OutputFormat[] = ['markdown'];
+export const DEFAULT_OUTPUT_FORMATS: OutputFormats[] = ['markdown'];
 
-export const OUTPUT_FORMAT_LABELS: Record<OutputFormat, string> = {
+export const OUTPUT_FORMAT_LABELS: Record<OutputFormats, string> = {
   markdown: 'Markdown',
   html: 'HTML',
   text: 'Text Content',
+  links: 'Links',
   'screenshot-visible': 'Screenshot (Visible)',
   'screenshot-fullpage': 'Screenshot (Full Page)',
 };

--- a/src/context/globalInfo.tsx
+++ b/src/context/globalInfo.tsx
@@ -3,6 +3,7 @@ import { AlertSnackbarProps } from "../components/ui/AlertSnackbar";
 import { WhereWhatPair } from "maxun-core";
 import { QueryClient, QueryClientProvider, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getStoredRuns, getStoredRecordings } from "../api/storage";
+import { OutputFormats } from "../constants/outputFormats";
 
 const createDataCacheClient = () => new QueryClient({
   defaultOptions: {
@@ -29,7 +30,7 @@ interface RobotMeta {
     params: any[];
     type?: 'extract' | 'scrape' | 'crawl' | 'search';
     url?: string;
-    formats?: ('markdown' | 'html' | 'screenshot-visible' | 'screenshot-fullpage')[];
+    formats?: OutputFormats[];
     isLLM?: boolean;
 }
 


### PR DESCRIPTION
What this PR does?

Adds support to scrape links for all robot types scrape, crawl and search (scrape mode).

<img width="1613" height="701" alt="Screenshot 2026-05-03 at 10 35 12 PM" src="https://github.com/user-attachments/assets/32cace23-44c3-433f-ad78-1bdc9fe4066b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for "links" output format to extract and display all URLs from scraped pages
  * Links are now viewable in run results with a dedicated section and can be downloaded as a text file

* **Refactor**
  * Improved type consistency for output format handling throughout the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->