### PR TITLE
Feat/sdk targeted list limits (list-limits part of issue #1107)

### DIFF
--- a/server/src/api/sdk.ts
+++ b/server/src/api/sdk.ts
@@ -434,15 +434,22 @@ router.put("/sdk/robots/:id", requireAPIKey, async (req: AuthenticatedRequest, r
 
         const updateData: any = {};
 
-        if (updates.workflow) {
-            try {
-                updateData.recording = {
-                    workflow: normalizeWorkflowUrls(updates.workflow)
-                };
-            } catch {
-                return res.status(400).json({ error: "Invalid URL in workflow" });
-            }
+        /**
+         * A single working copy of the workflow. A request may replace the
+         * workflow wholesale, patch individual values such as `limits`, or do
+         * both, so every block below edits this one array, and it is written
+         * back to `updateData` once at the end.
+         */
+        let workflow: any[];
+        try {
+            workflow = updates.workflow
+                ? normalizeWorkflowUrls(updates.workflow)
+                : JSON.parse(JSON.stringify(robot.recording?.workflow || []));
+        } catch {
+            return res.status(400).json({ error: "Invalid URL in workflow" });
         }
+
+        let workflowTouched = Boolean(updates.workflow);
 
         if (updates.meta) {
             let normalizedMetaUrl: string | undefined;
@@ -456,12 +463,6 @@ router.put("/sdk/robots/:id", requireAPIKey, async (req: AuthenticatedRequest, r
                 }
             }
 
-            let workflow: any[];
-            try {
-                workflow = updates.workflow ? normalizeWorkflowUrls(updates.workflow) : JSON.parse(JSON.stringify(robot.recording?.workflow || []));
-            } catch {
-                return res.status(400).json({ error: "Invalid URL in workflow" });
-            }
             if (normalizedMetaUrl) {
                 workflow.forEach((pair: any) => {
                     let stepUpdate = false;
@@ -479,7 +480,7 @@ router.put("/sdk/robots/:id", requireAPIKey, async (req: AuthenticatedRequest, r
                         pair.where.url = normalizedMetaUrl;
                     }
                 });
-                updateData.recording = { workflow };
+                workflowTouched = true;
             }
 
             updateData.recording_meta = {
@@ -488,6 +489,34 @@ router.put("/sdk/robots/:id", requireAPIKey, async (req: AuthenticatedRequest, r
                 ...(normalizedMetaUrl ? { url: normalizedMetaUrl } : {}),
                 updatedAt: new Date().toISOString()
             };
+        }
+
+        /**
+         * Targeted limit updates, addressed by position in the workflow. Runs
+         * after the workflow and meta blocks so the value the caller asked for
+         * survives whatever those wrote. Anything not named here keeps the
+         * value it already had.
+         */
+        if (Array.isArray(updates.limits) && updates.limits.length > 0) {
+            for (const { pairIndex, actionIndex, argIndex, limit } of updates.limits) {
+                if (!Number.isInteger(limit) || limit < 1) {
+                    return res.status(400).json({ error: `Invalid limit: ${limit}. Must be a positive integer.` });
+                }
+
+                const arg = workflow[pairIndex]?.what?.[actionIndex]?.args?.[argIndex];
+                if (!arg || typeof arg !== 'object') {
+                    return res.status(400).json({
+                        error: `No action argument at pair ${pairIndex}, action ${actionIndex}, arg ${argIndex}.`
+                    });
+                }
+
+                (arg as { limit: number }).limit = limit;
+                workflowTouched = true;
+            }
+        }
+
+        if (workflowTouched) {
+            updateData.recording = { ...robot.recording, workflow };
         }
 
         if (updates.google_sheet_email !== undefined) {

--- a/server/src/api/sdk.ts
+++ b/server/src/api/sdk.ts
@@ -497,12 +497,38 @@ router.put("/sdk/robots/:id", requireAPIKey, async (req: AuthenticatedRequest, r
          * survives whatever those wrote. Anything not named here keeps the
          * value it already had.
          */
-        if (Array.isArray(updates.limits) && updates.limits.length > 0) {
-            for (const { pairIndex, actionIndex, argIndex, limit } of updates.limits) {
-                if (!Number.isInteger(limit) || limit < 1) {
-                    return res.status(400).json({ error: `Invalid limit: ${limit}. Must be a positive integer.` });
+        if (updates.limits !== undefined) {
+            if (!Array.isArray(updates.limits)) {
+                return res.status(400).json({ error: '"limits" must be an array.' });
+            }
+
+            // Validate the whole payload before applying any of it, so a
+            // malformed entry cannot throw mid-loop or leave the workflow
+            // half-patched.
+            for (let i = 0; i < updates.limits.length; i++) {
+                const entry = updates.limits[i];
+
+                if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+                    return res.status(400).json({ error: `limits[${i}] must be an object.` });
                 }
 
+                for (const field of ['pairIndex', 'actionIndex', 'argIndex']) {
+                    const value = entry[field];
+                    if (!Number.isInteger(value) || value < 0) {
+                        return res.status(400).json({
+                            error: `limits[${i}].${field} must be a non-negative integer.`
+                        });
+                    }
+                }
+
+                if (!Number.isInteger(entry.limit) || entry.limit < 1) {
+                    return res.status(400).json({
+                        error: `limits[${i}].limit must be a positive integer.`
+                    });
+                }
+            }
+
+            for (const { pairIndex, actionIndex, argIndex, limit } of updates.limits) {
                 const arg = workflow[pairIndex]?.what?.[actionIndex]?.args?.[argIndex];
                 if (!arg || typeof arg !== 'object') {
                     return res.status(400).json({


### PR DESCRIPTION
## The problem

The web app can change one setting on a robot at a time. If you edit a scrape list's limit, it sends just that limit, and only that limit changes.

The SDK can't. `PUT /api/sdk/robots/:id` only accepts `meta` and `workflow`, so changing one number means rebuilding and resending the robot's whole workflow every selector, every field, every pagination rule.

The web app route (`server/src/routes/storage.ts:414`) already accepts `limits`, `credentials`, and `targetUrl` and applies each one on its own. The SDK route never got the same treatment. Sending `{"limits": [...]}` to the SDK endpoint returns **200 OK** and silently does nothing, because Express ignores body keys the handler doesn't read. Checked against Maxun Cloud before starting:

```
PUT status: 200
limit 10 -> 10 (wanted 7)
```

Success response, no change.

## What this PR does

Teaches the SDK endpoint to understand `limits`, using the same format the web app already sends:

```jsonc
PUT /api/sdk/robots/:id
{ "limits": [ { "pairIndex": 0, "actionIndex": 0, "argIndex": 0, "limit": 25 } ] }
```

If the request has no `workflow`, the handler loads the saved one from the database and changes only the values named in `limits`. Everything else stays as it was.

## The changes

**1. Added the `limits` handling.** Walks to the exact argument and sets its limit.

**2. Cleaned up how the workflow is saved.** The handler used to write `updateData.recording` in three different places, and the `meta` branch declared its own `workflow` variable that hid the outer one. Adding a fourth writer would
have made this worse, so now there's one workflow variable that every branch edits, and one save at the end.

**3. Made `limits` apply last.** If a request contains both `workflow` and `limits`, the limit the caller asked for wins. This matters because the web app sends both together on every save.

**4. Stopped throwing away other data.** The save is now `{ ...robot.recording, workflow }` instead of `{ workflow }`. Document robots store `documentKey` and `documentFileName` next to the workflow (`storage.ts:2375`), so the old code would have wiped the link to the uploaded file whenever the workflow was updated through the SDK. The web app route
already did this correctly at `storage.ts:593`.

**5. Added error messages.** A limit that isn't a positive whole number, or coordinates pointing at nothing, now return 400 instead of quietly doing nothing.

## How to check it works

Start the stack on this branch, make a robot with a list, and grab its id. Then:

```bash
curl -X PUT "http://localhost:8080/api/sdk/robots/<ROBOT_ID>" \
  -H "x-api-key: <API_KEY>" -H "Content-Type: application/json" \
  -d '{"limits":[{"pairIndex":0,"actionIndex":0,"argIndex":0,"limit":25}]}'
```
Then read the value straight out of Postgres, not from the API response. The old code returned 200 here too:

```sql
SELECT jsonb_path_query(recording->'workflow', '$[*].what[*].args[*].limit')
FROM robot WHERE recording_meta->>'id' = '<ROBOT_ID>';
```

You may need different coordinates; enrichment decides where the `scrapeList` action ends up.

## Works for crawl and search too

* crawl and search robots keep their `limit` in the same place as extract robots,  inside the action's first argument.

```jsonc
// extract
{ "limit": 10, "fields": {...}, "listSelector": "..." }   // action: scrapeList
// crawl
{ "mode": "domain", "limit": 15, "maxDepth": 2 }          // action: crawl
// search
{ "mode": "discover", "limit": 8, "query": "..." }        // action: search
```
Because the handler addresses arguments by position rather than by action type, this one change covers all three. Verified on each.

Scrape robots store an empty workflow, so they have no limit to update.

## What I tested (and how others can test as well (tested in node-sdk repo))
 
Verification was driven from the Node SDK rather than from this repo, since that
is the client this endpoint exists to serve. The companion PR in `getmaxun/node-sdk` adds `Robot.setListLimit()` and an `examples/list-limit.ts` showing its use.

Reviewers who would rather stay in this repo can use the `curl` command above it hits the same code path with no SDK involved.

Against a local stack (there is an example test in the examples folder in node-sdk):
- **extract, crawl, and search robots**: limit changed on each, and the fields beside it were untouched — `fields` and `listSelector` on extract, `mode` and `maxDepth` on crawl, `query`, `provider` and `mode` on search
- changed a limit, then changed it again
- robot with two lists: changed one, confirmed the other kept its old value
- several limits updated in a single request
- `-1`, `0`, `2.5`, and a made-up coordinate all rejected with 400, and the stored value didn't move afterwards
- renamed a robot via `meta`: the limit was unaffected

Every result was read back out of Postgres, not just from the API response, because the pre-change behaviour also returned 200:
```
Phase extract | extract | 10  ->  3
Phase crawl   | crawl   | 15  ->  6
Phase search  | search  |  8  ->  2
```

## Notes
- There's a matching SDK PR (`getmaxun/node-sdk`) that adds `Robot.setListLimit()`. It does nothing without this change, so this one should merge first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Robot updates now maintain a single workflow copy when workflows are replaced.
  - Metadata URLs are preserved through workflow updates.
  - Targeted action limits can be updated using validated positive integer values.

- **Bug Fixes**
  - Existing recording details are preserved during workflow changes.
  - Workflows are saved only when changes are detected.
  - Invalid workflow URLs, limits, or action arguments now return HTTP 400 errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->