### PR TITLE
fix: match textfield label value for cli/mcp/api/sdk run types

### DIFF
--- a/src/components/run/ColapsibleRow.tsx
+++ b/src/components/run/ColapsibleRow.tsx
@@ -256,7 +256,15 @@ export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, cu
                                 ? t('runs_table.run_settings_modal.labels.run_by_schedule')
                                 : row.runByUserId
                                   ? t('runs_table.run_settings_modal.labels.run_by_user')
-                                  : t('runs_table.run_settings_modal.labels.run_by_unknown')
+                                  : row.runByCLI
+                                    ? t('runs_table.run_settings_modal.labels.run_by_cli')
+                                    : row.runByMCP
+                                      ? t('runs_table.run_settings_modal.labels.run_by_mcp')
+                                      : row.runBySDK
+                                        ? t('runs_table.run_settings_modal.labels.run_by_sdk')
+                                        : row.runByAPI
+                                          ? t('runs_table.run_settings_modal.labels.run_by_api')
+                                          : t('runs_table.run_settings_modal.labels.run_by_unknown')
                             }
                             value={runByLabel}
                             InputProps={{ readOnly: true }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced the run source label display in the run settings dialog to properly identify different types of run initiations, including CLI, MCP, SDK, and API sources, with accurate corresponding labels for each run type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->