### PR TITLE
fix(storage): honor MINIO_PUBLIC_URL for browser-facing object URLs

### DIFF
--- a/ENVEXAMPLE
+++ b/ENVEXAMPLE
@@ -14,6 +14,10 @@ MINIO_PORT=9000                         # Port for MinIO (default: 9000)
 MINIO_CONSOLE_PORT=9001                 # Web UI Port for MinIO (default: 9001)
 MINIO_ACCESS_KEY=minio_access_key       # MinIO access key
 MINIO_SECRET_KEY=minio_secret_key       # MinIO secret key
+# Public base URL browsers use to reach stored screenshots/files. Set this when
+# MinIO is behind a reverse proxy or on a non-localhost/non-9000 public address,
+# e.g. https://storage.example.com (no internal port appended). Optional.
+# MINIO_PUBLIC_URL=https://storage.example.com
 REDIS_HOST=redis                        # Redis host in Docker
 REDIS_PORT=6379                         # Redis port (default: 6379)
 REDIS_PASSWORD=redis_password           # Redis password (This is optional. Needed to authenticate with a password-protected Redis instance; if not set, Redis will connect without authentication.)

--- a/server/src/storage/mino.ts
+++ b/server/src/storage/mino.ts
@@ -166,9 +166,17 @@ class BinaryOutputService {
           { 'Content-Type': binaryData.mimeType || 'image/png' }
         );
 
-        const publicHost = process.env.MINIO_PUBLIC_HOST || 'http://localhost';
-        const publicPort = process.env.MINIO_PORT || '9000';
-        const publicUrl = `${publicHost}:${publicPort}/${this.bucketName}/${minioKey}`;
+        // Build the browser-facing object URL. Prefer a complete public base URL
+        // (MINIO_PUBLIC_URL) so deployments behind a reverse proxy or on a
+        // non-default public port are not forced onto the internal MinIO port —
+        // which produced unreachable "localhost:9000" links (#832). Falls back to
+        // the existing host:port composition for local/dev setups.
+        const publicBase = (
+          process.env.MINIO_PUBLIC_URL
+            ? process.env.MINIO_PUBLIC_URL
+            : `${process.env.MINIO_PUBLIC_HOST || 'http://localhost'}:${process.env.MINIO_PORT || '9000'}`
+        ).replace(/\/+$/, '');
+        const publicUrl = `${publicBase}/${this.bucketName}/${minioKey}`;
 
         uploadedBinaryOutput[key] = publicUrl;
 


### PR DESCRIPTION
## Description

Stored screenshots/files never load on any deployment where MinIO is not reachable at `localhost:9000` from the browser (reverse proxy, separate host, or a non-default public port).

### Root cause

In `server/src/storage/mino.ts`, the browser-facing object URL written to a run's `binaryOutput` was composed from the **internal** MinIO host/port:

```ts
const publicHost = process.env.MINIO_PUBLIC_HOST || 'http://localhost';
const publicPort = process.env.MINIO_PORT || '9000';
const publicUrl = `${publicHost}:${publicPort}/${this.bucketName}/${minioKey}`;
```

`MINIO_PORT` is the **internal** MinIO port used for the `minio` client connection, and the host defaults to `localhost`. So in a typical Docker/proxied deploy the generated URLs point at `localhost:9000` (or force `:9000` onto a proxied host like `https://storage.example.com:9000/...`), which the browser cannot reach — the screenshots silently 404. This matches the report in #832.

### Fix

Prefer a complete public base URL via a new optional `MINIO_PUBLIC_URL`, and only fall back to the existing `MINIO_PUBLIC_HOST:MINIO_PORT` composition when it is not set:

```ts
const publicBase = (
  process.env.MINIO_PUBLIC_URL
    ? process.env.MINIO_PUBLIC_URL
    : `${process.env.MINIO_PUBLIC_HOST || 'http://localhost'}:${process.env.MINIO_PORT || '9000'}`
).replace(/\/+$/, '');
const publicUrl = `${publicBase}/${this.bucketName}/${minioKey}`;
```

- **Non-breaking:** with no new env var set, the output is byte-for-byte identical to before (verified for the default and `MINIO_PUBLIC_HOST`+`MINIO_PORT` cases).
- Deployments behind a proxy can now set `MINIO_PUBLIC_URL=https://storage.example.com` and get correct, reachable URLs (no internal port appended).
- Documents the variable in `ENVEXAMPLE`.

Fixes #832

## Testing

No automated test suite exists in the repo, so I verified the URL-building logic in isolation across cases:

| Env | Output |
|---|---|
| (default) | `http://localhost:9000/<bucket>/<key>` (unchanged) |
| `MINIO_PUBLIC_HOST=http://1.2.3.4`, `MINIO_PORT=9000` | `http://1.2.3.4:9000/<bucket>/<key>` (unchanged) |
| `MINIO_PUBLIC_URL=https://storage.example.com` | `https://storage.example.com/<bucket>/<key>` (fixed) |
| `MINIO_PUBLIC_URL=https://storage.example.com/` | trailing slash stripped → correct |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MinIO now supports optional configurable public URL setting, enabling reverse-proxy and non-localhost deployment scenarios
  * System automatically falls back to default host/port configuration when custom URL is not provided

* **Documentation**
  * Added configuration documentation and setup instructions for MinIO public URL deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->