### PR TITLE
fix(browser-management): restrict handleChangeUrl to http(s) schemes

### DIFF
--- a/server/src/browser-management/inputHandlers.ts
+++ b/server/src/browser-management/inputHandlers.ts
@@ -291,6 +291,42 @@ const onChangeUrl = async (url: string, userId: string) => {
 }
 
 /**
+ * Schemes that {@link handleChangeUrl} is allowed to navigate to.
+ *
+ * The recording browser is a shared, privileged worker: it has network access to
+ * the internal environment (Playwright runs on the server) and its DOM is
+ * scraped back into the run output. Any client that can reach the
+ * `input:url` socket event could otherwise coerce the worker into fetching
+ * `file:///etc/passwd`, `chrome://gpu`, `data:text/html,...`, `javascript:...`
+ * or arbitrary internal HTTP endpoints, and exfiltrate the response through
+ * subsequent scrape steps.
+ *
+ * We use the WHATWG URL parser so that only well-formed absolute URLs with an
+ * explicit http/https scheme are accepted; relative paths, opaque schemes and
+ * malformed input are all rejected.
+ */
+const ALLOWED_NAVIGATION_PROTOCOLS: readonly string[] = ['http:', 'https:'];
+
+/**
+ * Validates a user-supplied navigation target and returns the parsed URL if it
+ * is safe to hand to `page.goto`. Returns `null` for any input that is
+ * malformed or uses a disallowed scheme (e.g. `file:`, `chrome:`, `about:`,
+ * `data:`, `javascript:`, `ftp:`, ...).
+ */
+const parseNavigationUrl = (url: string): URL | null => {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return null;
+    }
+    if (!ALLOWED_NAVIGATION_PROTOCOLS.includes(parsed.protocol)) {
+        return null;
+    }
+    return parsed;
+};
+
+/**
  * An url change event handler.
  * Navigates the page to the given url and generates data for the workflow.
  * @param activeBrowser - the active remote browser {@link RemoteBrowser}
@@ -306,6 +342,24 @@ const handleChangeUrl = async (activeBrowser: RemoteBrowser, page: Page, url: st
         }
 
         if (url) {
+            // Only http(s) URLs are safe to navigate to. Reject any other
+            // scheme (file:, chrome:, about:, data:, javascript:, ftp:, ...)
+            // before touching the workflow generator or Playwright, so that a
+            // malicious recording client cannot read local files or reach
+            // internal services through the shared browser worker.
+            const parsed = parseNavigationUrl(url);
+            if (!parsed) {
+                logger.log(
+                    "warn",
+                    `Rejected change url event: only http(s) URLs are allowed`,
+                );
+                activeBrowser.emitBrowserPageError(
+                    url,
+                    'Only http(s) URLs are allowed.',
+                );
+                return;
+            }
+
             const generator = activeBrowser.generator;
             await generator.onChangeUrl(url, page);
 

--- a/server/src/browser-management/inputHandlers.ts
+++ b/server/src/browser-management/inputHandlers.ts
@@ -293,17 +293,23 @@ const onChangeUrl = async (url: string, userId: string) => {
 /**
  * Schemes that {@link handleChangeUrl} is allowed to navigate to.
  *
- * The recording browser is a shared, privileged worker: it has network access to
- * the internal environment (Playwright runs on the server) and its DOM is
- * scraped back into the run output. Any client that can reach the
- * `input:url` socket event could otherwise coerce the worker into fetching
- * `file:///etc/passwd`, `chrome://gpu`, `data:text/html,...`, `javascript:...`
- * or arbitrary internal HTTP endpoints, and exfiltrate the response through
- * subsequent scrape steps.
+ * The recording browser is a shared, privileged worker: Playwright runs on the
+ * server and its DOM is scraped back into the run output, so any client that
+ * can reach the `input:url` socket event could otherwise coerce the worker
+ * into loading non-network URIs such as `file:///etc/passwd`, `chrome://gpu`,
+ * `data:text/html,...` or `javascript:...` and exfiltrate the response
+ * through subsequent scrape steps.
  *
- * We use the WHATWG URL parser so that only well-formed absolute URLs with an
- * explicit http/https scheme are accepted; relative paths, opaque schemes and
- * malformed input are all rejected.
+ * This constant, together with {@link parseNavigationUrl}, performs *scheme
+ * validation only* via the WHATWG URL parser: only well-formed absolute URLs
+ * with an explicit `http:` or `https:` scheme are accepted; relative paths,
+ * opaque schemes and malformed input are rejected.
+ *
+ * Limitations: this check does **not** mitigate internal-host SSRF. HTTP(S)
+ * requests to `http://localhost`, `http://127.0.0.1`, `http://[::1]`,
+ * `http://169.254.169.254` (cloud metadata), RFC1918 ranges, `.internal`
+ * hostnames, etc. still pass. If host/IP-range filtering is required it must
+ * be added separately in the `input:url` handling path.
  */
 const ALLOWED_NAVIGATION_PROTOCOLS: readonly string[] = ['http:', 'https:'];
 


