### PR TITLE
fix: strip hidden base64-encoded data blobs

### DIFF
--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -1864,6 +1864,8 @@ export default class Interpreter extends EventEmitter {
                 const elementsWithMxId = document.querySelectorAll('[data-mx-id]');
                 elementsWithMxId.forEach(el => el.removeAttribute('data-mx-id'));
 
+                document.querySelectorAll("input[type='hidden']").forEach(el => el.remove());
+
                 const html = document.documentElement.outerHTML;
                 const links = Array.from(document.querySelectorAll('a')).map(a => a.href);
                 const allMetadata = getAllMeta();

--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -1309,6 +1309,8 @@ export default class Interpreter extends EventEmitter {
               const elementsWithMxId = document.querySelectorAll('[data-mx-id]');
               elementsWithMxId.forEach(el => el.removeAttribute('data-mx-id'));
 
+              document.querySelectorAll("input[type='hidden']").forEach(el => el.remove());
+
               const html = document.documentElement.outerHTML;
               const links = Array.from(document.querySelectorAll('a')).map(a => a.href);
               const allMetadata = getAllMeta();

--- a/server/src/markdownify/scrape.ts
+++ b/server/src/markdownify/scrape.ts
@@ -181,7 +181,8 @@ export async function convertPageToMarkdown(url: string, page: Page): Promise<st
         "meta",
         "iframe",
         "object",
-        "embed"
+        "embed",
+        "input[type='hidden']"
       ];
 
       selectors.forEach(sel => {
@@ -277,7 +278,8 @@ export async function convertPageToHTML(url: string, page: Page): Promise<string
         "meta",
         "iframe",
         "object",
-        "embed"
+        "embed",
+        "input[type='hidden']"
       ];
 
       selectors.forEach(sel => {


### PR DESCRIPTION
Some websites contain hidden input elements with large Base64-encoded data blobs. These are not useful for scraping and can negatively impact the quality of the extracted content. This PR removes such elements before scraping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hidden form fields (`input[type="hidden"]`) are now removed from extracted page content.
  * Improved DOM cleanup for both content extraction and generated HTML/Markdown to avoid including invisible input data.
  * Content extraction behavior remains otherwise unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->