### PR TITLE
fix: hostname url normalization

### DIFF
--- a/src/components/robot/pages/RobotCreate.tsx
+++ b/src/components/robot/pages/RobotCreate.tsx
@@ -365,12 +365,11 @@ const RobotCreate: React.FC = () => {
   const isValidUrl = (rawUrl: string): boolean => {
     const trimmed = rawUrl.trim();
     if (!trimmed) return false;
-    if ((trimmed.match(/https?:\/\//gi) ?? []).length > 1) return false;
     try {
       const parsed = new URL(trimmed);
       if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
       if (!parsed.hostname) return false;
-      const isPlausibleHost = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(parsed.hostname)
+      const isPlausibleHost = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i.test(parsed.hostname)
         || parsed.hostname === 'localhost'
         || /^\d{1,3}(\.\d{1,3}){3}$/.test(parsed.hostname)
         || /^\[[0-9a-f:]+\]$/i.test(parsed.hostname);

--- a/src/components/robot/pages/RobotCreate.tsx
+++ b/src/components/robot/pages/RobotCreate.tsx
@@ -356,8 +356,10 @@ const RobotCreate: React.FC = () => {
   const normalizeUrl = (rawUrl: string): string => {
     const trimmed = rawUrl.trim();
     if (!trimmed) return trimmed;
-    if (!/^https?:\/\//i.test(trimmed)) return `https://${trimmed}`;
-    return trimmed;
+    if (/^https?:\/\//i.test(trimmed)) return trimmed;
+    if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return trimmed;
+    if (/^[a-z][a-z0-9+.-]*\/\/\//i.test(trimmed)) return trimmed;
+    return `https://${trimmed}`;
   };
 
   const handleStartRecording = async () => {

--- a/src/components/robot/pages/RobotCreate.tsx
+++ b/src/components/robot/pages/RobotCreate.tsx
@@ -362,6 +362,24 @@ const RobotCreate: React.FC = () => {
     return `https://${trimmed}`;
   };
 
+  const isValidUrl = (rawUrl: string): boolean => {
+    const trimmed = rawUrl.trim();
+    if (!trimmed) return false;
+    if ((trimmed.match(/https?:\/\//gi) ?? []).length > 1) return false;
+    try {
+      const parsed = new URL(trimmed);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+      if (!parsed.hostname) return false;
+      const isPlausibleHost = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(parsed.hostname)
+        || parsed.hostname === 'localhost'
+        || /^\d{1,3}(\.\d{1,3}){3}$/.test(parsed.hostname)
+        || /^\[[0-9a-f:]+\]$/i.test(parsed.hostname);
+      return isPlausibleHost;
+    } catch {
+      return false;
+    }
+  };
+
   const handleStartRecording = async () => {
     if (!url.trim()) {
       notify('error', 'Please enter a valid URL');
@@ -370,6 +388,11 @@ const RobotCreate: React.FC = () => {
 
     const normalizedUrl = normalizeUrl(url);
     setUrl(normalizedUrl);
+
+    if (!isValidUrl(normalizedUrl)) {
+      notify('error', 'Please enter a valid URL (e.g. https://example.com)');
+      return;
+    }
 
     setIsLoading(true);
 
@@ -459,6 +482,11 @@ const RobotCreate: React.FC = () => {
 
     const normalizedCrawlUrl = normalizeUrl(crawlUrl);
     setCrawlUrl(normalizedCrawlUrl);
+
+    if (!isValidUrl(normalizedCrawlUrl)) {
+      notify('error', 'Please enter a valid URL (e.g. https://example.com)');
+      return;
+    }
 
     setIsLoading(true);
     try {
@@ -1233,6 +1261,10 @@ const RobotCreate: React.FC = () => {
                   }
                   const normalizedUrl = normalizeUrl(url);
                   setUrl(normalizedUrl);
+                  if (!isValidUrl(normalizedUrl)) {
+                    notify('error', 'Please enter a valid URL (e.g. https://example.com)');
+                    return;
+                  }
                   setIsLoading(true);
                   try {
                     const hasPrompt = !!scrapePromptInstructions.trim();

--- a/src/components/robot/pages/RobotDuplicatePage.tsx
+++ b/src/components/robot/pages/RobotDuplicatePage.tsx
@@ -59,8 +59,22 @@ export const RobotDuplicatePage = ({ handleStart }: RobotDuplicatePageProps) => 
   const normalizeUrl = (rawUrl: string): string => {
     const trimmed = rawUrl.trim();
     if (!trimmed) return trimmed;
-    if (!/^https?:\/\//i.test(trimmed)) return `https://${trimmed}`;
-    return trimmed;
+    if (/^https?:\/\//i.test(trimmed)) return trimmed;
+    if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return trimmed;
+    if (/^[a-z][a-z0-9+.-]*\/\/\//i.test(trimmed)) return trimmed;
+    return `https://${trimmed}`;
+  };
+
+  const isNavigableUrl = (rawUrl: string): boolean => {
+    try {
+      const parsed = new URL(rawUrl);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+      return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(parsed.hostname)
+        || parsed.hostname === 'localhost'
+        || /^\d{1,3}(\.\d{1,3}){3}$/.test(parsed.hostname);
+    } catch {
+      return false;
+    }
   };
 
   const handleSave = async () => {
@@ -74,6 +88,11 @@ export const RobotDuplicatePage = ({ handleStart }: RobotDuplicatePageProps) => 
 
     if (!newName.trim()) {
       notify("error", t("robot_duplication.notifications.name_required"));
+      return;
+    }
+
+    if (!isNavigableUrl(normalizedUrl)) {
+      notify("error", t("robot_duplication.notifications.url_invalid", "Please enter a valid website URL (e.g. https://example.com)"));
       return;
     }
 

--- a/src/components/robot/pages/RobotDuplicatePage.tsx
+++ b/src/components/robot/pages/RobotDuplicatePage.tsx
@@ -69,7 +69,7 @@ export const RobotDuplicatePage = ({ handleStart }: RobotDuplicatePageProps) => 
     try {
       const parsed = new URL(rawUrl);
       if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
-      return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(parsed.hostname)
+      return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i.test(parsed.hostname)
         || parsed.hostname === 'localhost'
         || /^\d{1,3}(\.\d{1,3}){3}$/.test(parsed.hostname)
         || /^\[[0-9a-f:]+\]$/i.test(parsed.hostname);

--- a/src/components/robot/pages/RobotDuplicatePage.tsx
+++ b/src/components/robot/pages/RobotDuplicatePage.tsx
@@ -71,7 +71,8 @@ export const RobotDuplicatePage = ({ handleStart }: RobotDuplicatePageProps) => 
       if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
       return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(parsed.hostname)
         || parsed.hostname === 'localhost'
-        || /^\d{1,3}(\.\d{1,3}){3}$/.test(parsed.hostname);
+        || /^\d{1,3}(\.\d{1,3}){3}$/.test(parsed.hostname)
+        || /^\[[0-9a-f:]+\]$/i.test(parsed.hostname);
     } catch {
       return false;
     }

--- a/src/components/robot/pages/RobotEditPage.tsx
+++ b/src/components/robot/pages/RobotEditPage.tsx
@@ -682,7 +682,8 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
       if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
       return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(parsed.hostname)
         || parsed.hostname === 'localhost'
-        || /^\d{1,3}(\.\d{1,3}){3}$/.test(parsed.hostname);
+        || /^\d{1,3}(\.\d{1,3}){3}$/.test(parsed.hostname)
+        || /^\[[0-9a-f:]+\]$/i.test(parsed.hostname);
     } catch {
       return false;
     }

--- a/src/components/robot/pages/RobotEditPage.tsx
+++ b/src/components/robot/pages/RobotEditPage.tsx
@@ -680,7 +680,7 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
     try {
       const parsed = new URL(rawUrl);
       if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
-      return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(parsed.hostname)
+      return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i.test(parsed.hostname)
         || parsed.hostname === 'localhost'
         || /^\d{1,3}(\.\d{1,3}){3}$/.test(parsed.hostname)
         || /^\[[0-9a-f:]+\]$/i.test(parsed.hostname);

--- a/src/components/robot/pages/RobotEditPage.tsx
+++ b/src/components/robot/pages/RobotEditPage.tsx
@@ -670,8 +670,22 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
   const normalizeUrl = (rawUrl: string): string => {
     const trimmed = rawUrl.trim();
     if (!trimmed) return trimmed;
-    if (!/^https?:\/\//i.test(trimmed)) return `https://${trimmed}`;
-    return trimmed;
+    if (/^https?:\/\//i.test(trimmed)) return trimmed;
+    if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return trimmed;
+    if (/^[a-z][a-z0-9+.-]*\/\/\//i.test(trimmed)) return trimmed;
+    return `https://${trimmed}`;
+  };
+
+  const isNavigableUrl = (rawUrl: string): boolean => {
+    try {
+      const parsed = new URL(rawUrl);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+      return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(parsed.hostname)
+        || parsed.hostname === 'localhost'
+        || /^\d{1,3}(\.\d{1,3}){3}$/.test(parsed.hostname);
+    } catch {
+      return false;
+    }
   };
 
   const handleTargetUrlChange = (newUrl: string) => {
@@ -1458,6 +1472,15 @@ export const RobotEditPage = ({ handleStart }: RobotSettingsProps) => {
 
   const handleSave = async () => {
     if (!robot) return;
+
+    const targetUrlValue = getTargetUrl();
+    const robotType = robot.recording_meta.type;
+    const hasEditableTargetUrl = !robot.recording_meta.type?.includes("prebuilt") &&
+      robotType !== 'search' && robotType !== 'doc-extract' && robotType !== 'doc-parse';
+    if (hasEditableTargetUrl && targetUrlValue && !isNavigableUrl(normalizeUrl(targetUrlValue))) {
+      notify("error", t("robot_edit.notifications.invalid_url", "Please enter a valid website URL (e.g. https://example.com)"));
+      return;
+    }
 
     if (robot.recording_meta.type === 'crawl' && crawlOutputFormats.length === 0) {
       notify("error", "Please select at least one output format");


### PR DESCRIPTION
Stops users from saving robots with URLs that can never work, like local file paths. Adds validation to only allow "http" and "https" URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved target URL handling to preserve already-absolute and scheme-based inputs, preventing incorrect `https://` prefixing.
  * Added stricter URL validation for robot creation, duplication, and editing so only navigable `http/https` destinations are accepted.
  * Invalid URLs are now blocked before actions complete, with a user-facing “invalid URL” notification (including an example) to guide correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->