### PR TITLE
Fix schedule run state transition

### DIFF
--- a/server/src/workflow-management/scheduler/index.ts
+++ b/server/src/workflow-management/scheduler/index.ts
@@ -557,6 +557,7 @@ async function executeRun(id: string, userId: string) {
       }
     }
 
+    await run.update({ status: 'running' });
     plainRun.status = 'running';
 
     try {


### PR DESCRIPTION
Fixes #1167.

## Summary

This PR fixes an issue where scheduled robot runs remained in the `Scheduled` state while they were actively executing.
Previously, scheduled runs would transition directly from:

`Scheduled -> Success/Failed` instead of reflecting the actual execution state: `Scheduled → Running → Success/Failed`

The run status is now updated to `Running` when execution begins, consistent with manually triggered runs.

## Testing

* Created and scheduled a robot run.
* Verified the run initially appears as `Scheduled`.
* Verified the status changes to `Running` once the scheduled execution begins.
* Verified the status changes to `Success` after a successful run.
* Verified failed scheduled runs transition from `Running` to `Failed`.
* Confirmed non-scheduled runs continue to behave as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow run status tracking by ensuring runs are marked as **Running** before non-scrape workflows begin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->