### PR TITLE
fix: extract engine reliability, accuracy enhancement

### DIFF
--- a/maxun-core/src/browserSide/scraper.js
+++ b/maxun-core/src/browserSide/scraper.js
@@ -387,27 +387,29 @@ function scrapableHeuristics(maxCountPerPage = 50, minArea = 20000, scrolls = 3,
 
     // If MBE approach didn't find all elements, try independent scraping
     if (mbeResults.some(result => Object.values(result).some(v => v === undefined))) {
-        // Fall back to independent scraping
-        const results = [];
         const foundElements = new Map();
 
-        // Find all elements for each selector
         Object.entries(lists).forEach(([key, config]) => {
-            const elements = findAllElements(config);
-            foundElements.set(key, elements);
+            foundElements.set(key, findAllElements(config));
         });
 
-        // Create result objects for each found element
-        foundElements.forEach((elements, key) => {
-            elements.forEach((element, index) => {
-                if (!results[index]) {
-                    results[index] = {};
-                }
-                results[index][key] = getElementValue(element, lists[key].attribute);
+        const lengths = {};
+        foundElements.forEach((elements, key) => { lengths[key] = elements.length; });
+        const rowCount = Math.max(...Object.values(lengths), 0);
+
+        const results = [];
+        for (let index = 0; index < rowCount; index++) {
+            const record = {};
+            foundElements.forEach((elements, key) => {
+                const element = elements[index];
+                record[key] = element ? getElementValue(element, lists[key].attribute) : undefined;
             });
-        });
+            if (Object.values(record).some(v => v !== undefined)) {
+                results.push(record);
+            }
+        }
 
-        return results.filter(result => Object.keys(result).length > 0);
+        return results;
     }
 
     return mbeResults;
@@ -1281,6 +1283,8 @@ function scrapableHeuristics(maxCountPerPage = 50, minArea = 20000, scrolls = 3,
       containerIndex < containers.length;
       containerIndex++
     ) {
+      if (limit && tableData.length >= limit) break;
+
       const container = containers[containerIndex];
       const { tableFields } = containerFields[containerIndex];
 
@@ -1348,7 +1352,7 @@ function scrapableHeuristics(maxCountPerPage = 50, minArea = 20000, scrolls = 3,
 
           for (
             let rowIndex = 0;
-            rowIndex < Math.min(processedRows.length, limit);
+            rowIndex < Math.min(processedRows.length, limit) && (!limit || tableData.length < limit);
             rowIndex++
           ) {
             const record = {};

--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -443,7 +443,7 @@ export default class Interpreter extends EventEmitter {
 
   /**
    * Attaches a one-time set of listeners to a page that track how many XHR/fetch
-   * requests are currently in flight. Used by waitForDynamicStability's fallback
+   * requests are currently in flight. Used by waitForPageReady's fallback
    * path as a faster, more accurate readiness signal than a fixed network-quiet
    * window. Safe to call repeatedly — it's a no-op after the first call per page.
    */
@@ -569,7 +569,7 @@ export default class Interpreter extends EventEmitter {
    * requests (tracked by ensurePageListeners) instead of a fixed network-quiet
    * window and DOM-text-length polling — faster and more deterministic.
    */
-  private async waitForDynamicStability(page: Page, upcomingWorkflow: Workflow = []): Promise<void> {
+  private async waitForPageReady(page: Page, upcomingWorkflow: Workflow = []): Promise<void> {
     this.ensurePageListeners(page);
     const counter = this.pageRequestCounters.get(page)!;
     try {
@@ -708,7 +708,7 @@ export default class Interpreter extends EventEmitter {
           this.options.debugChannel.setActionType('scrape');
         }
 
-        await this.waitForDynamicStability(page, [{
+        await this.waitForPageReady(page, [{
           action: 'scrape',
           args: [selector]
         } as any]);
@@ -729,7 +729,7 @@ export default class Interpreter extends EventEmitter {
           this.options.debugChannel.setActionType('scrapeSchema');
         }
 
-        await this.waitForDynamicStability(page, [{
+        await this.waitForPageReady(page, [{
           action: 'scrapeSchema',
           args: [schema]
         } as any]);
@@ -1390,7 +1390,7 @@ export default class Interpreter extends EventEmitter {
                 throw new Error(`Navigation failed: ${err.message}`);
               });
 
-              await this.waitForDynamicStability(page, currentWorkflow || []);
+              await this.waitForPageReady(page, currentWorkflow || []);
               await this.dismissOverlays(page);
 
               const pageResult = await scrapePageContent(url);
@@ -1747,7 +1747,7 @@ export default class Interpreter extends EventEmitter {
                 this.log(`Failed to navigate to ${result.url}, skipping...`, Level.WARN);
               });
 
-              await this.waitForDynamicStability(page, currentWorkflow || []);
+              await this.waitForPageReady(page, currentWorkflow || []);
               await this.dismissOverlays(page);
 
               const pageData = await page.evaluate(() => {
@@ -1993,7 +1993,7 @@ export default class Interpreter extends EventEmitter {
             }
 
             if (needsDataSoon) {
-              await this.waitForDynamicStability(page, (currentWorkflow || []).slice(0, -1));
+              await this.waitForPageReady(page, (currentWorkflow || []).slice(0, -1));
             }
           } catch (error: any) {
             this.log(`goto failed: ${error.message}`, Level.WARN);
@@ -2022,11 +2022,11 @@ export default class Interpreter extends EventEmitter {
             await executeAction(invokee, methodName, args);
             
             if (needsDataSoon) {
-              await this.waitForDynamicStability(page, (currentWorkflow || []).slice(0, -1));
+              await this.waitForPageReady(page, (currentWorkflow || []).slice(0, -1));
             }
           } catch (error: any) {
             await executeAction(invokee, methodName, ['domcontentloaded', { timeout: 10000 }]);
-            await this.waitForDynamicStability(page, (currentWorkflow || []).slice(0, -1));
+            await this.waitForPageReady(page, (currentWorkflow || []).slice(0, -1));
           }
         } else if (methodName === 'click') {
           try {
@@ -2098,7 +2098,7 @@ export default class Interpreter extends EventEmitter {
           return;
         }
 
-        await this.waitForDynamicStability(page, [{
+        await this.waitForPageReady(page, [{
           action: 'scrapeList',
           args: [config]
         } as any]);

--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -89,6 +89,8 @@ export default class Interpreter extends EventEmitter {
 
   private scrapeListCounter: number = 0;
 
+  private pageRequestCounters = new WeakMap<Page, { pending: number }>();
+
   private totalActions: number = 0;
 
   private executedActions: number = 0;
@@ -406,7 +408,6 @@ export default class Interpreter extends EventEmitter {
   private blockNeedsVisualRender(steps: What[]): boolean {
     return steps.some((s) => {
       if (s.action === 'screenshot') return true;
-      if (s.action === 'scrapeList' || s.action === 'scrapeSchema') return true;
 
       const firstArg = Array.isArray(s.args) ? s.args[0] : s.args;
       if (!firstArg || typeof firstArg !== 'object') return false;
@@ -441,26 +442,30 @@ export default class Interpreter extends EventEmitter {
   }
 
   /**
-   * Helper to wait for a "Network Quiet Window" (no meaningful activity for X ms).
+   * Attaches a one-time set of listeners to a page that track how many XHR/fetch
+   * requests are currently in flight. Used by waitForDynamicStability's fallback
+   * path as a faster, more accurate readiness signal than a fixed network-quiet
+   * window. Safe to call repeatedly — it's a no-op after the first call per page.
    */
-  private async waitForNetworkQuiet(page: Page, timeout: number = 4000, quietWindow: number = 600): Promise<void> {
-    let lastRequestTime = Date.now();
-    const onRequest = () => { lastRequestTime = Date.now(); };
-    page.on('request', onRequest);
-    page.on('requestfinished', onRequest);
-    page.on('requestfailed', onRequest);
-    try {
-      const checkInterval = 100;
-      const start = Date.now();
-      while (Date.now() - start < timeout) {
-        if (Date.now() - lastRequestTime > quietWindow) return;
-        await new Promise(r => setTimeout(r, checkInterval));
+  private ensurePageListeners(page: Page): void {
+    if (this.pageRequestCounters.has(page)) return;
+    const counter = { pending: 0 };
+    this.pageRequestCounters.set(page, counter);
+    page.on('request', (req) => {
+      if (req.resourceType() === 'xhr' || req.resourceType() === 'fetch') {
+        counter.pending++;
       }
-    } finally {
-      page.off('request', onRequest);
-      page.off('requestfinished', onRequest);
-      page.off('requestfailed', onRequest);
-    }
+    });
+    page.on('requestfinished', (req) => {
+      if (req.resourceType() === 'xhr' || req.resourceType() === 'fetch') {
+        counter.pending = Math.max(0, counter.pending - 1);
+      }
+    });
+    page.on('requestfailed', (req) => {
+      if (req.resourceType() === 'xhr' || req.resourceType() === 'fetch') {
+        counter.pending = Math.max(0, counter.pending - 1);
+      }
+    });
   }
 
   /**
@@ -489,6 +494,59 @@ export default class Interpreter extends EventEmitter {
   }
 
   /**
+   * Best-effort overlay/modal dismissal. Called before reading page content in the
+   * crawl and search-scrape robot types (which have no recorded close-button clicks).
+   * Silently swallows all errors so it can never break a run.
+   */
+  private async dismissOverlays(page: Page): Promise<void> {
+    try {
+      await page.keyboard.press('Escape').catch(() => {});
+      await new Promise(r => setTimeout(r, 400));
+      const clicked = await page.evaluate(() => {
+        function isVisible(el: Element): boolean {
+          const rect = (el as HTMLElement).getBoundingClientRect();
+          if (rect.width === 0 || rect.height === 0) return false;
+          const style = window.getComputedStyle(el);
+          return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+        }
+        const SELECTORS = [
+          '[role="dialog"] [aria-label*="close" i]',
+          '[role="dialog"] [aria-label*="关闭"]',
+          '[role="alertdialog"] [aria-label*="close" i]',
+          '[role="alertdialog"] button',
+          '[class*="modal" i] [class*="close" i]',
+          '[class*="popup" i] [class*="close" i]',
+          '[class*="dialog" i] [class*="close" i]',
+          '[class*="overlay" i] [class*="close" i]',
+          '[class*="modal" i] [class*="dismiss" i]',
+          'button[aria-label*="close" i]',
+          'button[aria-label*="关闭"]',
+          'button[class*="close" i]',
+          '.close-button', '.btn-close', '.modal__close',
+        ];
+        for (const sel of SELECTORS) {
+          try {
+            const el = document.querySelector(sel);
+            if (el && isVisible(el)) { (el as HTMLElement).click(); return true; }
+          } catch {}
+        }
+
+        const CLOSE_LABELS = new Set(['×','✕','✖','x','X','Close','close','关闭','Dismiss','dismiss','Got it','知道了','我知道了']);
+        const candidates = Array.from(document.querySelectorAll('button, [role="button"], a[href="#"]'));
+        for (const el of candidates) {
+          const text = (el as HTMLElement).innerText?.trim() || el.getAttribute('aria-label') || '';
+          if (CLOSE_LABELS.has(text) && isVisible(el)) {
+            (el as HTMLElement).click();
+            return true;
+          }
+        }
+        return false;
+      }).catch(() => false);
+      if (clicked) await new Promise(r => setTimeout(r, 700));
+    } catch {}
+  }
+
+  /**
    * Function to wait for images to load.
    */
   private async waitForImagesLoaded(page: Page): Promise<void> {
@@ -498,42 +556,53 @@ export default class Interpreter extends EventEmitter {
     ).catch(() => {});
   }
 
+  /**
+   * Waits for the page to be ready for extraction/scraping.
+   *
+   * Fast path: if the upcoming workflow names a specific extraction selector,
+   * wait for that selector directly — this is the most accurate and usually the
+   * quickest signal available, and is unique to this interpreter (mx-cloud's own
+   * copy of this lookup was unused dead code).
+   *
+   * Fallback path: when no target selector is known (or it doesn't show up in
+   * time), wait via requestIdleCallback plus a live count of in-flight XHR/fetch
+   * requests (tracked by ensurePageListeners) instead of a fixed network-quiet
+   * window and DOM-text-length polling — faster and more deterministic.
+   */
   private async waitForDynamicStability(page: Page, upcomingWorkflow: Workflow = []): Promise<void> {
+    this.ensurePageListeners(page);
+    const counter = this.pageRequestCounters.get(page)!;
     try {
       const targetSelector = this.getUpcomingExtractionSelector(upcomingWorkflow);
-
-      const signals: Promise<any>[] = [
-        this.waitForNetworkQuiet(page, 10000, 1000),
-        page.evaluate(async () => {
-          let lastLen = 0;
-          let stableIterations = 0;
-
-          for (let i = 0; i < 60; i++) {
-            const currentLen = document.body.innerText.length;
-            if (currentLen > 200 && currentLen === lastLen) {
-              stableIterations++;
-            } else {
-              stableIterations = 0;
-            }
-            if (stableIterations >= 8) return true;
-            lastLen = currentLen;
-            await new Promise(r => setTimeout(r, 100));
-          }
-          return false;
-        }).catch(() => {}),
-        new Promise(resolve => setTimeout(resolve, 10000))
-      ];
 
       if (targetSelector) {
         const found = await page.waitForSelector(targetSelector, { timeout: 8000 }).catch(() => null);
         if (found) {
-          await new Promise(resolve => setTimeout(resolve, 1000));
+          await new Promise(resolve => setTimeout(resolve, 200));
           return;
         }
       }
 
-      await Promise.race(signals);
-      await new Promise(resolve => setTimeout(resolve, 1500));
+      await page.evaluate(() => new Promise<void>((resolve) => {
+        if ('requestIdleCallback' in window) {
+          (window as any).requestIdleCallback(() => resolve(), { timeout: 3000 });
+        } else {
+          setTimeout(resolve, 300);
+        }
+      })).catch(() => {});
+
+      const deadline = Date.now() + 8000;
+      while (counter.pending > 0 && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+
+      await page.evaluate(() => new Promise<void>((resolve) => {
+        if ('requestIdleCallback' in window) {
+          (window as any).requestIdleCallback(() => resolve(), { timeout: 2000 });
+        } else {
+          setTimeout(resolve, 200);
+        }
+      })).catch(() => {});
     } catch (e) {
     }
   }
@@ -766,14 +835,23 @@ export default class Interpreter extends EventEmitter {
           let paginationUsed = false;
 
           if (!config.pagination) {
-            scrapeResults = await page.evaluate((cfg) => {
-              try {
-                return window.scrapeList(cfg);
-              } catch (error: any) {
-                console.warn('ScrapeList evaluation failed:', error.message);
-                return [];
+            const SCRAPE_RETRIES = 2;
+            const SCRAPE_RETRY_DELAY = 500;
+            for (let attempt = 0; attempt <= SCRAPE_RETRIES; attempt++) {
+              scrapeResults = await page.evaluate((cfg) => {
+                try {
+                  return window.scrapeList(cfg);
+                } catch (error: any) {
+                  console.warn('ScrapeList evaluation failed:', error.message);
+                  return [];
+                }
+              }, config);
+              if (scrapeResults.length > 0) break;
+              if (attempt < SCRAPE_RETRIES) {
+                this.log(`ScrapeList returned empty on attempt ${attempt + 1}, retrying in ${SCRAPE_RETRY_DELAY}ms...`, Level.WARN);
+                await new Promise(r => setTimeout(r, SCRAPE_RETRY_DELAY));
               }
-            }, config);
+            }
           } else {
             paginationUsed = true;
             scrapeResults = await this.handlePagination(page, config, actionName);
@@ -1313,6 +1391,7 @@ export default class Interpreter extends EventEmitter {
               });
 
               await this.waitForDynamicStability(page, currentWorkflow || []);
+              await this.dismissOverlays(page);
 
               const pageResult = await scrapePageContent(url);
               pageResult.metadata.depth = depth;
@@ -1669,6 +1748,7 @@ export default class Interpreter extends EventEmitter {
               });
 
               await this.waitForDynamicStability(page, currentWorkflow || []);
+              await this.dismissOverlays(page);
 
               const pageData = await page.evaluate(() => {
                 const getMeta = (name: string) => {
@@ -1887,8 +1967,31 @@ export default class Interpreter extends EventEmitter {
             }
             if (!existingOpts.timeout) existingOpts.timeout = 15000;
 
-            await executeAction(invokee, methodName, [url, existingOpts]);
-            
+            try {
+              await executeAction(invokee, methodName, [url, existingOpts]);
+            } catch (gotoError: any) {
+              const TRANSIENT_GOTO_ERROR_PATTERNS = [
+                'ERR_NAME_NOT_RESOLVED',
+                'ERR_CONNECTION_REFUSED',
+                'ERR_CONNECTION_TIMED_OUT',
+                'ERR_CONNECTION_CLOSED',
+                'ERR_CONNECTION_RESET',
+                'ERR_INTERNET_DISCONNECTED',
+                'ERR_ADDRESS_UNREACHABLE',
+                'ERR_PROXY_CONNECTION_FAILED',
+                'ERR_TUNNEL_CONNECTION_FAILED',
+                'ERR_NETWORK_CHANGED',
+              ];
+              const isTransient = TRANSIENT_GOTO_ERROR_PATTERNS.some(pattern => gotoError.message?.includes(pattern));
+              if (isTransient) {
+                this.log(`goto failed: ${gotoError.message} — retrying once after backoff`, Level.WARN);
+                await new Promise(resolve => setTimeout(resolve, 1500));
+                await executeAction(invokee, methodName, [url, existingOpts]);
+              } else {
+                throw gotoError;
+              }
+            }
+
             if (needsDataSoon) {
               await this.waitForDynamicStability(page, (currentWorkflow || []).slice(0, -1));
             }
@@ -2012,8 +2115,12 @@ export default class Interpreter extends EventEmitter {
           debugLog(`Page evaluation failed: ${error.message}`);
           return;
         }
+        const sortedKeys = results.length > 0 ? Object.keys(results[0]).sort() : [];
         const newResults = results.filter(item => {
-            const uniqueKey = JSON.stringify(item);
+            const uniqueKey = sortedKeys.map(k => {
+              const v = (item as any)[k];
+              return v == null ? '' : (typeof v === 'object' ? JSON.stringify(v) : String(v));
+            }).join('\x00');
             if (scrapedItems.has(uniqueKey)) return false;
             scrapedItems.add(uniqueKey);
             return true;

--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -2084,6 +2084,8 @@ export default class Interpreter extends EventEmitter {
     let previousHeight = 0;
     let scrapedItems: Set<string> = new Set<string>();
     let visitedUrls: Set<string> = new Set<string>();
+    let visitedSignatures: Set<string> = new Set<string>();
+    
     const MAX_RETRIES = 3;
     const RETRY_DELAY = 1000;
     const MAX_UNCHANGED_RESULTS = 5;
@@ -2467,6 +2469,9 @@ export default class Interpreter extends EventEmitter {
           
             const beforeSignature = await captureContentSignature();
             debugLog(`Before click: ${beforeSignature.itemCount} items`);
+            if (beforeSignature.firstItems) {
+              visitedSignatures.add(beforeSignature.firstItems);
+            }
           
             while (retryCount < MAX_RETRIES && !paginationSuccess) {
               try {
@@ -2515,18 +2520,24 @@ export default class Interpreter extends EventEmitter {
                   const newUrl = page.url();
                   const afterSignature = await captureContentSignature();
                   
-                  if (newUrl !== currentUrl) {
+                  if (newUrl !== currentUrl && !visitedUrls.has(newUrl)) {
                     debugLog(`URL changed to ${newUrl}`);
                     visitedUrls.add(newUrl);
-                    paginationSuccess = true;
-                  } 
-                  else if (afterSignature.firstItems !== beforeSignature.firstItems) {
-                    debugLog("Content changed without URL change");
+                    if (afterSignature.firstItems) visitedSignatures.add(afterSignature.firstItems);
                     paginationSuccess = true;
                   }
-                  else if (afterSignature.itemCount !== beforeSignature.itemCount) {
-                    debugLog(`Item count changed from ${beforeSignature.itemCount} to ${afterSignature.itemCount}`);
+                  else if (afterSignature.firstItems !== beforeSignature.firstItems && !visitedSignatures.has(afterSignature.firstItems)) {
+                    debugLog("Content changed without URL change");
+                    if (afterSignature.firstItems) visitedSignatures.add(afterSignature.firstItems);
                     paginationSuccess = true;
+                  }
+                  else if (afterSignature.itemCount !== beforeSignature.itemCount && !visitedSignatures.has(afterSignature.firstItems)) {
+                    debugLog(`Item count changed from ${beforeSignature.itemCount} to ${afterSignature.itemCount}`);
+                    if (afterSignature.firstItems) visitedSignatures.add(afterSignature.firstItems);
+                    paginationSuccess = true;
+                  }
+                  else {
+                    debugLog('Pagination appears to have cycled back to previously seen content/URL — treating as no progress');
                   }
                 }
               } catch (error: any) {


### PR DESCRIPTION
What this PR does?

Fixes:

1. Dismisses cookie banners and popups automatically before scraping a page during crawl and search, so they don't block the real content.
2. Automatically retries a page visit once if it fails due to a temporary network hiccup, instead of giving up right away.
3. Cuts out unnecessary waiting time before scraping starts, and stops waiting on ads/trackers that don't affect the actual content.
4. If a scrape comes back empty, it now retries instead of accepting a blank result.
5. Table scraping now stops once it has collected the number of rows requested, instead of continuing to scrape past the limit.
6. Fixed a bug where scraping multiple fields from a list could mix up values between rows when the fields didn't line up perfectly.
7. Made the scraper smarter about knowing when a page has actually finished loading, by watching real network activity instead of just waiting a fixed amount of time, so pages get scraped faster without losing accuracy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list extraction fallback to correctly assemble rows when MBE-derived fields include `undefined` values.
  * Tightened scraping limit enforcement to stop reliably within table containers and row extraction.
  * Enhanced page readiness detection using a new readiness routine (including dismissing overlays beforehand) and reduced dependency on DOM/network quietness heuristics.
  * Added best-effort overlay dismissal before page content reads.
  * Retried transient navigation/connectivity failures once with backoff.
  * Reduced duplicate pagination results with a more stable per-item key, improved progress/cycle detection, and retried non-paginated scraping when results are empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->