### PR TITLE
fix: !show target url for `doc-extract` & `doc-parse`

### DIFF
--- a/src/components/robot/pages/RobotEditPage.tsx
+++ b/src/components/robot/pages/RobotEditPage.tsx
@@ -1345,7 +1345,7 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
                 style={{ marginBottom: "20px" }}
               />
 
-              {robot.recording_meta.type !== 'search' && (
+              {!['search', 'doc-parse', 'doc-extract'].includes(robot.recording_meta.type || '') && (
                 <TextField
                   label={t("robot_duplication.fields.target_url")}
                   key={t("robot_duplication.fields.target_url")}

--- a/src/components/robot/pages/RobotSettingsPage.tsx
+++ b/src/components/robot/pages/RobotSettingsPage.tsx
@@ -129,7 +129,7 @@ export const RobotSettingsPage = ({ handleStart }: RobotSettingsProps) => {
         <Box style={{ display: "flex", flexDirection: "column" }}>
           {robot && (
             <>
-              {robot.recording_meta.type !== 'search' && (
+              {!['search', 'doc-parse', 'doc-extract'].includes(robot.recording_meta.type || '') && (
                 <TextField
                   label={t("robot_settings.target_url")}
                   key="Target URL"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * The target URL field visibility has been updated on robot configuration pages. The field is now hidden for doc-parse, doc-extract, and search robot types on both the edit and settings pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->