### PR TITLE
fix: Proxy Test endpoint reports success even when configured proxy is invalid

### DIFF
--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -95,10 +95,14 @@ router.get('/test', requireSignIn, async (req: Request, res: Response) => {
             });
 
             const page = await context.newPage();
-            await page.goto('https://example.com', {
+            const response = await page.goto('https://example.com', {
                 waitUntil: 'domcontentloaded',
                 timeout: 30000,
             });
+
+            if (!response || !response.ok()) {
+                throw new Error(`Proxy test failed with status ${response?.status() || 'unknown'}`);
+            }
 
             res.status(200).send({ success: true });
         } finally {

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from 'express';
+import type { Browser, BrowserContext } from 'playwright-core';
 import { connectToRemoteBrowser } from '../browser-management/browserConnection';
 import User from '../models/User';
 import { encrypt, decrypt } from '../utils/auth';
@@ -76,22 +77,36 @@ router.get('/test', requireSignIn, async (req: Request, res: Response) => {
         const decryptedProxyUsername = user.proxy_username ? decrypt(user.proxy_username) : null;
         const decryptedProxyPassword = user.proxy_password ? decrypt(user.proxy_password) : null;
 
-        const proxyOptions: any = {
-            server: decryptedProxyUrl,
-            ...(decryptedProxyUsername && decryptedProxyPassword && {
-                username: decryptedProxyUsername,
-                password: decryptedProxyPassword,
-            }),
-        };
+        if (!decryptedProxyUrl) {
+            return res.status(400).send({ success: false, error: 'Proxy is not configured' });
+        }
 
-        const browser = await connectToRemoteBrowser();
-        const page = await browser.newPage();
-        await page.goto('https://example.com');
-        await browser.close();
+        let browser: Browser | null = null;
+        let context: BrowserContext | null = null;
 
-        res.status(200).send({ success: true });
-    } catch (error) {
-        res.status(500).send({ success: false, error: 'Proxy connection failed' });
+        try {
+            browser = await connectToRemoteBrowser();
+            context = await browser.newContext({
+                proxy: {
+                    server: decryptedProxyUrl,
+                    username: decryptedProxyUsername || undefined,
+                    password: decryptedProxyPassword || undefined,
+                },
+            });
+
+            const page = await context.newPage();
+            await page.goto('https://example.com', {
+                waitUntil: 'domcontentloaded',
+                timeout: 30000,
+            });
+
+            res.status(200).send({ success: true });
+        } finally {
+            await context?.close().catch(() => {});
+            await browser?.close().catch(() => {});
+        }
+    } catch (error: any) {
+        res.status(500).send({ success: false, error: error.message || 'Proxy connection failed' });
     }
 });
 


### PR DESCRIPTION
Fixes #1165 

This PR fixes the proxy test so it returns an error when the configured proxy is invalid, unreachable, or has incorrect credentials, and only reports success when the proxy is actually usable.

**Future Improvements**

While testing, I noticed a separate UX issue. Failed proxy tests (e.g. unreachable, dead, or invalid credentials) may take up to 30 seconds to return, and the UI provides no feedback while waiting.

If these UX improvements align with Maxun's direction, I'm happy to add a loading state to the Test Proxy button and ensure ProxyForm.testProxy() consistently displays an error notification in this PR or open a follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy connection testing by validating configuration before connecting.
  * Added authenticated proxy support for test connections.
  * Added response-status verification to detect unsuccessful connections.
  * Added a 30-second timeout and more consistent page-load handling.
  * Improved browser and session cleanup after tests.
  * Preserved underlying error details to provide clearer failure messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->