### PR TITLE
Fix: Server and client crash when multiple recordings are discarded in rapid succession

### DIFF
--- a/server/src/browser-management/classes/RemoteBrowser.ts
+++ b/server/src/browser-management/classes/RemoteBrowser.ts
@@ -214,16 +214,15 @@ export class RemoteBrowser {
         options: Parameters<Page['goto']>[1] = {},
     ): Promise<Response | null> {
         const normalizedTarget = this.normalizeUrl(url);
-        const currentUrl = page.url();
-
-        if (currentUrl && this.normalizeUrl(currentUrl) === normalizedTarget) {
-            logger.debug(`Skipping duplicate navigation to ${url}`);
-            return null;
-        }
 
         const runNavigation = async (): Promise<Response | null> => {
             if (page.isClosed()) {
                 throw new Error('Cannot navigate: page is closed');
+            }
+
+            if (this.normalizeUrl(page.url()) === normalizedTarget) {
+                logger.debug(`Skipping duplicate navigation to ${url}`);
+                return null;
             }
 
             this.navigationVersion++;

--- a/server/src/browser-management/classes/RemoteBrowser.ts
+++ b/server/src/browser-management/classes/RemoteBrowser.ts
@@ -2,7 +2,8 @@ import {
     Page,
     Browser,
     CDPSession,
-    BrowserContext
+    BrowserContext,
+    Response
 } from 'playwright-core';
 import { Socket } from "socket.io";
 import { PlaywrightBlocker } from '@cliqz/adblocker-playwright';
@@ -86,6 +87,8 @@ export class RemoteBrowser {
     private userId: string;
 
     private lastEmittedUrl: string | null = null;
+    private navigationVersion = 0;
+    private navigationQueue: Promise<unknown> = Promise.resolve();
 
     /**
      * {@link WorkflowGenerator} instance specific to the remote browser.
@@ -197,6 +200,41 @@ export class RemoteBrowser {
         return normalizedNew !== normalizedLast;
     }
 
+    private isNavigationContextError(error: any): boolean {
+        const message = error?.message || '';
+        return message.includes('Execution context was destroyed') ||
+            message.includes('Cannot find context with specified id') ||
+            message.includes('Target closed') ||
+            message.includes('Navigation failed because page was closed');
+    }
+
+    public async navigateTo(
+        page: Page,
+        url: string,
+        options: Parameters<Page['goto']>[1] = {},
+    ): Promise<Response | null> {
+        const normalizedTarget = this.normalizeUrl(url);
+        const currentUrl = page.url();
+
+        if (currentUrl && this.normalizeUrl(currentUrl) === normalizedTarget) {
+            logger.debug(`Skipping duplicate navigation to ${url}`);
+            return null;
+        }
+
+        const runNavigation = async (): Promise<Response | null> => {
+            if (page.isClosed()) {
+                throw new Error('Cannot navigate: page is closed');
+            }
+
+            this.navigationVersion++;
+            return page.goto(url, options);
+        };
+
+        const navigation = this.navigationQueue.then(runNavigation, runNavigation);
+        this.navigationQueue = navigation.catch(() => {});
+        return navigation;
+    }
+
     /**
      * Broadcasts an event to all clients connected to this browser's namespace.
      * Falls back to direct socket emit if namespace is unavailable.
@@ -276,12 +314,22 @@ export class RemoteBrowser {
                 if (window.rrweb && window.isRecording) {
                   window.isRecording = false;
                 }
-              }).catch(() => {});
+              }).catch((error: any) => {
+                if (!this.isNavigationContextError(error)) {
+                  logger.warn(`[rrweb] Failed to stop previous recording: ${error?.message}`);
+                }
+              });
 
               if (this.isRecordingMode && !page.isClosed()) {
+                const navigationVersion = this.navigationVersion;
                 await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {
                   logger.warn('[rrweb] Network idle timeout on navigation, proceeding with rrweb initialization');
                 });
+
+                if (navigationVersion !== this.navigationVersion || page.isClosed()) {
+                  logger.debug('[rrweb] Skipping stale recording initialization after newer navigation');
+                  return;
+                }
 
                 await this.initializeRRWebRecording(page).catch((error: any) => {
                   logger.warn(`[rrweb] Failed to initialize recording on navigation: ${error?.message}`);
@@ -297,6 +345,7 @@ export class RemoteBrowser {
             try {
               const injectScript = async (): Promise<boolean> => {
                   try {
+                      const navigationVersion = this.navigationVersion;
                       await page.waitForLoadState('networkidle', { timeout: 5000 });
 
                       if (page.isClosed()) {
@@ -304,9 +353,18 @@ export class RemoteBrowser {
                         return false;
                       }
 
+                      if (navigationVersion !== this.navigationVersion) {
+                        logger.debug('Skipping stale script injection after newer navigation');
+                        return false;
+                      }
+
                       await page.evaluate(getInjectableScript());
                       return true;
                   } catch (error: any) {
+                      if (this.isNavigationContextError(error)) {
+                        logger.log('debug', `Script injection skipped after navigation changed: ${error.message}`);
+                        return false;
+                      }
                       logger.log('warn', `Script injection attempt failed: ${error.message}`);
                       return false;
                   }
@@ -334,8 +392,14 @@ export class RemoteBrowser {
       try {
         const rrwebJsPath = require.resolve('rrweb/dist/rrweb.min.js');
         const rrwebScriptContent = readFileSync(rrwebJsPath, 'utf8');
+        const navigationVersion = this.navigationVersion;
 
         await page.context().addInitScript(rrwebScriptContent);
+
+        if (navigationVersion !== this.navigationVersion || page.isClosed()) {
+          logger.debug('[rrweb] Skipping stale script injection before evaluate');
+          return;
+        }
 
         await page.evaluate((scriptContent) => {
           if (typeof window.rrweb === 'undefined') {
@@ -346,6 +410,11 @@ export class RemoteBrowser {
             }
           }
         }, rrwebScriptContent);
+
+        if (navigationVersion !== this.navigationVersion || page.isClosed()) {
+          logger.debug('[rrweb] Skipping stale recording initialization after script injection');
+          return;
+        }
 
         const rrwebLoaded = await page.evaluate(() => typeof window.rrweb !== 'undefined');
         if (rrwebLoaded) {
@@ -420,6 +489,10 @@ export class RemoteBrowser {
           logger.error(`Failed to initialize rrweb recording: ${rrwebStatus.error}`);
         }
       } catch (error: any) {
+        if (this.isNavigationContextError(error)) {
+          logger.debug(`[rrweb] Initialization skipped after navigation changed: ${error.message}`);
+          return;
+        }
         logger.error(`Failed to initialize rrweb recording: ${error.message}`);
       }
     }

--- a/server/src/browser-management/classes/RemoteBrowser.ts
+++ b/server/src/browser-management/classes/RemoteBrowser.ts
@@ -485,6 +485,9 @@ export class RemoteBrowser {
           this.isDOMStreamingActive = true;
           this.emitLoadingProgress(80, 0);
           this.setupScrollEventListener();
+        } else if (rrwebStatus.error === 'already recording') {
+          logger.debug('[rrweb] Recording already active, skipping duplicate initialization');
+          this.isDOMStreamingActive = true;
         } else {
           logger.error(`Failed to initialize rrweb recording: ${rrwebStatus.error}`);
         }

--- a/server/src/browser-management/classes/RemoteBrowser.ts
+++ b/server/src/browser-management/classes/RemoteBrowser.ts
@@ -27,6 +27,11 @@ declare global {
   }
 }
 
+interface PageNavigationState {
+    version: number;
+    queue: Promise<unknown>;
+}
+
 // const MEMORY_CONFIG = {
 //     gcInterval: 20000,
 //     maxHeapSize: 1536 * 1024 * 1024,
@@ -87,8 +92,7 @@ export class RemoteBrowser {
     private userId: string;
 
     private lastEmittedUrl: string | null = null;
-    private navigationVersion = 0;
-    private navigationQueue: Promise<unknown> = Promise.resolve();
+    private pageNavigationStates = new WeakMap<Page, PageNavigationState>();
 
     /**
      * {@link WorkflowGenerator} instance specific to the remote browser.
@@ -208,12 +212,22 @@ export class RemoteBrowser {
             message.includes('Navigation failed because page was closed');
     }
 
+    private getPageNavigationState(page: Page): PageNavigationState {
+        let state = this.pageNavigationStates.get(page);
+        if (!state) {
+            state = { version: 0, queue: Promise.resolve() };
+            this.pageNavigationStates.set(page, state);
+        }
+        return state;
+    }
+
     public async navigateTo(
         page: Page,
         url: string,
         options: Parameters<Page['goto']>[1] = {},
     ): Promise<Response | null> {
         const normalizedTarget = this.normalizeUrl(url);
+        const navigationState = this.getPageNavigationState(page);
 
         const runNavigation = async (): Promise<Response | null> => {
             if (page.isClosed()) {
@@ -225,12 +239,12 @@ export class RemoteBrowser {
                 return null;
             }
 
-            this.navigationVersion++;
+            navigationState.version++;
             return page.goto(url, options);
         };
 
-        const navigation = this.navigationQueue.then(runNavigation, runNavigation);
-        this.navigationQueue = navigation.catch(() => {});
+        const navigation = navigationState.queue.then(runNavigation, runNavigation);
+        navigationState.queue = navigation.catch(() => {});
         return navigation;
     }
 
@@ -320,12 +334,13 @@ export class RemoteBrowser {
               });
 
               if (this.isRecordingMode && !page.isClosed()) {
-                const navigationVersion = this.navigationVersion;
+                const navigationState = this.getPageNavigationState(page);
+                const navigationVersion = navigationState.version;
                 await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {
                   logger.warn('[rrweb] Network idle timeout on navigation, proceeding with rrweb initialization');
                 });
 
-                if (navigationVersion !== this.navigationVersion || page.isClosed()) {
+                if (navigationVersion !== navigationState.version || page.isClosed()) {
                   logger.debug('[rrweb] Skipping stale recording initialization after newer navigation');
                   return;
                 }
@@ -344,7 +359,8 @@ export class RemoteBrowser {
             try {
               const injectScript = async (): Promise<boolean> => {
                   try {
-                      const navigationVersion = this.navigationVersion;
+                      const navigationState = this.getPageNavigationState(page);
+                      const navigationVersion = navigationState.version;
                       await page.waitForLoadState('networkidle', { timeout: 5000 });
 
                       if (page.isClosed()) {
@@ -352,7 +368,7 @@ export class RemoteBrowser {
                         return false;
                       }
 
-                      if (navigationVersion !== this.navigationVersion) {
+                      if (navigationVersion !== navigationState.version) {
                         logger.debug('Skipping stale script injection after newer navigation');
                         return false;
                       }
@@ -391,11 +407,12 @@ export class RemoteBrowser {
       try {
         const rrwebJsPath = require.resolve('rrweb/dist/rrweb.min.js');
         const rrwebScriptContent = readFileSync(rrwebJsPath, 'utf8');
-        const navigationVersion = this.navigationVersion;
+        const navigationState = this.getPageNavigationState(page);
+        const navigationVersion = navigationState.version;
 
         await page.context().addInitScript(rrwebScriptContent);
 
-        if (navigationVersion !== this.navigationVersion || page.isClosed()) {
+        if (navigationVersion !== navigationState.version || page.isClosed()) {
           logger.debug('[rrweb] Skipping stale script injection before evaluate');
           return;
         }
@@ -410,7 +427,7 @@ export class RemoteBrowser {
           }
         }, rrwebScriptContent);
 
-        if (navigationVersion !== this.navigationVersion || page.isClosed()) {
+        if (navigationVersion !== navigationState.version || page.isClosed()) {
           logger.debug('[rrweb] Skipping stale recording initialization after script injection');
           return;
         }

--- a/server/src/browser-management/inputHandlers.ts
+++ b/server/src/browser-management/inputHandlers.ts
@@ -370,7 +370,7 @@ const handleChangeUrl = async (activeBrowser: RemoteBrowser, page: Page, url: st
             await generator.onChangeUrl(url, page);
 
             try {
-                await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
+                await activeBrowser.navigateTo(page, url, { waitUntil: "domcontentloaded", timeout: 30000 });
 
                 const finalUrl = page.url();
                 if (finalUrl.startsWith('chrome-error://') || finalUrl.startsWith('chrome://chromewebdata')) {


### PR DESCRIPTION
## Description

Fixes #1021 

If multiple recordings are discarded very quickly, a new `page.goto()` starts before the previous one finishes, causing the previous navigation to be cancelled (`net::ERR_ABORTED`). The rrweb setup then tries to run `page.evaluate()`, but the page has already changed, so its execution context no longer exists, resulting in an error.

Because this error happens inside asynchronous page event handlers (`framenavigated` and `load`), it isn't caught properly and becomes an unhandled promise rejection. This causes the server to crash (exit code 1), and the client is then terminated with SIGTERM.

<img width="1055" height="367" alt="Screenshot 2026-07-29 at 12 55 40 PM" src="https://github.com/user-attachments/assets/05c4b0d0-8337-4ecd-8a0e-75b24bc21305" />


## Root cause

1. Concurrent, overlapping `page.goto()` calls abort each other.
2. rrweb initialization and script injection call `page.evaluate()` on a context
   that a newer navigation has already destroyed.
3. The resulting rejections were unhandled inside the event handlers.

## Changes

- Made page navigations run one at a time, so a new navigation no longer cancels one that is already in progress. Also skipped duplicate navigations to the same URL.
- Prevented rrweb initialization and script injection from running on an outdated or closed page by checking whether the page had already navigated away.
- Handled expected navigation errors gracefully by logging them at the debug level instead of letting them crash the application.
- Added try/catch blocks around page event handlers to prevent unhandled promise rejections.
- Treated the rrweb "already recording" case as a normal situation instead of an error.
- Updated URL changes to use the same navigation flow, ensuring all navigations are handled consistently.

## Testing

I started a recording and repeatedly discarded it in quick succession to reproduce the issue. After each attempt, I verified that both the server and client continued running without crashing. I also confirmed that no errors were logged in the backend, no unhandled promise rejections occurred, and the client was not terminated by SIGTERM. Next, I started a normal recording and navigated between pages to ensure the existing functionality was unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation reliability by sequencing navigations per page.
  * Prevented stale async navigation work from running after newer navigations.
  * Reduced noisy rrweb errors caused by page/context shutdowns and interrupted navigations.
  * Improved rrweb recording initialization across navigations by skipping stale attempts.
  * Preserved existing detection of browser error pages after navigation failures.
  * URL changes now route through the centralized navigation flow to keep parameters and checks consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->