### PR TITLE
docs(readme): add one-click Railway self-host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The simplest & fastest way to get started is to use the hosted version: https://
 
 Deploy Maxun on Railway with a prewired multi-service stack (nginx gateway, frontend, backend, remote Chromium, PostgreSQL, and MinIO):
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/maxun?referralCode=ToZEjF&utm_medium=integration&utm_source=button&utm_campaign=maxun)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/maxun?utm_medium=integration&utm_source=button&utm_campaign=maxun)
 
 After deploy, open only the **gateway** public URL so the UI and API share one origin (required for Maxun's httpOnly auth cookie). Optional `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` unlock AI mode.
 
@@ -133,7 +133,7 @@ Maxun can run locally with or without Docker
 4. [SDK](https://github.com/getmaxun/node-sdk)
 
 ### Upgrading & Self Hosting
-1. [One-Click Self Host on Railway](https://railway.com/deploy/maxun?referralCode=ToZEjF&utm_medium=integration&utm_source=button&utm_campaign=maxun)
+1. [One-Click Self Host on Railway](https://railway.com/deploy/maxun?utm_medium=integration&utm_source=button&utm_campaign=maxun)
 2. [Self Host Maxun With Docker](https://docs.maxun.dev/self-host)
 3. [Upgrade Maxun With Docker Compose Setup](https://docs.maxun.dev/installation/upgrade#upgrading-with-docker-compose)
 4. [Upgrade Maxun Without Docker Compose Setup](https://docs.maxun.dev/installation/upgrade#upgrading-with-local-setup)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ Learn more <a href="https://docs.maxun.dev/robot/search/search-introduction">her
 ### Getting Started
 The simplest & fastest way to get started is to use the hosted version: https://app.maxun.dev.
 
+### One-Click Self Host (Railway)
+
+Deploy Maxun on Railway with a prewired multi-service stack (nginx gateway, frontend, backend, remote Chromium, PostgreSQL, and MinIO):
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/maxun?referralCode=ToZEjF&utm_medium=integration&utm_source=button&utm_campaign=maxun)
+
+After deploy, open only the **gateway** public URL so the UI and API share one origin (required for Maxun's httpOnly auth cookie). Optional `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` unlock AI mode.
+
 ### Installation
 Maxun can run locally with or without Docker
 1. [Setup with Docker Compose](https://docs.maxun.dev/installation/docker)
@@ -125,9 +133,10 @@ Maxun can run locally with or without Docker
 4. [SDK](https://github.com/getmaxun/node-sdk)
 
 ### Upgrading & Self Hosting
-1. [Self Host Maxun With Docker](https://docs.maxun.dev/self-host)
-2. [Upgrade Maxun With Docker Compose Setup](https://docs.maxun.dev/installation/upgrade#upgrading-with-docker-compose)
-3. [Upgrade Maxun Without Docker Compose Setup](https://docs.maxun.dev/installation/upgrade#upgrading-with-local-setup)
+1. [One-Click Self Host on Railway](https://railway.com/deploy/maxun?referralCode=ToZEjF&utm_medium=integration&utm_source=button&utm_campaign=maxun)
+2. [Self Host Maxun With Docker](https://docs.maxun.dev/self-host)
+3. [Upgrade Maxun With Docker Compose Setup](https://docs.maxun.dev/installation/upgrade#upgrading-with-docker-compose)
+4. [Upgrade Maxun Without Docker Compose Setup](https://docs.maxun.dev/installation/upgrade#upgrading-with-local-setup)
 
 ## Features
 


### PR DESCRIPTION
## Summary

Adds a one-click **Deploy on Railway** path to the README so users can self-host Maxun without wiring Docker Compose by hand.

- New **One-Click Self Host (Railway)** section under Quick Start with the official Railway deploy button
- Points at the published marketplace template: https://railway.com/deploy/maxun
- Notes that only the gateway public URL should be used (same-origin auth cookie)
- Adds Railway as the first item under Upgrading & Self Hosting

Template stack: nginx gateway, frontend, backend, remote Chromium, PostgreSQL, and MinIO.

## Test plan

- [ ] Confirm the Deploy on Railway button renders in the README preview
- [ ] Confirm https://railway.com/deploy/maxun opens the Maxun template deploy flow
- [ ] Optional: smoke-deploy and open only the gateway URL to verify login/registration