### PR DESCRIPTION
## Summary

Restrict `handleChangeUrl` in `server/src/browser-management/inputHandlers.ts` so that the shared recording browser only navigates to `http:` / `https:` URLs. The `input:url` socket event currently forwards the client-supplied string straight into `page.goto(url)` with no scheme validation, which lets an authenticated recording client point the Playwright worker at `file:///…`, `chrome://…`, `about:…`, `data:…`, `javascript:…` or `ftp:…` URIs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security fix

## Vulnerability details

- **Category:** CWE-20 Improper Input Validation (scheme filtering) → local file read / URI-scheme abuse in the browser worker
- **Component:** `server/src/browser-management/inputHandlers.ts` — `handleChangeUrl` / `input:url` socket handler
- **Trust boundary crossed:** authenticated recording client → shared Playwright worker
- **Preconditions:**
  1. An authenticated Maxun user with an active recording session (a `browserId` minted after `requireSignIn`).
  2. A socket client connected to the per-browser namespace `io.of(browserId)`.
  3. The Playwright browser worker running (the `browser` service in `docker-compose.yml`, or the local fallback).

### Data flow

`registerInputHandlers` in the same file binds the raw payload to the handler with no validation:

```ts
// server/src/browser-management/inputHandlers.ts (pre-fix, line 935 in current file)
socket.on("input:url", (data) => onChangeUrl(data, userId));
```

`onChangeUrl` → `handleWrapper` → `handleChangeUrl(activeBrowser, page, url)` then previously did:

```ts
if (url) {
    const generator = activeBrowser.generator;
    await generator.onChangeUrl(url, page);
    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
    ...
}
```

There is no allow-list on `url`. Any string the client sends is passed to `page.goto`, and the resulting DOM is then available to subsequent scrape actions on the same recording — i.e. the response body can be exfiltrated through normal run output.

### Impact

The Playwright browser runs inside the `browser` Docker service (see `docker-compose.yml` and `server/src/browser-management/browserConnection.ts` — `chromium.connect(wsEndpoint, …)`). So the reachable filesystem is the browser container's, not the backend's. Even scoped to that container, this is a genuine capability escalation for a recording user:

- `file:///etc/passwd`, `file:///proc/self/environ`, `file:///root/.cache/ms-playwright/…`, any file readable by the Chromium process (browser cache, launch config, potentially bind-mounted volumes) can be rendered and scraped out.
- `chrome://gpu`, `chrome://version`, `about:…` internal pages leak environment / build details.
- `data:text/html,<script>…</script>` and `javascript:…` execute attacker-controlled script inside the same-origin recording context, which is a nice pivot for the DOM-based automation that runs afterwards.
- Malformed / relative / opaque inputs were previously handed to Playwright and produced silent no-ops or `chrome-error://` states.

The `http:` / `https:` allow-list does not attempt to solve SSRF to internal HTTP hosts (`http://backend:8080/`, `http://minio:9000/`, `http://169.254.169.254/`, etc.) — that is a separate class of finding and would need an internal-host block to address. This PR is scoped to the scheme axis only.

## Fix

The change is 54 additions in a single file (`server/src/browser-management/inputHandlers.ts`) and no other behaviour changes:

1. Introduce a `readonly` allow-list `ALLOWED_NAVIGATION_PROTOCOLS = ['http:', 'https:']`.
2. Add `parseNavigationUrl(url)` which uses the WHATWG `URL` parser and returns the parsed `URL` only if the protocol is allow-listed, otherwise `null`. Malformed input, relative paths, protocol-relative URLs and opaque schemes all fall into the `null` branch (either the parser throws or the protocol check rejects them).
3. In `handleChangeUrl`, call `parseNavigationUrl(url)` before touching `activeBrowser.generator.onChangeUrl` or `page.goto`. On rejection we log a `warn`, surface a friendly error to the client via the existing `activeBrowser.emitBrowserPageError(url, 'Only http(s) URLs are allowed.')` broadcast, and return early.

Why this shape:

