### PR TITLE
fix(runs): lazy load run output details

### DIFF
--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -213,6 +213,9 @@ router.get(('/recordings/:id/runs'), requireSignIn, async (req, res) => {
       where: {
         robotMetaId: req.params.id
       },
+      attributes: {
+        exclude: ['serializableOutput', 'binaryOutput']
+      },
       raw: true
     });
     const formattedRuns = runs.map(formatRunResponse);
@@ -918,7 +921,11 @@ router.post('/recordings/:id/duplicate', requireSignIn, async (req: Authenticate
  */
 router.get('/runs', requireSignIn, async (req, res) => {
   try {
-    const data = await Run.findAll();
+    const data = await Run.findAll({
+      attributes: {
+        exclude: ['serializableOutput', 'binaryOutput']
+      }
+    });
     return res.send(data);
   } catch (e) {
     logger.log('info', 'Error while reading runs');
@@ -1097,7 +1104,7 @@ router.put('/runs/:id', requireSignIn, async (req: AuthenticatedRequest, res) =>
  */
 router.get('/runs/run/:id', requireSignIn, async (req, res) => {
   try {
-    const run = await Run.findOne({ where: { runId: req.params.runId }, raw: true });
+    const run = await Run.findOne({ where: { runId: req.params.id }, raw: true });
     if (!run) {
       return res.status(404).send(null);
     }

--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -154,6 +154,20 @@ export const getStoredRuns = async (): Promise<string[] | null> => {
   }
 };
 
+export const getStoredRun = async (id: string): Promise<any | null> => {
+  try {
+    const response = await axios.get(`${apiUrl}/storage/runs/run/${id}`);
+    if (response.status === 200) {
+      return response.data;
+    } else {
+      throw new Error(`Couldn't retrieve stored run ${id}`);
+    }
+  } catch (error: any) {
+    console.log(error);
+    return null;
+  }
+};
+
 export const duplicateRecording = async (id: string, targetUrl: string, newName?: string): Promise<any> => {
   try {
     const response = await axios.post(`${apiUrl}/storage/recordings/${id}/duplicate`, {

--- a/src/components/run/ColapsibleRow.tsx
+++ b/src/components/run/ColapsibleRow.tsx
@@ -7,10 +7,11 @@ import {
   DialogContent,
   DialogContentText,
   DialogActions,
+  CircularProgress,
 } from "@mui/material";
 import { Button } from "@mui/material";
 import { DeleteForever, KeyboardArrowDown, KeyboardArrowUp, Settings } from "@mui/icons-material";
-import { deleteRunFromStorage } from "../../api/storage";
+import { deleteRunFromStorage, getStoredRun } from "../../api/storage";
 import { columns, Data } from "./RunsTable";
 import { RunContent } from "./RunContent";
 import { GenericModal } from "../ui/GenericModal";
@@ -56,6 +57,8 @@ export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, cu
   const [isDeleteOpen, setDeleteOpen] = useState(false);
   const [openSettingsModal, setOpenSettingsModal] = useState(false);
   const [userEmail, setUserEmail] = useState<string | null>(null);
+  const [runDetails, setRunDetails] = useState<Data>(row);
+  const [isLoadingRunDetails, setIsLoadingRunDetails] = useState(false);
   const runByLabel = row.runByScheduleId
     ? `${row.runByScheduleId}`
     : row.runByUserId
@@ -108,6 +111,43 @@ export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, cu
     const newOpen = !isOpen;
     onToggleExpanded(newOpen);
   };
+
+  useEffect(() => {
+    setRunDetails(prev => {
+      if (prev.runId !== row.runId) return row;
+      return {
+        ...row,
+        serializableOutput: prev.serializableOutput ?? row.serializableOutput,
+        binaryOutput: prev.binaryOutput ?? row.binaryOutput,
+      };
+    });
+  }, [row]);
+
+  useEffect(() => {
+    const hasOutputLoaded =
+      runDetails.serializableOutput !== undefined &&
+      runDetails.binaryOutput !== undefined;
+
+    if (!isOpen || row.status === 'running' || row.status === 'queued' || hasOutputLoaded) return;
+
+    let isCancelled = false;
+    setIsLoadingRunDetails(true);
+
+    getStoredRun(row.runId)
+      .then((run) => {
+        if (!run || isCancelled) return;
+        setRunDetails(prev => ({ ...prev, ...run }));
+      })
+      .finally(() => {
+        if (!isCancelled) {
+          setIsLoadingRunDetails(false);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [isOpen, row.runId, row.status, runDetails.serializableOutput, runDetails.binaryOutput]);
 
   useEffect(() => {
     const fetchUserEmail = async () => {
@@ -233,9 +273,15 @@ export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, cu
       <TableRow>
         <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={6}>
           <Collapse in={isOpen} timeout="auto" unmountOnExit>
-            <RunContent row={row} abortRunHandler={handleAbort} currentLog={currentLog}
-              logEndRef={logEndRef} interpretationInProgress={runningRecordingName === row.name}
-              workflowProgress={workflowProgress} />
+            {isLoadingRunDetails ? (
+              <Box display="flex" justifyContent="center" py={3}>
+                <CircularProgress size={24} />
+              </Box>
+            ) : (
+              <RunContent row={runDetails} abortRunHandler={handleAbort} currentLog={currentLog}
+                logEndRef={logEndRef} interpretationInProgress={runningRecordingName === row.name}
+                workflowProgress={workflowProgress} />
+            )}
           </Collapse>
         </TableCell>
       </TableRow>


### PR DESCRIPTION
## Summary
- omit `serializableOutput` and `binaryOutput` from run list responses so the runs table does not download bulky payloads up front
- add a single-run client fetch and load full run output when an expanded row needs to render captured data
- fix the single-run storage route to read the declared `:id` route parameter

Closes #989.

## Validation
- `npm install --legacy-peer-deps --package-lock=false`
- `npm run build`
- `npx -p typescript@5.0.4 tsc -p server/tsconfig.json`
- `git diff --check`

## Notes
- `npm run build:server` currently fails with TypeScript 5.9.3 in untouched `server/src/mcp-worker.ts` deep type instantiation errors.
- `npm run lint` cannot run in this checkout because `./node_modules/.bin/eslint` is missing from declared dependencies.
- This PR was prepared with AI assistance and reviewed against the current code paths; the checks listed above were run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Run details now load dynamically when expanding run rows with a loading indicator displayed during fetch.
  * Improved performance of run listings by reducing response sizes.

* **Bug Fixes**
  * Fixed URL parameter handling for the run details endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getmaxun/maxun/pull/1067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->