### PR TITLE
feat(core): add support for summary data format

### DIFF
--- a/maxun-core/src/index.ts
+++ b/maxun-core/src/index.ts
@@ -6,3 +6,5 @@ export type {
   WorkflowFile, WhereWhatPair, Where, What,
 } from './types/workflow';
 export { unaryOperators, naryOperators, meta as metaOperators } from './types/logic';
+export { OUTPUT_FORMAT_OPTIONS, HEAVY_RENDER_FORMATS } from './types/formats';
+export type { OutputFormat } from './types/formats';

--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -7,6 +7,7 @@ import {
   Where, What, PageState, Workflow, WorkflowFile,
   ParamType, SelectorArray, CustomFunctions,
 } from './types/workflow';
+import { HEAVY_RENDER_FORMATS } from './types/formats';
 
 import { operators, meta } from './types/logic';
 import { arrayToObject } from './utils/utils';
@@ -412,14 +413,12 @@ export default class Interpreter extends EventEmitter {
 
       if (s.action === 'scrape') {
         const formats: string[] = firstArg.formats ?? [];
-        const heavyFormats = ['markdown', 'html', 'text', 'screenshot-visible', 'screenshot-full'];
-        return formats.some((f: string) => heavyFormats.includes(f));
+        return formats.some((f: string) => (HEAVY_RENDER_FORMATS as readonly string[]).includes(f));
       }
 
       if (s.action === 'crawl' || s.action === 'search') {
         const outputFormats: string[] = (firstArg as any).outputFormats ?? [];
-        const heavyFormats = ['markdown', 'html', 'text', 'screenshot-visible', 'screenshot-full'];
-        return outputFormats.some((f: string) => heavyFormats.includes(f));
+        return outputFormats.some((f: string) => (HEAVY_RENDER_FORMATS as readonly string[]).includes(f));
       }
 
       return false;

--- a/maxun-core/src/types/formats.ts
+++ b/maxun-core/src/types/formats.ts
@@ -1,0 +1,25 @@
+export const OUTPUT_FORMAT_OPTIONS = [
+  'markdown',
+  'html',
+  'text',
+  'links',
+  'summary',
+  'screenshot-visible',
+  'screenshot-fullpage',
+] as const;
+
+export type OutputFormat = (typeof OUTPUT_FORMAT_OPTIONS)[number];
+
+/**
+ * Formats that require a full browser render of the page.
+ * Used to decide whether the interpreter needs to keep a live browser page open.
+ * 'links' is excluded — link extraction is lightweight and does not need rendering.
+ */
+export const HEAVY_RENDER_FORMATS: readonly OutputFormat[] = [
+  'markdown',
+  'html',
+  'text',
+  'summary',
+  'screenshot-visible',
+  'screenshot-fullpage',
+];

--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -19,6 +19,7 @@ import { sendWebhook } from "../routes/webhook";
 import { convertPageToHTML, convertPageToLinks, convertPageToMarkdown, convertPageToScreenshot, convertPageToText } from '../markdownify/scrape';
 import { executeBrowserAgent } from '../sdk/browserAgent';
 import { OutputFormats } from '../constants/output-formats';
+import { processRobotOutputFormats } from '../utils/output-post-processor';
 import { addJob } from '../storage/graphileWorker';
 import { QUEUE_NAMES } from '../task-runner';
 
@@ -399,6 +400,8 @@ function formatRunResponse(run: any) {
             searchData: {},
             markdown: '',
             html: '',
+            links: [] as string[],
+            summary: null as string | null,
             promptResult: null as any
         },
         screenshots: [] as any[],
@@ -428,6 +431,10 @@ function formatRunResponse(run: any) {
 
     if (output.html && Array.isArray(output.html)) {
         formattedRun.data.html = output.html[0]?.content || '';
+    }
+
+    if (output.summary && Array.isArray(output.summary) && output.summary.length > 0) {
+        formattedRun.data.summary = output.summary[0]?.content || null;
     }
 
     if (output.promptResult && Array.isArray(output.promptResult)) {
@@ -786,8 +793,8 @@ async function executeRun(id: string, userId: string) {
             let formats = rawFormats && rawFormats.length > 0 ? rawFormats : ['markdown'];
 
             if (requestedFormats && Array.isArray(requestedFormats) && requestedFormats.length > 0) {
-                formats = requestedFormats.filter((f): f is 'text' | 'markdown' | 'html' | 'links' | 'screenshot-visible' | 'screenshot-fullpage' =>
-                    ['text', 'markdown', 'html', 'links', 'screenshot-visible', 'screenshot-fullpage'].includes(f)
+                formats = requestedFormats.filter((f): f is 'text' | 'markdown' | 'html' | 'links' | 'screenshot-visible' | 'screenshot-fullpage' | 'summary' =>
+                    ['text', 'markdown', 'html', 'links', 'screenshot-visible', 'screenshot-fullpage', 'summary'].includes(f)
                 );
             }
 
@@ -863,18 +870,42 @@ async function executeRun(id: string, userId: string) {
                     }
                 }
 
-                if (formats.includes('markdown')) {
+                if (formats.includes('markdown') || formats.includes('summary')) {
                     try {
                         const markdownPromise = convertPageToMarkdown(url, currentPage);
                         const timeoutPromise = new Promise<never>((_, reject) => {
                             setTimeout(() => reject(new Error(`Markdown conversion timed out after ${SCRAPE_TIMEOUT / 1000}s`)), SCRAPE_TIMEOUT);
                         });
                         markdown = await Promise.race([markdownPromise, timeoutPromise]);
-                        if (markdown && markdown.trim().length > 0) {
+                        if (markdown && markdown.trim().length > 0 && formats.includes('markdown')) {
                             serializableOutput.markdown = [{ content: markdown }];
                         }
                     } catch (error: any) {
                         logger.log('warn', `Markdown conversion failed for API run ${plainRun.runId}: ${error.message}`);
+                    }
+                }
+
+                if (formats.includes('summary')) {
+                    try {
+                        if (!markdown) {
+                            markdown = await Promise.race([
+                                convertPageToMarkdown(url, currentPage),
+                                new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`Markdown timed out`)), SCRAPE_TIMEOUT))
+                            ]);
+                        }
+                        if (markdown && markdown.trim().length > 0) {
+                            const { summarizeMarkdown } = require('../utils/summarizer');
+                            const llmConfig = {
+                                provider: ((recording.recording_meta as any).promptLlmProvider || 'ollama') as 'anthropic' | 'openai' | 'ollama',
+                                model: (recording.recording_meta as any).promptLlmModel as string | undefined,
+                                apiKey: (recording.recording_meta as any).promptLlmApiKey as string | undefined,
+                                baseUrl: (recording.recording_meta as any).promptLlmBaseUrl as string | undefined,
+                            };
+                            const summaryText = await summarizeMarkdown(markdown, llmConfig);
+                            serializableOutput.summary = [{ content: summaryText }];
+                        }
+                    } catch (error: any) {
+                        logger.log('warn', `Summary generation failed for API run ${plainRun.runId}: ${error.message}`);
                     }
                 }
 
@@ -978,6 +1009,7 @@ async function executeRun(id: string, userId: string) {
 
                 if (serializableOutput.markdown) webhookPayload.markdown = markdown;
                 if (serializableOutput.html) webhookPayload.html = html;
+                if (serializableOutput.summary) webhookPayload.summary = serializableOutput.summary[0]?.content || '';
                 if (uploadedBinaryOutput['screenshot-visible']) webhookPayload.screenshot_visible = uploadedBinaryOutput['screenshot-visible'];
                 if (uploadedBinaryOutput['screenshot-fullpage']) webhookPayload.screenshot_fullpage = uploadedBinaryOutput['screenshot-fullpage'];
 
@@ -1095,8 +1127,51 @@ async function executeRun(id: string, userId: string) {
 
         const interpretationInfo = await Promise.race([interpretationPromise, timeoutPromise]);
 
+        const finalRun = await Run.findByPk(run.id);
+        let categorizedOutput = {
+            crawl: finalRun?.serializableOutput?.crawl || {},
+            search: finalRun?.serializableOutput?.search || {},
+        };
+        let postBinaryOutput: Record<string, any> = { ...(interpretationInfo.binaryOutput || {}) };
+
+        if (robotType === 'crawl' || robotType === 'search') {
+            const outputFormats = run.interpreterSettings?.formats || (recording.recording_meta as any).formats as string[] | undefined;
+            const llmConfig = {
+                provider: ((recording.recording_meta as any).promptLlmProvider || 'ollama') as 'anthropic' | 'openai' | 'ollama',
+                model: (recording.recording_meta as any).promptLlmModel as string | undefined,
+                apiKey: (recording.recording_meta as any).promptLlmApiKey as string | undefined,
+                baseUrl: (recording.recording_meta as any).promptLlmBaseUrl as string | undefined,
+            };
+            try {
+                const processedOutput = await processRobotOutputFormats({
+                    robotType,
+                    outputFormats,
+                    categorizedOutput: {
+                        crawl: categorizedOutput.crawl as Record<string, any>,
+                        search: categorizedOutput.search as Record<string, any>,
+                    },
+                    currentPage,
+                    initialBinaryOutput: postBinaryOutput,
+                    llmConfig,
+                });
+                categorizedOutput.crawl = processedOutput.categorizedOutput.crawl;
+                categorizedOutput.search = processedOutput.categorizedOutput.search;
+                postBinaryOutput = processedOutput.binaryOutput;
+
+                await run.update({
+                    serializableOutput: {
+                        ...(finalRun?.serializableOutput || {}),
+                        crawl: categorizedOutput.crawl,
+                        search: categorizedOutput.search,
+                    }
+                });
+            } catch (postProcessError: any) {
+                logger.log('warn', `Output post-processing failed for run ${plainRun.runId}: ${postProcessError.message}`);
+            }
+        }
+
         const binaryOutputService = new BinaryOutputService('maxun-run-screenshots');
-        const uploadedBinaryOutput = await binaryOutputService.uploadAndStoreBinaryOutput(run, interpretationInfo.binaryOutput);
+        const uploadedBinaryOutput = await binaryOutputService.uploadAndStoreBinaryOutput(run, postBinaryOutput);
 
         if (browser && browser.interpreter) {
             await browser.interpreter.clearState();

--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -1532,7 +1532,7 @@ async function waitForRunCompletion(runId: string, interval: number = 2000) {
  *                   enum: [markdown, html]
  *                 description: Optional override formats for this run.
  *           example:
- *             formats: ["html"]
+ *             formats: ['markdown','html','text','links','summary','screenshot-visible','screenshot-fullpage']
  *     responses:
  *       200:
  *         description: Robot run started successfully.

--- a/server/src/api/sdk.ts
+++ b/server/src/api/sdk.ts
@@ -747,6 +747,8 @@ router.post("/sdk/robots/:id/execute", requireAPIKey, async (req: AuthenticatedR
 
         let markdown: string | undefined = undefined;
         let html: string | undefined = undefined;
+        let summary: string | undefined = undefined;
+
         if (run.serializableOutput?.markdown && Array.isArray(run.serializableOutput.markdown)) {
             markdown = run.serializableOutput.markdown[0]?.content || undefined;
         }
@@ -758,6 +760,12 @@ router.post("/sdk/robots/:id/execute", requireAPIKey, async (req: AuthenticatedR
         }
         if (!html && scrapeOutput?.html && Array.isArray(scrapeOutput.html)) {
             html = scrapeOutput.html[0]?.content || undefined;
+        }
+        if (run.serializableOutput?.summary && Array.isArray(run.serializableOutput.summary)) {
+            summary = run.serializableOutput.summary[0]?.content || undefined;
+        }
+        if (!summary && scrapeOutput?.summary && Array.isArray(scrapeOutput.summary)) {
+            summary = scrapeOutput.summary[0]?.content || undefined;
         }
 
         const promptResultRaw = run.serializableOutput?.promptResult;
@@ -777,6 +785,7 @@ router.post("/sdk/robots/:id/execute", requireAPIKey, async (req: AuthenticatedR
                     text: text,
                     markdown: markdown,
                     html: html,
+                    summary: summary,
                     promptResult: promptResult
                 },
                 screenshots: Object.values(run.binaryOutput || {})

--- a/server/src/constants/output-formats.ts
+++ b/server/src/constants/output-formats.ts
@@ -3,8 +3,9 @@ export const OUTPUT_FORMAT_OPTIONS = [
   'html',
   'text',
   'links',
+  'summary',
   'screenshot-visible',
-  'screenshot-fullpage',
+  'screenshot-fullpage'
 ] as const;
 
 export type OutputFormats = (typeof OUTPUT_FORMAT_OPTIONS)[number];
@@ -14,8 +15,9 @@ export const SCRAPE_OUTPUT_FORMAT_OPTIONS: OutputFormats[] = [
   'html',
   'text',
   'links',
+  'summary',
   'screenshot-visible',
-  'screenshot-fullpage',
+  'screenshot-fullpage'
 ];
 
 export const SEARCH_SCRAPE_OUTPUT_FORMAT_OPTIONS: OutputFormats[] = [
@@ -23,8 +25,9 @@ export const SEARCH_SCRAPE_OUTPUT_FORMAT_OPTIONS: OutputFormats[] = [
   'html',
   'text',
   'links',
+  'summary',
   'screenshot-visible',
-  'screenshot-fullpage',
+  'screenshot-fullpage'
 ];
 
 const OUTPUT_FORMAT_SET = new Set<string>(OUTPUT_FORMAT_OPTIONS as readonly string[]);

--- a/server/src/task-runner.ts
+++ b/server/src/task-runner.ts
@@ -267,9 +267,37 @@ async function processRunExecution(data: ExecuteRunData): Promise<void> {
             if (text) serializableOutput.text = [{ content: text }];
           }
 
-          if (formats.includes('markdown')) {
-            const markdown = await Promise.race([convertPageToMarkdown(url, currentPage), new Promise<never>((_, r) => setTimeout(() => r(new Error('timeout')), SCRAPE_TIMEOUT))]);
-            serializableOutput.markdown = [{ content: markdown }];
+          let markdown = '';
+          if (formats.includes('markdown') || formats.includes('summary')) {
+            try {
+              markdown = await Promise.race([convertPageToMarkdown(url, currentPage), new Promise<never>((_, r) => setTimeout(() => r(new Error('timeout')), SCRAPE_TIMEOUT))]);
+              if (markdown && markdown.trim().length > 0 && formats.includes('markdown')) {
+                serializableOutput.markdown = [{ content: markdown }];
+              }
+            } catch (error: any) {
+              logger.log('warn', `Markdown conversion failed for run ${data.runId}: ${error.message}`);
+            }
+          }
+
+          if (formats.includes('summary')) {
+            try {
+              if (!markdown) {
+                markdown = await Promise.race([convertPageToMarkdown(url, currentPage), new Promise<never>((_, r) => setTimeout(() => r(new Error('timeout')), SCRAPE_TIMEOUT))]);
+              }
+              if (markdown && markdown.trim().length > 0) {
+                const { summarizeMarkdown } = require('./utils/summarizer');
+                const llmConfig = {
+                  provider: ((recording.recording_meta as any).promptLlmProvider || 'ollama') as 'anthropic' | 'openai' | 'ollama',
+                  model: (recording.recording_meta as any).promptLlmModel as string | undefined,
+                  apiKey: (recording.recording_meta as any).promptLlmApiKey as string | undefined,
+                  baseUrl: (recording.recording_meta as any).promptLlmBaseUrl as string | undefined,
+                };
+                const summaryText = await summarizeMarkdown(markdown, llmConfig);
+                serializableOutput.summary = [{ content: summaryText }];
+              }
+            } catch (error: any) {
+              logger.log('warn', `Summary generation failed for run ${data.runId}: ${error.message}`);
+            }
           }
 
           if (formats.includes('html')) {
@@ -322,7 +350,12 @@ async function processRunExecution(data: ExecuteRunData): Promise<void> {
           }
 
           try {
-            await sendWebhook(plainRun.robotMetaId, 'run_completed', { runId: data.runId, robotId: plainRun.robotMetaId, robotName: recording.recording_meta.name, status: 'success', finishedAt: new Date().toLocaleString() });
+            const webhookPayload: any = { runId: data.runId, robotId: plainRun.robotMetaId, robotName: recording.recording_meta.name, status: 'success', finishedAt: new Date().toLocaleString() };
+            if (serializableOutput.markdown) webhookPayload.markdown = serializableOutput.markdown[0]?.content || '';
+            if (serializableOutput.html) webhookPayload.html = serializableOutput.html[0]?.content || '';
+            if (serializableOutput.links) webhookPayload.links = serializableOutput.links;
+            if (serializableOutput.summary) webhookPayload.summary = serializableOutput.summary[0]?.content || '';
+            await sendWebhook(plainRun.robotMetaId, 'run_completed', webhookPayload);
           } catch (webhookError: any) {
             logger.log('warn', `Failed to send webhooks for run ${data.runId}: ${webhookError.message}`);
           }
@@ -406,6 +439,12 @@ async function processRunExecution(data: ExecuteRunData): Promise<void> {
           categorizedOutput: { crawl: categorizedOutput.crawl as Record<string, any>, search: categorizedOutput.search as Record<string, any> },
           currentPage,
           initialBinaryOutput: binaryOutput,
+          llmConfig: {
+            provider: ((recording.recording_meta as any).promptLlmProvider || 'ollama') as 'anthropic' | 'openai' | 'ollama',
+            model: (recording.recording_meta as any).promptLlmModel as string | undefined,
+            apiKey: (recording.recording_meta as any).promptLlmApiKey as string | undefined,
+            baseUrl: (recording.recording_meta as any).promptLlmBaseUrl as string | undefined,
+          },
         });
 
         categorizedOutput.crawl = processedOutput.categorizedOutput.crawl;

--- a/server/src/utils/output-post-processor.ts
+++ b/server/src/utils/output-post-processor.ts
@@ -3,6 +3,7 @@ import logger from '../logger';
 import { parseMarkdown } from '../markdownify/markdown';
 import { convertPageToScreenshot } from '../markdownify/scrape';
 import { DEFAULT_OUTPUT_FORMATS } from '../constants/output-formats';
+import { LLMConfig } from '../sdk/browserAgent';
 
 interface CategorizedOutput {
   crawl: Record<string, any>;
@@ -15,6 +16,7 @@ interface ProcessRobotOutputParams {
   categorizedOutput: CategorizedOutput;
   currentPage: Page;
   initialBinaryOutput?: Record<string, any>;
+  llmConfig?: LLMConfig;
 }
 
 interface ProcessRobotOutputResult {
@@ -31,6 +33,7 @@ export async function processRobotOutputFormats(
     categorizedOutput,
     currentPage,
     initialBinaryOutput,
+    llmConfig,
   } = params;
 
   const binaryOutput: Record<string, any> = {
@@ -72,6 +75,18 @@ export async function processRobotOutputFormats(
         }
         if (!effectiveFormats.includes('text')) delete pageResult.text;
         if (!effectiveFormats.includes('links')) delete pageResult.links;
+
+        if (effectiveFormats.includes('summary')) {
+          const pageText = (pageResult.markdown || pageResult.text || '').substring(0, 40000);
+          if (pageText.trim()) {
+            try {
+              const { summarizeMarkdown } = require('../utils/summarizer');
+              pageResult.summary = await summarizeMarkdown(pageText, llmConfig);
+            } catch (e: any) {
+              logger.log('warn', `Failed to generate crawl page summary: ${e.message}`);
+            }
+          }
+        }
 
         const pageUrl = pageResult.metadata?.url || pageResult.url;
         const hasPageUrl = typeof pageUrl === 'string' && pageUrl.trim() !== '';
@@ -143,6 +158,18 @@ export async function processRobotOutputFormats(
           }
           if (!effectiveFormats.includes('text')) delete result.text;
           if (!effectiveFormats.includes('links')) delete result.links;
+
+          if (effectiveFormats.includes('summary')) {
+            const pageText = (result.markdown || result.text || '').substring(0, 40000);
+            if (pageText.trim()) {
+              try {
+                const { summarizeMarkdown } = require('../utils/summarizer');
+                result.summary = await summarizeMarkdown(pageText, llmConfig);
+              } catch (e: any) {
+                logger.log('warn', `Failed to generate search result summary: ${e.message}`);
+              }
+            }
+          }
 
           const resultUrl = result.metadata?.url || result.url;
           const hasResultUrl = typeof resultUrl === 'string' && resultUrl.trim() !== '';

--- a/server/src/utils/summarizer.ts
+++ b/server/src/utils/summarizer.ts
@@ -1,0 +1,145 @@
+import Anthropic from '@anthropic-ai/sdk';
+import axios from 'axios';
+import logger from '../logger';
+import { LLMConfig } from '../sdk/browserAgent';
+
+const SYSTEM_PROMPT = `You are a web page summarizer. Your output is plain text only.
+
+STRICT RULES — violating any of these is an error:
+- Output ONLY the summary. Do not write any preamble, intro, or closing. Do not say "Here is", "Here's", "Sure", "This page", "In summary", "Conclusion", or anything like that. Start immediately with the content.
+- NO markdown of any kind: no ** bold **, no * italic *, no ## headers, no \`code\`, no > quotes, no --- dividers, no code fences.
+- NO section headers or titles. Do not label sections like "Benefits:", "Top Tools:", "Conclusion:", etc.
+- Write 2–4 plain sentences covering the main point. Then, only if there is a genuine list (features, named items, steps), add plain bullet points using a hyphen (-). No bold inside bullet points.
+- Keep it short and factual. Do not pad, repeat, or editorialize.`;
+
+const USER_PROMPT_PREFIX = `Summarize the following web page in plain text. Start directly with the summary — no intro, no headings, no bold, no markdown.\n\n`;
+
+const MAX_TOKENS = 1500;
+
+function cleanOutput(text: string): string {
+  let out = text.trim();
+
+  // Strip code fences
+  const fenceMatch = out.match(/^```(?:markdown)?\r?\n([\s\S]*?)```\s*$/);
+  if (fenceMatch) {
+    out = fenceMatch[1].trim();
+  } else if (out.startsWith('```')) {
+    out = out.replace(/^```[^\n]*\n/, '').replace(/```\s*$/, '').trim();
+  }
+
+  // Strip markdown bold/italic (**text**, *text*, __text__, _text_)
+  out = out.replace(/\*\*([^*]+)\*\*/g, '$1');
+  out = out.replace(/__([^_]+)__/g, '$1');
+  out = out.replace(/\*([^*]+)\*/g, '$1');
+  out = out.replace(/_([^_]+)_/g, '$1');
+
+  // Strip ATX headers (## Heading)
+  out = out.replace(/^#{1,6}\s+/gm, '');
+
+  // Strip inline code
+  out = out.replace(/`([^`]+)`/g, '$1');
+
+  // Strip preamble lines like "Here is...", "Sure!", "This is a summary of..."
+  out = out.replace(/^(here(?:'s| is)\b[^\n]*\n+|sure[!,.]?\s*\n+|in summary[,:]?\s*\n+)/i, '');
+
+  return out.trim();
+}
+
+/**
+ * Summarizes markdown/text content using the robot's configured LLM provider.
+ * Supports: anthropic, openai (and compatible), ollama (local).
+ */
+export async function summarizeMarkdown(markdown: string, llmConfig?: LLMConfig): Promise<string> {
+  if (!markdown || markdown.trim().length === 0) {
+    throw new Error('Content is empty');
+  }
+
+  const truncated = markdown.substring(0, 40000);
+  const userPrompt = USER_PROMPT_PREFIX + truncated;
+
+  const config: LLMConfig = llmConfig || { provider: 'ollama' };
+  const { provider } = config;
+
+  if (provider === 'anthropic') {
+    const anthropic = new Anthropic({ apiKey: config.apiKey || process.env.ANTHROPIC_API_KEY });
+    const model = config.model || 'claude-haiku-4-5-20251001';
+    logger.info(`[Summarizer] Using Anthropic (${model})`);
+
+    const response = await anthropic.messages.create({
+      model,
+      max_tokens: MAX_TOKENS,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userPrompt }],
+    });
+    const textContent = response.content.find((c: any) => c.type === 'text');
+    const content = textContent?.type === 'text' ? textContent.text : '';
+    if (!content || content.trim().length === 0) {
+      throw new Error('Anthropic returned empty summary');
+    }
+    return cleanOutput(content);
+  }
+
+  if (provider === 'openai') {
+    const baseUrl = config.baseUrl || 'https://api.openai.com/v1';
+    const model = config.model || 'gpt-4o-mini';
+    logger.info(`[Summarizer] Using OpenAI-compatible at ${baseUrl} (${model})`);
+
+    const response = await axios.post(
+      `${baseUrl}/chat/completions`,
+      {
+        model,
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: userPrompt },
+        ],
+        max_tokens: MAX_TOKENS,
+        temperature: 0.1,
+      },
+      {
+        headers: {
+          'Authorization': `Bearer ${config.apiKey || process.env.OPENAI_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        timeout: 60000,
+      }
+    );
+    const content = response.data.choices?.[0]?.message?.content || '';
+    if (!content || content.trim().length === 0) {
+      throw new Error('OpenAI returned empty summary');
+    }
+    return cleanOutput(content);
+  }
+
+  if (provider === 'ollama') {
+    const baseUrl = config.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+    const model = config.model || 'llama3.2';
+    logger.info(`[Summarizer] Using Ollama at ${baseUrl} (${model})`);
+
+    const controller = new AbortController();
+    const tid = setTimeout(() => controller.abort(), 120000);
+    try {
+      const response = await axios.post(
+        `${baseUrl}/api/chat`,
+        {
+          model,
+          messages: [
+            { role: 'system', content: SYSTEM_PROMPT },
+            { role: 'user', content: userPrompt },
+          ],
+          stream: false,
+          options: { temperature: 0.1, num_predict: MAX_TOKENS },
+        },
+        { signal: controller.signal as any }
+      );
+      const content = response.data.message?.content || '';
+      if (!content || content.trim().length === 0) {
+        throw new Error('Ollama returned empty summary');
+      }
+      return cleanOutput(content);
+    } finally {
+      clearTimeout(tid);
+    }
+  }
+
+  throw new Error(`Unsupported LLM provider: ${provider}`);
+}

--- a/server/src/workflow-management/scheduler/index.ts
+++ b/server/src/workflow-management/scheduler/index.ts
@@ -348,13 +348,43 @@ async function executeRun(id: string, userId: string) {
           if (text) serializableOutput.text = [{ content: text }];
         }
 
-        if (formats.includes("markdown")) {
-          const markdownPromise = convertPageToMarkdown(url, currentPage);
-          const timeoutPromise = new Promise<never>((_, reject) => {
-            setTimeout(() => reject(new Error(`Markdown conversion timed out after ${SCRAPE_TIMEOUT/1000}s`)), SCRAPE_TIMEOUT);
-          });
-          markdown = await Promise.race([markdownPromise, timeoutPromise]);
-          serializableOutput.markdown = [{ content: markdown }];
+        if (formats.includes("markdown") || formats.includes("summary")) {
+          try {
+            const markdownPromise = convertPageToMarkdown(url, currentPage);
+            const timeoutPromise = new Promise<never>((_, reject) => {
+              setTimeout(() => reject(new Error(`Markdown conversion timed out after ${SCRAPE_TIMEOUT/1000}s`)), SCRAPE_TIMEOUT);
+            });
+            markdown = await Promise.race([markdownPromise, timeoutPromise]);
+            if (markdown && markdown.trim().length > 0 && formats.includes("markdown")) {
+              serializableOutput.markdown = [{ content: markdown }];
+            }
+          } catch (error: any) {
+            logger.log('warn', `Markdown conversion failed for scheduled run ${plainRun.runId}: ${error.message}`);
+          }
+        }
+
+        if (formats.includes("summary")) {
+          try {
+            if (!markdown) {
+              markdown = await Promise.race([
+                convertPageToMarkdown(url, currentPage),
+                new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`Markdown timed out`)), SCRAPE_TIMEOUT))
+              ]);
+            }
+            if (markdown && markdown.trim().length > 0) {
+              const { summarizeMarkdown } = require('../../utils/summarizer');
+              const llmConfig = {
+                provider: ((recording.recording_meta as any).promptLlmProvider || 'ollama') as 'anthropic' | 'openai' | 'ollama',
+                model: (recording.recording_meta as any).promptLlmModel as string | undefined,
+                apiKey: (recording.recording_meta as any).promptLlmApiKey as string | undefined,
+                baseUrl: (recording.recording_meta as any).promptLlmBaseUrl as string | undefined,
+              };
+              const summaryText = await summarizeMarkdown(markdown, llmConfig);
+              serializableOutput.summary = [{ content: summaryText }];
+            }
+          } catch (error: any) {
+            logger.log('warn', `Summary generation failed for scheduled run ${plainRun.runId}: ${error.message}`);
+          }
         }
 
         if (formats.includes("html")) {
@@ -454,6 +484,7 @@ async function executeRun(id: string, userId: string) {
 
         if (formats.includes('markdown')) webhookPayload.markdown = markdown;
         if (formats.includes('html')) webhookPayload.html = html;
+        if (serializableOutput.summary) webhookPayload.summary = serializableOutput.summary[0]?.content || '';
         if (uploadedBinaryOutput['screenshot-visible']) webhookPayload.screenshot_visible = uploadedBinaryOutput['screenshot-visible'];
         if (uploadedBinaryOutput['screenshot-fullpage']) webhookPayload.screenshot_fullpage = uploadedBinaryOutput['screenshot-fullpage'];
 
@@ -584,6 +615,12 @@ async function executeRun(id: string, userId: string) {
         },
         currentPage,
         initialBinaryOutput: binaryOutput,
+        llmConfig: {
+          provider: ((recording.recording_meta as any).promptLlmProvider || 'ollama') as 'anthropic' | 'openai' | 'ollama',
+          model: (recording.recording_meta as any).promptLlmModel as string | undefined,
+          apiKey: (recording.recording_meta as any).promptLlmApiKey as string | undefined,
+          baseUrl: (recording.recording_meta as any).promptLlmBaseUrl as string | undefined,
+        },
       });
 
       categorizedOutput.crawl = processedOutput.categorizedOutput.crawl;

--- a/src/components/run/RunContent.tsx
+++ b/src/components/run/RunContent.tsx
@@ -168,6 +168,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
   const [htmlContent, setHtmlContent] = useState<string>('');
   const [textContent, setTextContent] = useState<string>('');
   const [linksContent, setLinksContent] = useState<string[]>([]);
+  const [summaryContent, setSummaryContent] = useState<string>('');
   const [smartQueryResult, setSmartQueryResult] = useState<string>('');
 
   const [schemaData, setSchemaData] = useState<any[]>([]);
@@ -219,6 +220,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
     setSmartQueryResult('');
     setTextContent('');
     setLinksContent([]);
+    setSummaryContent('');
 
     if (!row.serializableOutput) return;
 
@@ -254,6 +256,13 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
           typeof item === 'string' ? item : item?.url ?? ''
         ).filter(Boolean);
         if (urls.length > 0) setLinksContent(urls);
+      }
+
+      if (output?.summary && Array.isArray(output.summary)) {
+        const summaryData = output.summary[0];
+        if (summaryData?.content) {
+          setSummaryContent(summaryData.content);
+        }
       }
     };
 
@@ -313,7 +322,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
 
     if (!row.serializableOutput) return;
 
-    const modernKeys = ['scrapeSchema', 'scrapeList', 'crawl', 'search', 'markdown', 'html', 'textContent', 'text', 'scrapeDoc', 'links', 'promptResult'];
+    const modernKeys = ['scrapeSchema', 'scrapeList', 'crawl', 'search', 'markdown', 'html', 'textContent', 'text', 'scrapeDoc', 'links', 'summary', 'promptResult'];
     const hasModernData = modernKeys.some(key => row.serializableOutput[key]);
 
     const hasLegacySchema = row.serializableOutput.scrapeSchema && Array.isArray(row.serializableOutput.scrapeSchema);
@@ -1307,12 +1316,13 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
   const hasHTML = htmlContent && htmlContent.length > 0;
   const hasTextFormat = textContent && textContent.length > 0;
   const hasLinks = linksContent && linksContent.length > 0;
+  const hasSummary = summaryContent && summaryContent.length > 0;
   const promptResultData = smartQueryResult || null;
   const hasPromptResult = !!promptResultData;
   const hasCrawlPageScreenshots = crawlData.some(group => Array.isArray(group) && group.some((item: any) => item?.screenshotVisible || item?.screenshotFullpage));
   const hasSearchResultScreenshots = searchData.some((item: any) => item?.screenshotVisible || item?.screenshotFullpage);
   const showCapturedScreenshotSection = hasScreenshots && !hasCrawlPageScreenshots && !hasSearchResultScreenshots;
-  const isExtractRobot = schemaData.length > 0 || listData.length > 0 || legacyData.length > 0 || (!hasMarkdown && !hasHTML && !hasTextFormat && !hasLinks && crawlData.length === 0 && searchData.length === 0);
+  const isExtractRobot = schemaData.length > 0 || listData.length > 0 || legacyData.length > 0 || (!hasMarkdown && !hasHTML && !hasTextFormat && !hasLinks && !hasSummary && crawlData.length === 0 && searchData.length === 0);
 
   return (
     <Box sx={{ width: '100%' }}>
@@ -1347,7 +1357,7 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                   </Button>
                 )}
             </>
-          ) : (!hasData && !hasScreenshots && !hasMarkdown && !hasHTML && !hasTextFormat && !hasLinks && !hasPromptResult ? (
+          ) : (!hasData && !hasScreenshots && !hasMarkdown && !hasHTML && !hasTextFormat && !hasLinks && !hasPromptResult && !hasSummary ? (
             <Box sx={{ p: 2 }}>
               <Typography paragraph>
                 {t('run_content.no_data_found', 'No data found. Need help?')}{" "}
@@ -1513,6 +1523,35 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                         sx={{ color: '#FF00C3', textTransform: 'none', p: 0, minWidth: 'auto', backgroundColor: 'transparent', '&:hover': { textDecoration: 'underline', backgroundColor: 'transparent' } }}
                       >
                         Download Links
+                      </Button>
+                    </Box>
+                  </AccordionDetails>
+                </Accordion>
+              )}
+
+              {hasSummary && crawlData.length === 0 && searchData.length === 0 && (
+                <Accordion defaultExpanded style={{ marginLeft: "-38px" }}>
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                      <PsychologyIcon sx={{ mr: 1 }} />
+                      <Typography variant='subtitle1'>Summary</Typography>
+                    </Box>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <Box sx={{ position: 'relative' }}>
+                      <Paper sx={{ p: 2, pr: '50px', maxHeight: '500px', overflow: 'auto', backgroundColor: darkMode ? '#1e1e1e' : '#f5f5f5' }}>
+                        <Typography component="pre" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontFamily: 'monospace', fontSize: '14px', lineHeight: 1.6, m: 0, color: 'inherit' }}>
+                          {summaryContent}
+                        </Typography>
+                      </Paper>
+                      <CopyButton content={summaryContent} darkMode={darkMode} />
+                    </Box>
+                    <Box sx={{ mt: 2 }}>
+                      <Button
+                        onClick={() => downloadMarkdown(summaryContent, `${row.name || 'summary'}.md`)}
+                        sx={{ color: '#FF00C3', textTransform: 'none', p: 0, minWidth: 'auto', '&:hover': { textDecoration: 'underline', backgroundColor: 'transparent' } }}
+                      >
+                        Download Summary
                       </Button>
                     </Box>
                   </AccordionDetails>
@@ -2107,6 +2146,43 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                           );
                         })()}
 
+                        {crawlData[0][currentCrawlIndex].summary && (
+                          <Accordion>
+                            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                                <Typography variant='subtitle1'>
+                                  <PsychologyIcon sx={{ mr: 1, verticalAlign: 'middle', mb: '3px' }} /> Summary
+                                </Typography>
+                              </Box>
+                            </AccordionSummary>
+                            <AccordionDetails>
+                              <Box sx={{ position: 'relative' }}>
+                                <Paper sx={{ p: 2, pr: '64px', maxHeight: '500px', overflow: 'auto', backgroundColor: darkMode ? '#1e1e1e' : '#f5f5f5' }}>
+                                  <Typography component="pre" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontFamily: 'monospace', fontSize: '14px', lineHeight: 1.6, m: 0 }}>
+                                    {typeof crawlData[0][currentCrawlIndex].summary === 'string'
+                                      ? crawlData[0][currentCrawlIndex].summary
+                                      : crawlData[0][currentCrawlIndex].summary?.content || ''}
+                                  </Typography>
+                                </Paper>
+                                <CopyButton content={typeof crawlData[0][currentCrawlIndex].summary === 'string' ? crawlData[0][currentCrawlIndex].summary : crawlData[0][currentCrawlIndex].summary?.content || ''} darkMode={darkMode} />
+                              </Box>
+                              <Box sx={{ mt: 1 }}>
+                                <Button
+                                  onClick={() => {
+                                    const pageUrl = crawlData[0][currentCrawlIndex]?.metadata?.url || '';
+                                    const baseFilename = pageUrl ? pageUrl.replace(/^https?:\/\//, '').replace(/\//g, '_').replace(/[^a-zA-Z0-9_.-]/g, '_') : `page_${currentCrawlIndex + 1}`;
+                                    const content = typeof crawlData[0][currentCrawlIndex].summary === 'string' ? crawlData[0][currentCrawlIndex].summary : crawlData[0][currentCrawlIndex].summary?.content || '';
+                                    downloadMarkdown(content, `${baseFilename}_summary.md`);
+                                  }}
+                                  sx={{ color: '#FF00C3', textTransform: 'none', p: 0, minWidth: 'auto', backgroundColor: 'transparent', '&:hover': { textDecoration: 'underline', backgroundColor: 'transparent' } }}
+                                >
+                                  Download Summary
+                                </Button>
+                              </Box>
+                            </AccordionDetails>
+                          </Accordion>
+                        )}
+
                         {(crawlData[0][currentCrawlIndex].screenshotVisible || crawlData[0][currentCrawlIndex].screenshotFullpage) && (
                           <Accordion>
                             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
@@ -2496,6 +2572,46 @@ export const RunContent = ({ row, currentLog, interpretationInProgress, logEndRe
                                 </Accordion>
                               );
                             })()}
+
+                            {searchData[currentSearchIndex]?.summary && (
+                              <Accordion>
+                                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                                    <Typography variant='subtitle1'>
+                                      <PsychologyIcon sx={{ mr: 1, verticalAlign: 'middle', mb: '3px' }} /> Summary
+                                    </Typography>
+                                  </Box>
+                                </AccordionSummary>
+                                <AccordionDetails>
+                                  <Box sx={{ position: 'relative' }}>
+                                    <Paper sx={{ p: 2, pr: '64px', maxHeight: '500px', overflow: 'auto', backgroundColor: darkMode ? '#1e1e1e' : '#f5f5f5' }}>
+                                      <Typography component="pre" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', fontFamily: 'monospace', fontSize: '14px', lineHeight: 1.6, m: 0 }}>
+                                        {typeof searchData[currentSearchIndex].summary === 'string'
+                                          ? searchData[currentSearchIndex].summary
+                                          : searchData[currentSearchIndex].summary?.content || ''}
+                                      </Typography>
+                                    </Paper>
+                                    <CopyButton
+                                      content={typeof searchData[currentSearchIndex].summary === 'string' ? searchData[currentSearchIndex].summary : searchData[currentSearchIndex].summary?.content || ''}
+                                      darkMode={darkMode}
+                                    />
+                                  </Box>
+                                  <Box sx={{ mt: 1 }}>
+                                    <Button
+                                      onClick={() => {
+                                        const pageUrl = searchData[currentSearchIndex]?.url || searchData[currentSearchIndex]?.metadata?.url || '';
+                                        const baseFilename = pageUrl ? pageUrl.replace(/^https?:\/\//, '').replace(/\//g, '_').replace(/[^a-zA-Z0-9_.-]/g, '_') : `result_${currentSearchIndex + 1}`;
+                                        const content = typeof searchData[currentSearchIndex].summary === 'string' ? searchData[currentSearchIndex].summary : searchData[currentSearchIndex].summary?.content || '';
+                                        downloadMarkdown(content, `${baseFilename}_summary.md`);
+                                      }}
+                                      sx={{ color: '#FF00C3', textTransform: 'none', p: 0, minWidth: 'auto', backgroundColor: 'transparent', '&:hover': { textDecoration: 'underline', backgroundColor: 'transparent' } }}
+                                    >
+                                      Download Summary
+                                    </Button>
+                                  </Box>
+                                </AccordionDetails>
+                              </Accordion>
+                            )}
 
                             {(searchData[currentSearchIndex].screenshotVisible || searchData[currentSearchIndex].screenshotFullpage) && (
                               <Accordion>

--- a/src/constants/outputFormats.ts
+++ b/src/constants/outputFormats.ts
@@ -3,6 +3,7 @@ export const OUTPUT_FORMAT_OPTIONS = [
   'html',
   'text',
   'links',
+  'summary',
   'screenshot-visible',
   'screenshot-fullpage',
 ] as const;
@@ -18,6 +19,7 @@ export const OUTPUT_FORMAT_LABELS: Record<OutputFormats, string> = {
   html: 'HTML',
   text: 'Text Content',
   links: 'Links',
+  summary: 'Summary',
   'screenshot-visible': 'Screenshot (Visible)',
   'screenshot-fullpage': 'Screenshot (Full Page)',
 };


### PR DESCRIPTION
What this PR does?

closes #1090 

Adds the summary format for scrape, crawl and search + scrape robot types.


https://github.com/user-attachments/assets/9d2fe2da-6a04-4122-aad0-53bc465d935f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end "summary" output format for scrape, crawl, and search workflows with server-side summary generation using configured model.
  * UI shows Summary sections (primary and per-page/per-result) with copy and download actions.
  * Run and SDK responses include summary when available.
  * Webhook run_completed payloads include summary data when present.
  * Added full-page screenshot capture option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->