- Using the WHATWG parser (rather than a regex) avoids the classic `javascript:%20alert(1)` / `\tjavascript:` / `JAVASCRIPT://` bypasses — the parser normalises the protocol to lower-case with a trailing colon before we compare.
- Reusing `emitBrowserPageError` keeps the UX consistent with the existing "network error" path a few lines below, so the recorder UI already knows how to render the error.
- No new dependencies. No changes to the socket wiring, the workflow generator or the storage layer. Legitimate `http(s)` recording flows are unaffected — the parser accepts every well-formed `http`/`https` URL that `page.goto` would have accepted.

## Testing

Verified against 23 inputs — behaviour matches the intent (accept = navigation proceeds, reject = `emitBrowserPageError` with `Only http(s) URLs are allowed.`):

Accepted (`http:` / `https:` only): `https://example.com/`, `http://example.com/`, `https://example.com:8443/path?q=1#frag`, `http://user:pass@example.com/`, `HTTPS://EXAMPLE.COM/`, `https://xn--e1afmkfd.xn--p1ai/`.

Rejected: `file:///etc/passwd`, `file:///root/.cache/ms-playwright/`, `chrome://gpu`, `about:blank`, `data:text/html,<script>alert(1)</script>`, `javascript:alert(1)`, `ftp://example.com/`, `ws://example.com/`, `gopher://example.com/`, `//example.com/`, `/relative/path`, `example.com`, ``, `   `, `\tjavascript:alert(1)`, `JAVASCRIPT:alert(1)`, `java\nscript:alert(1)`.

Beyond the unit-level checks, I re-ran a recording session end-to-end against `https://example.com` and verified that (a) navigation still works, (b) URL bar updates propagate, (c) attempting to send `file:///etc/passwd` through the URL input surfaces the error toast and does not touch `page.goto`.

## Proof of concept

Preconditions: signed-in user, active recording session (so a `browserId` exists), and a socket connected to that namespace. In the browser console of the recording tab (which already holds the authenticated socket), the current client-side socket is exposed on the recorder store — but the simplest reproducer is to reuse the same socket the UI holds:

```js
// From the recording tab devtools, once a recording is active.
// The recorder already has an open socket-io connection to io.of(browserId);
// grab it and emit the raw event that the URL bar would normally send.
const s = window.__socket ?? (window.io && window.io.connect(location.origin + '/' + activeBrowserId));
s.emit('input:url', 'file:///etc/passwd');
// Before this PR: the browser worker navigates and the file contents render
// in the recording iframe, and any subsequent scrape step captures them.
// After this PR: no navigation, and the error toast shows
//                "Only http(s) URLs are allowed."
```

Equivalent one-liner from a Node client that reuses the auth cookie:

```js
const { io } = require('socket.io-client');
const s = io(`${MAXUN_URL}/${browserId}`, { extraHeaders: { cookie: SESSION_COOKIE } });
s.on('connect', () => s.emit('input:url', 'file:///etc/passwd'));
```

The relevant server-side listener is `socket.on("input:url", ...)` inside `registerInputHandlers` in `server/src/browser-management/inputHandlers.ts` (verified present at line 935 of the current file), and the pool wiring lives in `server/src/browser-management/controller.ts` where each browser gets its own `io.of(id)` namespace.

## Adversarial review

Before submitting I tried to disprove this. Two things worth calling out honestly:

1. Maxun's OSS deployment is explicitly documented as "designed for trusted, local environments" (see maintainer comment on #981), so cross-user isolation isn't a stated goal. That framing does soften severity, but rendering arbitrary files off the browser container is still not a normal recorder capability, and this fix is a small, self-contained scheme allow-list rather than a broader access-control change. It reduces attacker capability without changing the trust model.
2. The commit that inspired the audit mentioned "arbitrary internal HTTP endpoints." That claim overreaches — an `http(s)` allow-list does not block `http://backend:8080/`, `http://minio:9000/` or `http://169.254.169.254/`. The PR body and the code comment are scoped to what the fix actually delivers (URI-scheme filtering); the internal-host SSRF axis is a separate follow-up and is called out here so it doesn't get lost.

I also checked whether an existing sanitizer would already prevent this — the pre-fix `handleChangeUrl` has no scheme check, `generator.onChangeUrl` does not validate either, and the socket namespace `io.of(browserId)` has no `io.use` / `namespace.use` handshake middleware, so nothing upstream catches these payloads.

---




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser navigation URL handling by enforcing an allowlist for `http` and `https` only.
  * Malformed or unsupported URLs are now rejected before navigation begins, with a clear error surfaced to the user.
  * Added an extra safety check to prevent unintended or unsafe page loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->