### PR TITLE
feat: add OrcaRouter preset to OpenAI-compatible providers

### DIFF
--- a/src/components/robot/pages/RobotCreate.tsx
+++ b/src/components/robot/pages/RobotCreate.tsx
@@ -55,7 +55,7 @@ function TabPanel(props: TabPanelProps) {
 }
 
 type LlmProvider = 'anthropic' | 'openai' | 'ollama';
-type OpenAICompatiblePresetId = 'openai' | 'qianfan' | 'openrouter' | 'deepseek' | 'custom';
+type OpenAICompatiblePresetId = 'openai' | 'qianfan' | 'openrouter' | 'orcarouter' | 'deepseek' | 'custom';
 
 interface OpenAICompatiblePreset {
   label: string;
@@ -102,6 +102,16 @@ const OPENAI_COMPATIBLE_PRESETS: Record<OpenAICompatiblePresetId, OpenAICompatib
     apiKeyPlaceholder: 'OpenRouter API key',
     apiKeyHelperText: 'Use an OpenRouter API key. If blank, Maxun falls back to OPENAI_API_KEY on the server.',
   },
+  orcarouter: {
+    label: 'OrcaRouter',
+    baseUrl: 'https://api.orcarouter.ai/v1',
+    baseUrlPlaceholder: 'https://api.orcarouter.ai/v1',
+    baseUrlHelperText: 'Use the OrcaRouter OpenAI-compatible endpoint, or override it for your account.',
+    modelPlaceholder: 'e.g. orcarouter/auto',
+    modelHelperText: 'Enter an OrcaRouter model id from your enabled models.',
+    apiKeyPlaceholder: 'OrcaRouter API key',
+    apiKeyHelperText: 'Use an OrcaRouter API key. If blank, Maxun falls back to OPENAI_API_KEY on the server.',
+  },
   deepseek: {
     label: 'DeepSeek',
     baseUrl: 'https://api.deepseek.com',
@@ -128,6 +138,7 @@ const OPENAI_COMPATIBLE_PRESET_IDS: OpenAICompatiblePresetId[] = [
   'openai',
   'qianfan',
   'openrouter',
+  'orcarouter',
   'deepseek',
   'custom',
 ];

--- a/src/components/robot/pages/RobotEditPage.tsx
+++ b/src/components/robot/pages/RobotEditPage.tsx
@@ -31,7 +31,7 @@ import {
 } from "../../../constants/outputFormats";
 
 type LlmProvider = 'anthropic' | 'openai' | 'ollama';
-type OpenAICompatiblePresetId = 'openai' | 'qianfan' | 'openrouter' | 'deepseek' | 'custom';
+type OpenAICompatiblePresetId = 'openai' | 'qianfan' | 'openrouter' | 'orcarouter' | 'deepseek' | 'custom';
 
 interface OpenAICompatiblePreset {
   label: string;
@@ -79,6 +79,16 @@ const OPENAI_COMPATIBLE_PRESETS: Record<OpenAICompatiblePresetId, OpenAICompatib
     apiKeyPlaceholder: 'OpenRouter API key',
     apiKeyHelperText: 'Use an OpenRouter API key. If blank, Maxun falls back to OPENAI_API_KEY on the server.',
   },
+  orcarouter: {
+    label: 'OrcaRouter',
+    baseUrl: 'https://api.orcarouter.ai/v1',
+    baseUrlPlaceholder: 'https://api.orcarouter.ai/v1',
+    baseUrlHelperText: 'Use the OrcaRouter OpenAI-compatible endpoint, or override it for your account.',
+    modelPlaceholder: 'e.g. orcarouter/auto',
+    modelHelperText: 'Enter an OrcaRouter model id from your enabled models.',
+    apiKeyPlaceholder: 'OrcaRouter API key',
+    apiKeyHelperText: 'Use an OrcaRouter API key. If blank, Maxun falls back to OPENAI_API_KEY on the server.',
+  },
   deepseek: {
     label: 'DeepSeek',
     baseUrl: 'https://api.deepseek.com',
@@ -101,7 +111,7 @@ const OPENAI_COMPATIBLE_PRESETS: Record<OpenAICompatiblePresetId, OpenAICompatib
   },
 };
 
-const OPENAI_COMPATIBLE_PRESET_IDS: OpenAICompatiblePresetId[] = ['openai', 'qianfan', 'openrouter', 'deepseek', 'custom'];
+const OPENAI_COMPATIBLE_PRESET_IDS: OpenAICompatiblePresetId[] = ['openai', 'qianfan', 'openrouter', 'orcarouter', 'deepseek', 'custom'];
 
 const getPreset = (id: OpenAICompatiblePresetId) => OPENAI_COMPATIBLE_PRESETS[id];
 


### PR DESCRIPTION
Adds [OrcaRouter](https://www.orcarouter.ai) as a named provider in the OpenAI-compatible preset dropdown, mirroring the existing OpenRouter preset. With one API key, users get 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint. Because the OpenAI-compatible preset is a thin base-URL swap, any Maxun robot that uses it also inherits OrcaRouter's gateway-level, zero-trust security controls for AI agents — with no application code changes. The gateway screens every prompt and response and governs every tool call on a default-deny basis, across four layers:

- **Scoped keys** — bind a key to specific models, IPs, spend caps, and expiry.
- **Guardrails** — screen for PII, secret leakage, prompt injection, and unsafe output.
- **Agent firewall** — tool allow-lists with per-argument validation.
- **Audit trail** — a record of every match, verdict, and approval decision.

I'm an engineer on the OrcaRouter team.

## Changes Made

- Added an `OrcaRouter` entry to `OPENAI_COMPATIBLE_PRESETS` in `src/components/robot/pages/RobotCreate.tsx` and `src/components/robot/pages/RobotEditPage.tsx`:
  - `baseUrl: https://api.orcarouter.ai/v1`
  - Model placeholder `e.g. orcarouter/auto`
  - API key placeholder `OrcaRouter API key` — blank keys fall back to `OPENAI_API_KEY` on the server, same as the other presets
- Added `orcarouter` to the `OpenAICompatiblePresetId` union and `OPENAI_COMPATIBLE_PRESET_IDS`, so it shows up in the "OpenAI-compatible Preset" selector alongside OpenAI, Qianfan, OpenRouter and DeepSeek.

## Verification

- `npx eslint` on both changed files passes (repo config: `eslint-config-react-app`).
- TypeScript build (`vite build`) compiles cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as a selectable OpenAI-compatible language model provider when creating or editing robots.
  * Included setup guidance for the provider’s endpoint, supported models, and API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->