### PR TITLE
fix: add maxun browser image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,12 +75,13 @@ services:
       - backend
 
   browser:
-    build:
-      context: .
-      dockerfile: browser/Dockerfile
-      args:
-        BROWSER_WS_PORT: ${BROWSER_WS_PORT:-3001}
-        BROWSER_HEALTH_PORT: ${BROWSER_HEALTH_PORT:-3002}
+    # build:
+    #   context: .
+    #   dockerfile: browser/Dockerfile
+    #   args:
+    #     BROWSER_WS_PORT: ${BROWSER_WS_PORT:-3001}
+    #     BROWSER_HEALTH_PORT: ${BROWSER_HEALTH_PORT:-3002}
+    image: getmaxun/maxun-browser:latest
     ports:
       - "${BROWSER_WS_PORT:-3001}:${BROWSER_WS_PORT:-3001}"
       - "${BROWSER_HEALTH_PORT:-3002}:${BROWSER_HEALTH_PORT:-3002}"


### PR DESCRIPTION
What this PR does?

Fixes the bug wherein the docker build resulted in an error if the browser directory from the repo was not present.

Fixes: #1112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the browser service deployment configuration to use a prebuilt Docker image instead of local builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->