### PR TITLE
fix: clock icon invisible in dark mode

### DIFF
--- a/src/context/theme-provider.tsx
+++ b/src/context/theme-provider.tsx
@@ -357,7 +357,7 @@ const ThemeModeProvider = ({ children }: { children: React.ReactNode }) => {
   return (
     <ThemeModeContext.Provider value={{ toggleTheme, darkMode }}>
       <ThemeProvider theme={darkMode ? darkTheme : lightTheme}>
-        <CssBaseline />
+        <CssBaseline enableColorScheme />
         {children}
       </ThemeProvider>
     </ThemeModeContext.Provider>


### PR DESCRIPTION
Adds `enableColorScheme` to `CssBaseline` so native date/time picker controls follow the MUI theme mode.

Fixes #1170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved theme support by enabling the document’s color scheme, helping browsers apply light and dark mode preferences more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->