### PR TITLE
fix(ui): match capture actions with recorder theme

### DIFF
--- a/src/components/recorder/RightSidePanel.tsx
+++ b/src/components/recorder/RightSidePanel.tsx
@@ -874,8 +874,8 @@ export const RightSidePanel: React.FC<RightSidePanelProps> = ({ onFinishCapture 
                   variant="outlined"
                   onClick={handleBackCaptureList}
                   sx={{
-                    color: '#ff00c3 !important',
-                    borderColor: '#ff00c3 !important',
+                    color: '#4b4848 !important',
+                    borderColor: '#858585 !important',
                     backgroundColor: 'whitesmoke !important',
                   }}
                 >

--- a/src/components/recorder/RightSidePanel.tsx
+++ b/src/components/recorder/RightSidePanel.tsx
@@ -1153,8 +1153,8 @@ export const RightSidePanel: React.FC<RightSidePanelProps> = ({ onFinishCapture 
                 color="error"
                 onClick={discardGetText}
                 sx={{
-                  color: '#ff00c3 !important',
-                  borderColor: '#ff00c3 !important',
+                  color: 'red !important',
+                  borderColor: 'red !important',
                   backgroundColor: 'whitesmoke !important',
                 }}
               >

--- a/src/components/recorder/RightSidePanel.tsx
+++ b/src/components/recorder/RightSidePanel.tsx
@@ -1180,8 +1180,8 @@ export const RightSidePanel: React.FC<RightSidePanelProps> = ({ onFinishCapture 
                 setActiveAction('none');
               }}
               sx={{
-                color: '#ff00c3 !important',
-                borderColor: '#ff00c3 !important',
+                color: 'red !important',
+                borderColor: 'red !important',
                 backgroundColor: 'whitesmoke !important',
               }}
             >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the “Back” button styling in the list capture pagination/limit step with new gray text and border colors.
  * Updated “Discard” button styling for text and screenshot capture flows, switching from magenta to red text and border while keeping the existing background.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->