### PR TITLE
fix: md conversion reliability, llm extraction accuracy

### DIFF
--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -949,7 +949,7 @@ async function executeRun(id: string, userId: string) {
                         };
                         logger.log('info', `Running smart query for API scrape run ${plainRun.runId}`);
                         const agentResult = await executeBrowserAgent(currentPage, promptInstructions, llmConfig);
-                        serializableOutput.promptResult = [{ content: agentResult.result, steps: agentResult.steps }];
+                        serializableOutput.promptResult = [{ content: agentResult.result, steps: agentResult.steps, success: agentResult.success }];
                         logger.log('info', `Smart query completed for API scrape run ${plainRun.runId}`);
                     } catch (agentErr: any) {
                         logger.log('warn', `Smart query failed for API scrape run ${plainRun.runId}: ${agentErr.message}`);

--- a/server/src/markdownify/markdown.ts
+++ b/server/src/markdownify/markdown.ts
@@ -3,8 +3,9 @@ import TurndownService from 'turndown';
 import { gfm } from 'joplin-turndown-plugin-gfm';
 import * as cheerio from 'cheerio';
 import { URL } from 'url';
+import { AsyncLocalStorage } from 'async_hooks';
 
-let _baseUrl: string | null = null;
+const _als = new AsyncLocalStorage<{ baseUrl: string | null }>();
 
 const _turndown = (() => {
   const t = new TurndownService({
@@ -51,14 +52,15 @@ const _turndown = (() => {
       node.nodeName === "A" && node.getAttribute("href"),
 
     replacement: (content: string, node: any) => {
-      let text = content.trim().replace(/\n+/g, " ");
+      let text = stripA11yText(content.trim().replace(/\n+/g, " "));
 
       if (!text) {
-        text =
+        text = stripA11yText(
           node.getAttribute("aria-label")?.trim() ||
           node.getAttribute("title")?.trim() ||
           getDomainFromUrl(node.getAttribute("href")) ||
-          "";
+          ""
+        );
       }
 
       if (!text) return "";
@@ -67,12 +69,15 @@ const _turndown = (() => {
       const normalizedHref = href.replace(/[\x00-\x1F\x7F-\x9F\s]/g, "").toLowerCase();
       if (normalizedHref.startsWith("javascript:")) return text;
 
+      const _baseUrl = _als.getStore()?.baseUrl ?? null;
       if (_baseUrl && isRelativeUrl(href)) {
         try {
           const u = new URL(href, _baseUrl);
           href = u.toString();
         } catch { }
       }
+
+      href = unwrapRedirect(href);
 
       const headingMatch = text.match(/^(#{1,6})\s+([\s\S]+)$/);
       if (headingMatch) {
@@ -96,6 +101,9 @@ const _turndown = (() => {
       let src = node.getAttribute("src")?.trim() || "";
       if (!src) return "";
 
+      if (src.startsWith("data:")) return "";
+
+      const _baseUrl = _als.getStore()?.baseUrl ?? null;
       if (_baseUrl && isRelativeUrl(src)) {
         try {
           src = new URL(src, _baseUrl).toString();
@@ -114,22 +122,34 @@ const TECHNICAL_SELECTOR = [
   "embed", "canvas", "audio", "video", "svg", "map", "area",
 ].join(",");
 
-const INNER_NOISE_SELECTOR = [
-  "nav", "footer",
-  ".nav", ".header", ".footer", ".sidebar", ".menu", ".ads", ".ad", ".advertisement",
-  "#nav", "#header", "#footer", "#sidebar", ".breadcrumb", ".social-share",
-  ".comments", ".popup", ".modal", ".cookie-banner", ".location-widget",
-  ".keyboard-shortcuts", ".skip-link", ".banner", ".top-bar", ".nav-bar",
-  '[role="complementary"]',
-  "#shortcut-menu", ".nav-sprite", ".a-header", ".a-footer",
-  ".gb_wa", ".gb_xa",
-  "#nav-belt", "#nav-main", "#nav-footer",
-  ".mw-editsection", ".mw-editsection-bracket", ".mw-editsection-divider",
-].join(",");
-
 const UI_ARTIFACTS = new Set([
   "Undo", "Done", "Edit", "Viewed categories", "Dismiss", "Close", "View detail", "View more",
 ]);
+
+/**
+ * Site chrome that is *semantically declared* as non-content. Removing these is
+ * lossless: <nav>/<aside> and the ARIA landmark roles exist specifically to mark
+ * navigation / complementary / page-header / page-footer regions, so they never
+ * contain the primary article. We intentionally do NOT guess content by class/id
+ * names, nor score/pick a single "main" block — both can discard real data.
+ */
+const CHROME_LANDMARK_SELECTOR = [
+  "nav", "aside",
+  '[role="navigation"]', '[role="banner"]', '[role="contentinfo"]',
+  '[role="search"]', '[role="complementary"]',
+].join(",");
+
+/**
+ * Cookie/consent overlays and injected browser widgets (e.g. Google Translate).
+ * These identifiers belong exclusively to consent managers / injected widgets
+ * and never wrap page content, so removing them cannot drop real data.
+ */
+const CHROME_WIDGET_SELECTOR = [
+  "#onetrust-banner-sdk", "#onetrust-consent-sdk", ".onetrust-pc-dark-filter", ".ot-sdk-container",
+  "#cookie-banner", "#cookie-consent", "#cookieConsent", "#CybotCookiebotDialog",
+  '[aria-label*="cookie consent" i]', '[id*="cookie-consent" i]', '[class*="cookie-consent" i]',
+  ".skiptranslate", ".goog-te-banner-frame", "#goog-gt-tt", "#google_translate_element",
+].join(",");
 
 export async function parseMarkdown(
   html: string | null | undefined,
@@ -137,20 +157,21 @@ export async function parseMarkdown(
 ): Promise<string> {
   if (!html) return "";
 
-  const tidiedHtml = tidyHtml(html);
-  _baseUrl = baseUrl ?? null;
-
-  try {
-    let out = _turndown.turndown(tidiedHtml);
-    out = fixBrokenLinks(out);
-    out = stripSkipLinks(out);
-    out = stripEditLinks(out);
-    out = cleanupExtraWhitespace(out);
-    return out.trim();
-  } catch (err) {
-    console.error("HTML→Markdown failed", { err });
-    return "";
-  }
+  return _als.run({ baseUrl: baseUrl ?? null }, () => {
+    try {
+      const tidiedHtml = tidyHtml(html as string);
+      let out = _turndown.turndown(tidiedHtml);
+      out = fixBrokenLinks(out);
+      out = stripSkipLinks(out);
+      out = stripEditLinks(out);
+      out = out.replace(/\s*\((?:opens?|opening)[^)]*\b(?:tab|window)\)/gi, "");
+      out = cleanupExtraWhitespace(out);
+      return out.trim();
+    } catch (err) {
+      console.error("HTML→Markdown failed", { err });
+      return "";
+    }
+  });
 }
 
 function isRelativeUrl(url: string): boolean {
@@ -165,6 +186,46 @@ function getDomainFromUrl(url: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Remove screen-reader-only annotations that get injected into visible link
+ * text, e.g. "Read more(opens in a new tab)". Generic and lossless — these
+ * phrases are accessibility hints, never real content.
+ */
+function stripA11yText(text: string): string {
+  return text
+    .replace(/\s*\((?:opens?|opening)[^)]*\b(?:tab|window)\)/gi, "")
+    .replace(/\s*\(external link\)/gi, "")
+    .trim();
+}
+
+/**
+ * Unwrap common link-redirect/tracking wrappers (Microsoft SafeLinks, Google
+ * /url redirects, etc.) back to the real destination URL. Generic across sites
+ * and lossless — the wrapped target is recovered from the wrapper's own query
+ * param, so no link is dropped, only de-obfuscated.
+ */
+function unwrapRedirect(href: string): string {
+  try {
+    const u = new URL(href);
+    const host = u.hostname.toLowerCase();
+
+    if (host.endsWith("safelinks.protection.outlook.com")) {
+      const target = u.searchParams.get("url");
+      if (target) return decodeURIComponent(target);
+    }
+
+    if (host.endsWith("google.com") && u.pathname === "/url") {
+      const target = u.searchParams.get("q") || u.searchParams.get("url");
+      if (target) return decodeURIComponent(target);
+    }
+
+    const generic = u.searchParams.get("redirect_uri") || u.searchParams.get("redirectUrl");
+    if (generic && /^https?:\/\//i.test(generic)) return decodeURIComponent(generic);
+  } catch {
+  }
+  return href;
 }
 
 function tidyHtml(html: string): string {
@@ -185,8 +246,13 @@ function tidyHtml(html: string): string {
     }
   });
 
-  $("body > header, body > footer, body > nav, body > aside").remove();
-  $('[role="navigation"], [role="banner"], [role="contentinfo"]').remove();
+  $(CHROME_LANDMARK_SELECTOR).remove();
+  $("header, footer").each((_i, el) => {
+    if ($(el).parents("article, main, section").length === 0) {
+      $(el).remove();
+    }
+  });
+  $(CHROME_WIDGET_SELECTOR).remove();
 
   const mainSelectors = ["main", "article", "#main-content", "#content", ".main", ".content", ".article", ".post-content", "[role='main']"];
   let bestContent: cheerio.Cheerio<any> | null = null;
@@ -210,8 +276,6 @@ function tidyHtml(html: string): string {
   }
 
   const $content = bestContent || $("body");
-
-  $content.find(INNER_NOISE_SELECTOR).remove();
 
   $content.find("button, span, a, div").each((_i, el) => {
     const $el = $(el);
@@ -263,5 +327,6 @@ function stripEditLinks(md: string): string {
 function cleanupExtraWhitespace(md: string): string {
   return md
     .replace(/\n{3,}/g, "\n\n")
-    .replace(/[ \t]+\n/g, "\n");
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\)•\[/g, ")• [");
 }

--- a/server/src/markdownify/scrape.ts
+++ b/server/src/markdownify/scrape.ts
@@ -28,6 +28,63 @@ async function waitForStability(page: Page): Promise<void> {
   } catch {}
 }
 
+async function dismissOverlays(page: Page): Promise<void> {
+  try {
+    await page.keyboard.press('Escape').catch(() => {});
+    await new Promise(r => setTimeout(r, 400));
+
+    const clicked = await page.evaluate(() => {
+      function isVisible(el: Element): boolean {
+        const r = (el as HTMLElement).getBoundingClientRect();
+        if (r.width === 0 || r.height === 0) return false;
+        const s = window.getComputedStyle(el);
+        return s.display !== 'none' && s.visibility !== 'hidden' && s.opacity !== '0';
+      }
+
+      const SELECTORS = [
+        '[role="dialog"] [aria-label*="close" i]',
+        '[role="dialog"] [aria-label*="关闭"]',
+        '[role="alertdialog"] [aria-label*="close" i]',
+        '[role="alertdialog"] button',
+        '[class*="modal" i] [class*="close" i]',
+        '[class*="popup" i] [class*="close" i]',
+        '[class*="dialog" i] [class*="close" i]',
+        '[class*="overlay" i] [class*="close" i]',
+        '[class*="modal" i] [class*="dismiss" i]',
+        'button[aria-label*="close" i]',
+        'button[aria-label*="关闭"]',
+        'button[class*="close" i]',
+        '.close-button', '.btn-close', '.modal__close',
+      ];
+
+      for (const sel of SELECTORS) {
+        for (const el of Array.from(document.querySelectorAll(sel))) {
+          if (isVisible(el)) {
+            (el as HTMLElement).click();
+            return true;
+          }
+        }
+      }
+
+      const CLOSE_LABELS = new Set(['×', '✕', '✖', 'x', 'X', 'Close', 'close', '关闭', 'Dismiss', 'dismiss', 'Got it', '知道了', '我知道了']);
+      for (const el of Array.from(document.querySelectorAll('button, [role="button"]'))) {
+        const text = ((el as HTMLElement).innerText || '').trim();
+        const label = (el.getAttribute('aria-label') || '').trim();
+        if ((CLOSE_LABELS.has(text) || CLOSE_LABELS.has(label)) && isVisible(el)) {
+          (el as HTMLElement).click();
+          return true;
+        }
+      }
+
+      return false;
+    }).catch(() => false);
+
+    if (clicked) {
+      await new Promise(r => setTimeout(r, 700));
+    }
+  } catch {}
+}
+
 async function gotoWithFallback(page: any, url: string, forScreenshot = false) {
   try {
     const current = page.url();
@@ -57,6 +114,7 @@ export async function convertPageToMarkdown(url: string, page: Page): Promise<st
 
     await gotoWithFallback(page, url);
     await waitForStability(page);
+    await dismissOverlays(page);
 
     const cleanedHtml = await page.evaluate(() => {
       function flattenShadowRoots(root: Element | ShadowRoot) {
@@ -163,6 +221,7 @@ export async function convertPageToHTML(url: string, page: Page): Promise<string
 
     await gotoWithFallback(page, url);
     await waitForStability(page);
+    await dismissOverlays(page);
 
     const cleanedHtml = await page.evaluate(() => {
       function flattenShadowRoots(root: Element | ShadowRoot) {
@@ -250,6 +309,8 @@ export async function convertPageToText(url: string, page: Page): Promise<string
     logger.log('info', `[Scrape] Using existing page instance for text conversion of ${url}`);
 
     await gotoWithFallback(page, url);
+    await waitForStability(page);
+    await dismissOverlays(page);
 
     const text = await page.evaluate(() => {
       const body = document.body;
@@ -275,6 +336,7 @@ export async function convertPageToLinks(url: string, page: Page): Promise<strin
 
     await gotoWithFallback(page, url);
     await waitForStability(page);
+    await dismissOverlays(page);
 
     const links = await page.evaluate(() =>
       Array.from(document.querySelectorAll('a'))

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -17,10 +17,10 @@ import { WorkflowFile } from 'maxun-core';
 import { cancelScheduledWorkflow, scheduleWorkflow } from '../storage/schedule';
 import { addJob } from '../storage/graphileWorker';
 import { QUEUE_NAMES } from '../task-runner';
-import { io as serverIo } from '../server';
+import { io as serverIo, recentRecoveries } from '../server';
 import { WorkflowEnricher } from '../sdk/workflowEnricher';
 import sequelizeInstance from '../storage/db';
-import { Op } from 'sequelize';
+import { Op, literal } from 'sequelize';
 import {
   DEFAULT_OUTPUT_FORMATS,
   parseOutputFormats,
@@ -671,6 +671,14 @@ router.post('/recordings/llm', requireSignIn, async (req: AuthenticatedRequest, 
 
     if (!prompt) {
       return res.status(400).json({ error: 'The "prompt" field is required.' });
+    }
+
+    const trimmedPrompt = (prompt as string).trim();
+    if (trimmedPrompt.length < 15) {
+      return res.status(400).json({ error: 'Extraction prompt is too short. Please describe what you want to extract (e.g., "Extract company names and descriptions from the YC companies page").' });
+    }
+    if (/field_\d+/i.test(trimmedPrompt)) {
+      return res.status(400).json({ error: 'Extraction prompt looks like a template placeholder. Please replace it with a specific description of what you want to extract.' });
     }
 
     if (!req.user) {
@@ -1639,6 +1647,141 @@ export async function recoverOrphanedRuns() {
     logger.log('info', `Orphaned run recovery completed. Processed ${orphanedRuns.length} runs.`);
   } catch (error: any) {
     logger.log('error', `Failed to recover orphaned runs: ${error.message}`);
+  }
+}
+
+/**
+ * Threshold (in minutes) after which a run sitting in 'running' with no active
+ * browser session in this instance's pool is considered "stuck" and recovered.
+ * This is intentionally larger than the EXECUTE_RUN interpretation timeout
+ * plus the browser-acquisition wait, so that genuinely in-progress runs are
+ * never recovered prematurely.
+ */
+const STUCK_RUNNING_THRESHOLD_MINUTES = 16;
+
+/**
+ * Periodic watchdog for runs stuck in 'running'.
+ *
+ * Unlike {@link recoverOrphanedRuns} (which only runs once at server startup,
+ * when the in-memory browser pool is guaranteed to be empty), this function is
+ * intended to run on a recurring interval. It catches runs that never progress
+ * past 'running' because the job that was supposed to execute them was lost
+ * (e.g. an unhandled rejection, a dropped job notification, etc.) without
+ * requiring a server restart to recover them.
+ *
+ * A run is only touched if it has been 'running' for longer than
+ * {@link STUCK_RUNNING_THRESHOLD_MINUTES} AND this instance has no live browser
+ * for it in {@link browserPool} — i.e. it is not actively being processed here.
+ * Recovery here just sets status back to 'queued'; the existing processQueuedRuns
+ * poller (running every 5s) picks it back up — no separate re-enqueue call needed.
+ */
+export async function recoverStuckRunningRuns() {
+  try {
+    const stuckRuns = await Run.findAll({
+      attributes: { exclude: ['serializableOutput', 'binaryOutput'] },
+      where: {
+        [Op.and]: [
+          { status: 'running' },
+          literal(`
+            CASE
+              WHEN "startedAt" ~ '^[0-9]{4}-'
+              THEN "startedAt"::timestamptz
+              ELSE to_timestamp("startedAt", 'FMMM/FMDD/YYYY, FMHH12:MI:SS AM')
+            END < now() - interval '${STUCK_RUNNING_THRESHOLD_MINUTES} minutes'
+          `),
+        ],
+      },
+      order: [['startedAt', 'ASC']],
+    });
+
+    if (stuckRuns.length === 0) {
+      return;
+    }
+
+    logger.log('warn', `Found ${stuckRuns.length} run(s) stuck in 'running' for over ${STUCK_RUNNING_THRESHOLD_MINUTES} minutes`);
+
+    for (const run of stuckRuns) {
+      try {
+        const runData = run.toJSON();
+
+        const browser = browserPool.getRemoteBrowser(runData.browserId);
+        if (browser) {
+          logger.log('info', `Run ${runData.runId} still has an active browser session, not treating as stuck`);
+          continue;
+        }
+
+        logger.log('warn', `Run ${runData.runId} has been 'running' for over ${STUCK_RUNNING_THRESHOLD_MINUTES} minutes with no active browser session - recovering`);
+
+        const retryCount = runData.retryCount || 0;
+        let recoveredStatus: 'queued' | 'failed' = 'failed';
+
+        if (retryCount < 3 && runData.runByUserId) {
+          await run.update({
+            status: 'queued',
+            retryCount: retryCount + 1,
+            serializableOutput: {},
+            binaryOutput: {},
+            browserId: undefined,
+            log: runData.log
+              ? `${runData.log}\n[RETRY ${retryCount + 1}/3] Re-queuing - run was stuck in 'running' with no progress for over ${STUCK_RUNNING_THRESHOLD_MINUTES} minutes`
+              : `[RETRY ${retryCount + 1}/3] Re-queuing - run was stuck in 'running' with no progress for over ${STUCK_RUNNING_THRESHOLD_MINUTES} minutes`,
+          });
+
+          logger.log('info', `Re-queued stuck run ${runData.runId} for processing (retry ${retryCount + 1}/3)`);
+          recoveredStatus = 'queued';
+        } else {
+          const message = `Run timed out - stuck in 'running' for over ${STUCK_RUNNING_THRESHOLD_MINUTES} minutes with no active browser session (${retryCount >= 3 ? 'max retries exceeded' : 'missing user reference'}).`;
+
+          await run.update({
+            status: 'failed',
+            finishedAt: new Date().toLocaleString(),
+            log: runData.log ? `${runData.log}\n${message}` : message,
+          });
+          recoveredStatus = 'failed';
+        }
+
+        try {
+          if (runData.runByUserId) {
+            const recoveryData = {
+              runId: runData.runId,
+              robotMetaId: runData.robotMetaId,
+              status: recoveredStatus,
+              finishedAt: new Date().toLocaleString(),
+              recovered: true,
+              message: recoveredStatus === 'queued'
+                ? 'Run was stuck and has been automatically re-queued for retry'
+                : 'Run was stuck in running state and has been marked as failed',
+            };
+
+            const userId = runData.runByUserId.toString();
+            serverIo.of('/queued-run').to(`user-${userId}`).emit(
+              recoveredStatus === 'failed' ? 'run-completed' : 'run-recovered',
+              recoveryData
+            );
+
+            if (!recentRecoveries.has(userId)) {
+              recentRecoveries.set(userId, []);
+            }
+            recentRecoveries.get(userId)!.push(recoveryData);
+          }
+        } catch (socketError: any) {
+          logger.log('warn', `Failed to emit recovery notification for stuck run ${runData.runId}: ${socketError.message}`);
+        }
+
+        if (runData.browserId) {
+          try {
+            browserPool.deleteRemoteBrowser(runData.browserId);
+            logger.log('info', `Cleaned up stale browser reference: ${runData.browserId}`);
+          } catch (cleanupError: any) {
+            logger.log('warn', `Failed to cleanup browser reference ${runData.browserId}: ${cleanupError.message}`);
+          }
+        }
+      } catch (runError: any) {
+        logger.log('error', `Failed to recover stuck run ${run.runId}: ${runError.message}`);
+      }
+    }
+  } catch (error: any) {
+    logger.log('error', `Error in recoverStuckRunningRuns: ${error.message}`);
   }
 }
 

--- a/server/src/sdk/browserAgent.ts
+++ b/server/src/sdk/browserAgent.ts
@@ -83,7 +83,9 @@ Rules:
 5. For dropdowns, use "select" not "click". For checkboxes/toggles, use "check" not "click".
 6. If a previous step shows "← FAILED", that action did not work — try a different approach.
 7. For ordinal/positional queries ("10th item", "first result", "last company"): use the screenshot to visually count and identify the item, then cross-reference with the page text to retrieve its full details. Return the result directly with {"action":"done","result":"..."}.
-8. Maximum ${MAX_STEPS} total steps.`;
+8. Maximum ${MAX_STEPS} total steps.
+9. "navigate" only works within the current site. If the target site is down, blocked, or doesn't have the requested content, do NOT try a different website — respond with {"action":"done","result":"..."} explaining the problem instead.
+10. If an action keeps failing or the page isn't changing (e.g. a blocked/verification screen), don't repeat it — respond with {"action":"done","result":"..."} describing what's blocking progress.`;
 
 function extractJson(content: string): AgentAction {
   const cleaned = content.trim();
@@ -483,7 +485,19 @@ function looksLikeCSSSelector(s: string): boolean {
   return /^[.#\[*]/.test(s) || /[\s>~+]/.test(s) || /:nth|:first|:last|:not\(/.test(s);
 }
 
-async function executeAction(page: Page, action: AgentAction): Promise<void> {
+/**
+ * Returns a rough "registrable domain" (last two labels of the hostname) used
+ * to decide whether a navigate action stays on the site the user configured.
+ * This is a heuristic (it doesn't know the public suffix list), but it's
+ * sufficient to tell "spf.zgj.sg.gov.cn" apart from "anjuke.com" or
+ * "soufun.com" while still allowing same-site subdomain navigation.
+ */
+function getRegistrableDomain(hostname: string): string {
+  const parts = hostname.toLowerCase().split('.').filter(Boolean);
+  return parts.slice(-2).join('.');
+}
+
+async function executeAction(page: Page, action: AgentAction, allowedDomain?: string): Promise<void> {
   switch (action.action) {
     case 'click': {
       const sel = action.selector;
@@ -512,6 +526,22 @@ async function executeAction(page: Page, action: AgentAction): Promise<void> {
     }
     case 'navigate': {
       if (!action.url) throw new Error('navigate: missing url');
+
+      if (allowedDomain) {
+        let targetDomain: string;
+        try {
+          targetDomain = getRegistrableDomain(new URL(action.url).hostname);
+        } catch {
+          throw new Error(`navigate: invalid URL "${action.url}"`);
+        }
+        if (targetDomain !== allowedDomain) {
+          throw new Error(
+            `navigate: blocked — "${action.url}" is on a different site ("${targetDomain}") than the configured target ("${allowedDomain}"). ` +
+            `Stay on the current site, or respond with {"action":"done","result":"..."} explaining what you found (or that the target site is unreachable).`
+          );
+        }
+      }
+
       await page.goto(action.url, { waitUntil: 'domcontentloaded', timeout: 30000 });
       break;
     }
@@ -635,6 +665,18 @@ export async function executeBrowserAgent(
 
   logger.info('[BrowserAgent] Direct extraction insufficient — starting action loop');
 
+  let allowedDomain: string | undefined;
+  try {
+    allowedDomain = getRegistrableDomain(new URL(initialPageState.url).hostname);
+  } catch {
+    allowedDomain = undefined;
+  }
+
+  const actionSignatureCounts = new Map<string, number>();
+  const MAX_REPEATS_PER_ACTION = 3;
+  let success = true;
+  let stuckSignature: string | null = null;
+
   for (let step = 0; step < MAX_STEPS; step++) {
     try {
       const pageState = step === 0 ? initialPageState : await capturePageState(page);
@@ -659,7 +701,18 @@ export async function executeBrowserAgent(
         break;
       }
 
-      await executeAction(page, action);
+      const signature = `${action.action}:${action.selector || action.url || action.key || ''}`;
+      const repeatCount = (actionSignatureCounts.get(signature) || 0) + 1;
+      actionSignatureCounts.set(signature, repeatCount);
+
+      if (repeatCount >= MAX_REPEATS_PER_ACTION) {
+        agentStep.error = `Same action repeated ${repeatCount} times without progress — stopping to avoid an infinite loop`;
+        logger.warn(`[BrowserAgent] Loop detected on step ${step + 1}: "${signature}" attempted ${repeatCount} times. Stopping early.`);
+        stuckSignature = signature;
+        break;
+      }
+
+      await executeAction(page, action, allowedDomain);
       await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => { });
       await new Promise(resolve => setTimeout(resolve, 800));
 
@@ -673,14 +726,19 @@ export async function executeBrowserAgent(
 
       if (step === MAX_STEPS - 1) {
         finalResult = `Agent stopped after ${step + 1} steps. Last error: ${shortError}`;
+        success = false;
       }
     }
   }
 
-  if (!finalResult) {
+  if (stuckSignature) {
+    finalResult = `Agent stopped after ${steps.length} step(s): repeated the same action ("${stuckSignature}") without making progress. The page is likely blocked (e.g. an anti-bot check) or the requested content isn't reachable.`;
+    success = false;
+  } else if (!finalResult) {
     finalResult = `Agent completed ${steps.length} step(s) but did not return a final result.`;
+    success = false;
   }
 
   logger.info(`[BrowserAgent] Token usage — prompt: ${accTokens.promptTokens}, completion: ${accTokens.completionTokens}, total: ${accTokens.totalTokens}`);
-  return { result: finalResult, steps, success: true, tokenUsage: accTokens };
+  return { result: finalResult, steps, success, tokenUsage: accTokens };
 }

--- a/server/src/sdk/selectorValidator.ts
+++ b/server/src/sdk/selectorValidator.ts
@@ -476,7 +476,6 @@ export class SelectorValidator {
             } catch { return []; }
           }
 
-          // Count list items (capped at 10 for speed)
           const listItems = evalXPath(listSelector).slice(0, 10);
           if (listItems.length === 0) return {};
 
@@ -485,7 +484,6 @@ export class SelectorValidator {
             if (!field?.selector) { rates[label] = 0; continue; }
             const isXPath = field.selector.startsWith('//') || field.selector.startsWith('(//');
             if (!isXPath) {
-              // CSS selector: check against each item
               let filled = 0;
               for (const item of listItems) {
                 try {
@@ -499,7 +497,6 @@ export class SelectorValidator {
               }
               rates[label] = filled / listItems.length;
             } else {
-              // XPath selector: evaluate from document root and count non-empty values
               const matched = evalXPath(field.selector);
               let filled = 0;
               for (const el of matched.slice(0, listItems.length)) {
@@ -510,7 +507,6 @@ export class SelectorValidator {
                   if (val.trim().length > 0) filled++;
                 } catch { }
               }
-              // Fill rate = non-empty matched elements / list item count
               rates[label] = matched.length === 0 ? 0 : filled / listItems.length;
             }
           }

--- a/server/src/sdk/selectorValidator.ts
+++ b/server/src/sdk/selectorValidator.ts
@@ -450,6 +450,82 @@ export class SelectorValidator {
   }
 
   /**
+   * Validate field selectors by checking how many list items return a non-empty value.
+   * Samples up to 10 list items for speed.
+   * Returns a fill-rate map { fieldName -> 0.0–1.0 }.
+   * Fields with fill rate < MIN_FILL_RATE should be discarded before saving the robot.
+   */
+  async validateFieldFillRates(
+    fields: Record<string, any>,
+    listSelector: string
+  ): Promise<Record<string, number>> {
+    if (!this.page) return {};
+
+    try {
+      const fillRates = await this.page.evaluate(
+        ({ fields, listSelector }: { fields: Record<string, any>; listSelector: string }) => {
+          function evalXPath(expr: string, contextNode: Document | Element = document): Element[] {
+            try {
+              const result = document.evaluate(
+                expr, contextNode, null,
+                XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null
+              );
+              return Array.from({ length: result.snapshotLength }, (_, i) =>
+                result.snapshotItem(i) as Element
+              );
+            } catch { return []; }
+          }
+
+          // Count list items (capped at 10 for speed)
+          const listItems = evalXPath(listSelector).slice(0, 10);
+          if (listItems.length === 0) return {};
+
+          const rates: Record<string, number> = {};
+          for (const [label, field] of Object.entries(fields) as [string, any][]) {
+            if (!field?.selector) { rates[label] = 0; continue; }
+            const isXPath = field.selector.startsWith('//') || field.selector.startsWith('(//');
+            if (!isXPath) {
+              // CSS selector: check against each item
+              let filled = 0;
+              for (const item of listItems) {
+                try {
+                  const el = item.querySelector(field.selector);
+                  if (!el) continue;
+                  const val = field.attribute && field.attribute !== 'innerText' && field.attribute !== 'textContent'
+                    ? el.getAttribute(field.attribute) || ''
+                    : (el as HTMLElement).innerText || el.textContent || '';
+                  if (val.trim().length > 0) filled++;
+                } catch { }
+              }
+              rates[label] = filled / listItems.length;
+            } else {
+              // XPath selector: evaluate from document root and count non-empty values
+              const matched = evalXPath(field.selector);
+              let filled = 0;
+              for (const el of matched.slice(0, listItems.length)) {
+                try {
+                  const val = field.attribute && field.attribute !== 'innerText' && field.attribute !== 'textContent'
+                    ? el.getAttribute(field.attribute) || ''
+                    : (el as HTMLElement).innerText || el.textContent || '';
+                  if (val.trim().length > 0) filled++;
+                } catch { }
+              }
+              // Fill rate = non-empty matched elements / list item count
+              rates[label] = matched.length === 0 ? 0 : filled / listItems.length;
+            }
+          }
+          return rates;
+        },
+        { fields, listSelector }
+      );
+      return fillRates || {};
+    } catch (error: any) {
+      logger.warn('[SelectorValidator] validateFieldFillRates failed:', error.message);
+      return {};
+    }
+  }
+
+  /**
    * Test Load More button by clicking it and checking if content loads
    */
   private async testLoadMoreButton(buttonSelector: string, listSelector: string): Promise<boolean> {

--- a/server/src/sdk/workflowEnricher.ts
+++ b/server/src/sdk/workflowEnricher.ts
@@ -402,7 +402,7 @@ export class WorkflowEnricher {
       const axios = require('axios');
 
       const keywords = this.extractMeaningfulKeywords(prompt);
-      const { systemPrompt, userPrompt } = this.buildUnifiedPrompt(prompt, elementGroups, keywords);
+      const { systemPrompt, userPrompt } = this.buildUnifiedPrompt(prompt, elementGroups, keywords, pageHTML);
 
       let llmResponse: string;
 
@@ -564,10 +564,36 @@ export class WorkflowEnricher {
     }).filter(Boolean).join('\n');
   }
 
+  /**
+   * Strip scripts/styles and return a clean body HTML snippet capped at maxChars.
+   * Used to give the LLM actual DOM context beyond structural metadata.
+   */
+  private static extractHtmlSnippet(rawHtml: string, maxChars = 3000): string {
+    try {
+      // Remove script, style, svg, noscript blocks
+      let cleaned = rawHtml
+        .replace(/<script[\s\S]*?<\/script>/gi, '')
+        .replace(/<style[\s\S]*?<\/style>/gi, '')
+        .replace(/<svg[\s\S]*?<\/svg>/gi, '')
+        .replace(/<noscript[\s\S]*?<\/noscript>/gi, '');
+      // Extract body content
+      const bodyMatch = cleaned.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+      const body = bodyMatch ? bodyMatch[1] : cleaned;
+      // Collapse whitespace
+      const collapsed = body.replace(/\s+/g, ' ').trim();
+      return collapsed.length > maxChars
+        ? collapsed.substring(0, maxChars) + '…[truncated]'
+        : collapsed;
+    } catch {
+      return '';
+    }
+  }
+
   private static buildUnifiedPrompt(
     prompt: string,
     elementGroups: any[],
-    keywords: string[]
+    keywords: string[],
+    pageHTML?: string
   ): { systemPrompt: string; userPrompt: string } {
     const groupsText = this.buildUnifiedGroupDescription(elementGroups, keywords);
 
@@ -597,8 +623,12 @@ Reply with ONLY valid JSON. No markdown blocks, no extra text. Pick a best choic
 If only one group is viable, set "second" to the same number as "first" (or -1).
 If no group matches, set both to -1.`;
 
-    const userPrompt = `USER REQUEST: "${prompt}"
+    const htmlSection = pageHTML
+      ? `\nPAGE HTML EXCERPT (use to verify group signals and selectors):\n${WorkflowEnricher.extractHtmlSnippet(pageHTML)}\n`
+      : '';
 
+    const userPrompt = `USER REQUEST: "${prompt}"
+${htmlSection}
 GROUPS (format: INDEX: COUNT items |signals| (fields) [flags] - "sample content"):
 ${groupsText}
 
@@ -1652,6 +1682,27 @@ Return ONLY the list name, nothing else:`;
       } else {
         logger.warn(`Low confidence (${filterResult.confidence}) or no fields selected. Using all detected fields as fallback.`);
       }
+
+      const MIN_FILL_RATE = 0; // Drop only fields that return nothing at all (completely broken selectors)
+      const fillRates = await validator.validateFieldFillRates(finalFields, autoDetectResult.listSelector || llmDecision.itemSelector);
+      const validatedFields: Record<string, any> = {};
+      const droppedFields: string[] = [];
+      for (const [label, fieldInfo] of Object.entries(finalFields)) {
+        const rate = fillRates[label];
+        if (rate !== undefined && rate <= MIN_FILL_RATE) {
+          droppedFields.push(`${label} (${Math.round(rate * 100)}% filled)`);
+        } else {
+          validatedFields[label] = fieldInfo;
+        }
+      }
+      if (droppedFields.length > 0) {
+        logger.warn(`[WorkflowEnricher] Dropped ${droppedFields.length} low-fill-rate fields: ${droppedFields.join(', ')}`);
+      }
+      if (Object.keys(validatedFields).length === 0) {
+        throw new Error('All fields returned empty values during selector re-validation — rejecting group');
+      }
+      finalFields = validatedFields;
+      logger.info(`[WorkflowEnricher] Selector re-validation passed: ${Object.keys(finalFields).length} fields retained`);
 
       const limit = llmDecision.limit || 100;
       logger.info(`Using limit: ${limit}`);

--- a/server/src/sdk/workflowEnricher.ts
+++ b/server/src/sdk/workflowEnricher.ts
@@ -570,16 +570,13 @@ export class WorkflowEnricher {
    */
   private static extractHtmlSnippet(rawHtml: string, maxChars = 3000): string {
     try {
-      // Remove script, style, svg, noscript blocks
       let cleaned = rawHtml
         .replace(/<script[\s\S]*?<\/script>/gi, '')
         .replace(/<style[\s\S]*?<\/style>/gi, '')
         .replace(/<svg[\s\S]*?<\/svg>/gi, '')
         .replace(/<noscript[\s\S]*?<\/noscript>/gi, '');
-      // Extract body content
       const bodyMatch = cleaned.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
       const body = bodyMatch ? bodyMatch[1] : cleaned;
-      // Collapse whitespace
       const collapsed = body.replace(/\s+/g, ' ').trim();
       return collapsed.length > maxChars
         ? collapsed.substring(0, maxChars) + '…[truncated]'
@@ -1683,7 +1680,7 @@ Return ONLY the list name, nothing else:`;
         logger.warn(`Low confidence (${filterResult.confidence}) or no fields selected. Using all detected fields as fallback.`);
       }
 
-      const MIN_FILL_RATE = 0; // Drop only fields that return nothing at all (completely broken selectors)
+      const MIN_FILL_RATE = 0;
       const fillRates = await validator.validateFieldFillRates(finalFields, autoDetectResult.listSelector || llmDecision.itemSelector);
       const validatedFields: Record<string, any> = {};
       const droppedFields: string[] = [];

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -18,7 +18,7 @@ import swaggerSpec from './swagger/config';
 import connectPgSimple from 'connect-pg-simple';
 import pg from 'pg';
 import session from 'express-session';
-import { processQueuedRuns, recoverOrphanedRuns } from './routes/storage';
+import { processQueuedRuns, recoverOrphanedRuns, recoverStuckRunningRuns } from './routes/storage';
 import { startWorkers, stopWorkers } from './task-runner';
 import { startGraphileWorkerUtils, stopGraphileWorkerUtils } from './storage/graphileWorker';
 import { startScheduleWorker, stopScheduleWorker } from './schedule-worker';
@@ -161,6 +161,15 @@ if (require.main === module) {
     browserPool.cleanupStaleBrowserSlots();
   }, 60000);
   serverIntervals.push(browserPoolCleanupInterval);
+
+  const stuckRunningRunsInterval = setInterval(async () => {
+    try {
+      await recoverStuckRunningRuns();
+    } catch (error: any) {
+      logger.log('error', `Error in recoverStuckRunningRuns interval: ${error.message}`);
+    }
+  }, 5 * 60 * 1000);
+  serverIntervals.push(stuckRunningRunsInterval);
 
   server.listen(SERVER_PORT, '0.0.0.0', async () => {
     try {

--- a/server/src/task-runner.ts
+++ b/server/src/task-runner.ts
@@ -325,7 +325,7 @@ async function processRunExecution(data: ExecuteRunData): Promise<void> {
               };
               await run.update({ log: 'Running smart query...' });
               const agentResult = await executeBrowserAgent(currentPage, promptInstructions, llmConfig);
-              serializableOutput.promptResult = [{ content: agentResult.result, steps: agentResult.steps }];
+              serializableOutput.promptResult = [{ content: agentResult.result, steps: agentResult.steps, success: agentResult.success }];
             } catch (agentError: any) {
               logger.log('warn', `Smart query failed for run ${data.runId}: ${agentError.message}`);
               serializableOutput.promptResult = [{ content: `Smart query failed: ${agentError.message}`, steps: [] }];

--- a/server/src/workflow-management/scheduler/index.ts
+++ b/server/src/workflow-management/scheduler/index.ts
@@ -423,7 +423,7 @@ async function executeRun(id: string, userId: string) {
             const promptInstructions = run.interpreterSettings?.promptInstructions || (recording.recording_meta as any).promptInstructions as string | undefined;
             if (promptInstructions) {
               const agentResult = await executeBrowserAgent(currentPage, promptInstructions, llmConfig);
-              serializableOutput.promptResult = [{ content: agentResult.result, steps: agentResult.steps }];
+              serializableOutput.promptResult = [{ content: agentResult.result, steps: agentResult.steps, success: agentResult.success }];
               logger.log('info', `Smart query completed for scheduled scrape run ${plainRun.runId}`);
             }
           } catch (agentErr: any) {


### PR DESCRIPTION
What this PR does?

Fixes:

1. Fixes a bug where running two robots at once could send links in the markdown to the wrong website.
2. Stops images from being dumped into markdown as huge blobs of text.
3. Handles cookie popups better so they don't get mixed into the actual scraped content, or accidentally wipe out real content.
4. Stops the LLM from wandering off to other websites when it hits an error page.
5. Runs that get stuck now retry automatically instead of just failing.
6. Robots no longer save broken empty fields, and the LLM gets a better look at the page so it picks the right data more often.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic recovery for stuck workflow runs, including retries and user queue notifications
  * Site-restricted navigation for the browser agent to prevent unintended domain changes
  * Field fill-rate validation during list scraping to improve selector quality
* **Bug Fixes**
  * Markdown conversion better resolves relative/redirect URLs and improves link/image handling and whitespace
  * Scraping now dismisses common overlays/popups before extracting content
  * Stricter LLM prompt validation for extraction requests
  * Browser agent stops repetitive, unproductive action loops early; scrape results now reflect agent success/failure more reliably
<!-- end of auto-generated comment: release notes by coderabbit.ai -->