### PR TITLE
fix: display llm robot create on reload or tab switch

### DIFF
--- a/server/src/models/Robot.ts
+++ b/server/src/models/Robot.ts
@@ -19,6 +19,7 @@ interface RobotMeta {
   promptLlmModel?: string;
   promptLlmApiKey?: string;
   promptLlmBaseUrl?: string;
+  status?: 'creating' | 'ready' | 'failed';
 }
 
 interface RobotWorkflow {

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -695,9 +695,6 @@ router.post('/recordings/llm', requireSignIn, async (req: AuthenticatedRequest, 
       return res.status(409).json({ error: `A robot with the name "${finalRobotName}" already exists.` });
     }
 
-    let workflowResult: any;
-    let finalUrl: string;
-
     const llmConfig = {
       provider: llmProvider || 'ollama',
       model: llmModel,
@@ -705,35 +702,10 @@ router.post('/recordings/llm', requireSignIn, async (req: AuthenticatedRequest, 
       baseUrl: llmBaseUrl
     };
 
-    if (url) {
-      logger.log('info', `Starting LLM workflow generation for provided URL: ${url}`);
-      workflowResult = await WorkflowEnricher.generateWorkflowFromPrompt(url, prompt, req.user.id, llmConfig);
-      finalUrl = workflowResult.url || url;
-    } else {
-      logger.log('info', `Starting LLM workflow generation with automatic URL detection for prompt: "${prompt}"`);
-      workflowResult = await WorkflowEnricher.generateWorkflowFromPromptWithSearch(prompt, req.user.id, llmConfig);
-      finalUrl = workflowResult.url || '';
-      if (finalUrl) {
-        logger.log('info', `Auto-detected URL: ${finalUrl}`);
-      }
-    }
-
-    if (finalUrl) {
-      finalUrl = normalizeRobotUrl(finalUrl);
-    }
-
-    if (!workflowResult.success || !workflowResult.workflow) {
-      logger.log('error', `Failed to generate workflow: ${JSON.stringify(workflowResult.errors)}`);
-      return res.status(400).json({
-        error: 'Failed to generate workflow from prompt',
-        details: workflowResult.errors
-      });
-    }
-
     const robotId = uuid();
     const currentTimestamp = new Date().toISOString();
 
-    const newRobot = await Robot.create({
+    const stubRobot = await Robot.create({
       id: uuid(),
       userId: req.user.id,
       recording_meta: {
@@ -741,13 +713,14 @@ router.post('/recordings/llm', requireSignIn, async (req: AuthenticatedRequest, 
         id: robotId,
         createdAt: currentTimestamp,
         updatedAt: currentTimestamp,
-        pairs: normalizeWorkflowUrls(workflowResult.workflow).length,
+        pairs: 0,
         params: [],
         type: 'extract',
-        url: finalUrl,
+        url: url || '',
         isLLM: true,
+        status: 'creating',
       },
-      recording: { workflow: normalizeWorkflowUrls(workflowResult.workflow) },
+      recording: { workflow: [] },
       google_sheet_email: null,
       google_sheet_name: null,
       google_sheet_id: null,
@@ -756,19 +729,70 @@ router.post('/recordings/llm', requireSignIn, async (req: AuthenticatedRequest, 
       schedule: null,
     });
 
-    logger.log('info', `LLM robot created with id: ${newRobot.id}`);
-    capture('maxun-oss-llm-robot-created', {
-      robot_meta: newRobot.recording_meta,
-      recording: newRobot.recording,
-      llm_provider: llmProvider || 'ollama',
-      prompt: prompt,
-      urlAutoDetected: !url,
-    });
+    logger.log('info', `LLM robot stub created with id: ${stubRobot.id}, starting workflow generation`);
 
-    return res.status(201).json({
-      message: 'LLM robot created successfully.',
-      robot: newRobot,
-    });
+    let workflowResult: any;
+    let finalUrl: string;
+
+    try {
+      if (url) {
+        logger.log('info', `Starting LLM workflow generation for provided URL: ${url}`);
+        workflowResult = await WorkflowEnricher.generateWorkflowFromPrompt(url, prompt, req.user.id, llmConfig);
+        finalUrl = workflowResult.url || url;
+      } else {
+        logger.log('info', `Starting LLM workflow generation with automatic URL detection for prompt: "${prompt}"`);
+        workflowResult = await WorkflowEnricher.generateWorkflowFromPromptWithSearch(prompt, req.user.id, llmConfig);
+        finalUrl = workflowResult.url || '';
+        if (finalUrl) {
+          logger.log('info', `Auto-detected URL: ${finalUrl}`);
+        }
+      }
+
+      if (finalUrl) {
+        finalUrl = normalizeRobotUrl(finalUrl);
+      }
+
+      if (!workflowResult.success || !workflowResult.workflow) {
+        logger.log('error', `Failed to generate workflow: ${JSON.stringify(workflowResult.errors)}`);
+        await stubRobot.destroy();
+        return res.status(400).json({
+          error: 'Failed to generate workflow from prompt',
+          details: workflowResult.errors
+        });
+      }
+
+      const normalizedWorkflow = normalizeWorkflowUrls(workflowResult.workflow);
+
+      await stubRobot.update({
+        recording_meta: {
+          ...stubRobot.recording_meta,
+          pairs: normalizedWorkflow.length,
+          url: finalUrl,
+          updatedAt: new Date().toISOString(),
+          status: 'ready',
+        },
+        recording: { workflow: normalizedWorkflow },
+      });
+
+      await stubRobot.reload();
+
+      logger.log('info', `LLM robot ready with id: ${stubRobot.id}`);
+      capture('maxun-oss-llm-robot-created', {
+        robot_meta: stubRobot.recording_meta,
+        recording: stubRobot.recording,
+        llm_provider: llmProvider || 'ollama',
+        prompt: prompt,
+        urlAutoDetected: !url,
+      });
+
+      return res.status(201).json({
+        message: 'LLM robot created successfully.',
+        robot: stubRobot,
+      });
+    } catch (llmError) {
+      try { await stubRobot.destroy(); } catch (_) {}
+      throw llmError;
+    }
   } catch (error: any) {
     if (error.name === 'SequelizeUniqueConstraintError' || error.parent?.code === '23505') {
       return res.status(409).json({ error: 'A robot with this name already exists.' });

--- a/src/components/robot/RecordingsTable.tsx
+++ b/src/components/robot/RecordingsTable.tsx
@@ -7,7 +7,7 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
-import { memo, useCallback, useEffect, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef } from "react";
 import { WorkflowFile } from "maxun-core";
 import SearchIcon from '@mui/icons-material/Search';
 import {
@@ -300,7 +300,7 @@ export const RecordingsTable = ({
             ...recording.recording_meta,
             content: recording.recording,
             parsedDate,
-            isLoading: recording.isLoading || false,
+            isLoading: recording.recording_meta?.status === 'creating' || recording.isLoading || false,
             isOptimistic: recording.isOptimistic || false
           };
         }
@@ -472,6 +472,32 @@ export const RecordingsTable = ({
       setRerenderRobots(false);
     }
   }, [rerenderRobots, setRerenderRobots, refetch]);
+
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    const hasCreating = (recordingsData as any[]).some(
+      (r: any) => r?.recording_meta?.status === 'creating'
+    );
+
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
+    }
+
+    if (hasCreating) {
+      pollingRef.current = setInterval(() => {
+        refetch();
+      }, 8000);
+    }
+
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
+    };
+  }, [recordingsData, refetch]);
 
   function useDebounce<T>(value: T, delay: number): T {
     const [debouncedValue, setDebouncedValue] = React.useState<T>(value);


### PR DESCRIPTION
Previously, the creation state of an LLM robot was stored only in memory, causing the creation placeholder to disappear if the page was reloaded or the user switched tabs during creation.

This PR persists the robot in the database with a `creating` state, ensuring the creation placeholder remains visible until the robot is fully created.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time status tracking and automatic polling for recordings in the creation state, refreshing every 8 seconds for improved visibility.

* **Refactor**
  * Optimized robot creation workflow for better responsiveness during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->