### PR TITLE
fix: validate all webhook urls

### DIFF
--- a/server/src/routes/webhook.ts
+++ b/server/src/routes/webhook.ts
@@ -3,6 +3,7 @@ import Robot from '../models/Robot';
 import { requireSignIn } from '../middlewares/auth';
 import axios from 'axios';
 import { v4 as uuid } from "uuid";
+import { validateWebhookUrl, WEBHOOK_REQUEST_OPTIONS } from '../utils/webhook-url';
 
 export const router = Router();
 
@@ -64,11 +65,9 @@ router.post('/add', requireSignIn, async (req: Request, res: Response) => {
             return res.status(400).json({ ok: false, error: 'Webhook URL is required' });
         }
 
-        // Validate URL format
-        try {
-            new URL(webhook.url);
-        } catch (error) {
-            return res.status(400).json({ ok: false, error: 'Invalid webhook URL format' });
+        const urlCheck = await validateWebhookUrl(webhook.url);
+        if (!urlCheck.safe) {
+            return res.status(400).json({ ok: false, error: urlCheck.reason || 'Invalid webhook URL' });
         }
 
         const robot = await Robot.findOne({ where: { 'recording_meta.id': robotId } });
@@ -124,12 +123,10 @@ router.post('/update', requireSignIn, async (req: Request, res: Response) => {
             return res.status(400).json({ ok: false, error: 'Webhook configuration, webhook ID, and robot ID are required' });
         }
 
-        // Validate URL format if provided
         if (webhook.url) {
-            try {
-                new URL(webhook.url);
-            } catch (error) {
-                return res.status(400).json({ ok: false, error: 'Invalid webhook URL format' });
+            const urlCheck = await validateWebhookUrl(webhook.url);
+            if (!urlCheck.safe) {
+                return res.status(400).json({ ok: false, error: urlCheck.reason || 'Invalid webhook URL' });
             }
         }
 
@@ -263,6 +260,15 @@ router.post('/test', requireSignIn, async (req: Request, res: Response) => {
             return res.status(400).json({ ok: false, error: 'Webhook configuration and robot ID are required' });
         }
 
+        if (!webhook.url) {
+            return res.status(400).json({ ok: false, error: 'Webhook URL is required' });
+        }
+
+        const urlCheck = await validateWebhookUrl(webhook.url);
+        if (!urlCheck.safe) {
+            return res.status(400).json({ ok: false, error: urlCheck.reason || 'Invalid webhook URL' });
+        }
+
         const robot = await Robot.findOne({ where: { 'recording_meta.id': robotId } });
 
         if (!robot) {
@@ -356,8 +362,9 @@ router.post('/test', requireSignIn, async (req: Request, res: Response) => {
         await updateWebhookLastCalled(robotId, webhook.id);
 
         const response = await axios.post(webhook.url, testPayload, {
+            ...WEBHOOK_REQUEST_OPTIONS,
             timeout: (webhook.timeout || 30) * 1000,
-            validateStatus: (status) => status < 500 
+            validateStatus: (status) => status < 500
         });
 
         const success = response.status >= 200 && response.status < 300;
@@ -440,9 +447,16 @@ const sendWebhookWithRetry = async (robotId: string, webhook: WebhookConfig, pay
     const timeout = webhook.timeout || 30;
 
     try {
+        const urlCheck = await validateWebhookUrl(webhook.url);
+        if (!urlCheck.safe) {
+            console.error(`Webhook ${webhook.url} refused: ${urlCheck.reason}`);
+            return;
+        }
+
         await updateWebhookLastCalled(robotId, webhook.id);
 
         const response = await axios.post(webhook.url, payload, {
+            ...WEBHOOK_REQUEST_OPTIONS,
             timeout: timeout * 1000,
             validateStatus: (status) => status >= 200 && status < 300
         });

--- a/server/src/routes/webhook.ts
+++ b/server/src/routes/webhook.ts
@@ -123,7 +123,7 @@ router.post('/update', requireSignIn, async (req: Request, res: Response) => {
             return res.status(400).json({ ok: false, error: 'Webhook configuration, webhook ID, and robot ID are required' });
         }
 
-        if (webhook.url) {
+        if ('url' in webhook) {
             const urlCheck = await validateWebhookUrl(webhook.url);
             if (!urlCheck.safe) {
                 return res.status(400).json({ ok: false, error: urlCheck.reason || 'Invalid webhook URL' });

--- a/server/src/utils/webhook-url.ts
+++ b/server/src/utils/webhook-url.ts
@@ -1,0 +1,105 @@
+import * as dns from 'dns/promises';
+import * as net from 'net';
+
+export interface WebhookUrlCheck {
+  safe: boolean;
+  reason?: string;
+}
+
+/**
+ * Blocks addresses that a webhook has no legitimate reason to reach:
+ * loopback, private ranges, link-local (including cloud metadata at
+ * 169.254.169.254), carrier-grade NAT, and the IPv6 equivalents.
+ */
+function isPrivateIp(ip: string): boolean {
+  if (net.isIPv4(ip)) {
+    const [a, b] = ip.split('.').map(Number);
+    return (
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168)
+    );
+  }
+
+  if (net.isIPv6(ip)) {
+    const lower = ip.toLowerCase();
+    if (lower.startsWith('::ffff:')) {
+      const mapped = lower.slice('::ffff:'.length);
+      if (net.isIPv4(mapped)) return isPrivateIp(mapped);
+      return true;
+    }
+    return (
+      lower === '::' ||
+      lower === '::1' ||
+      lower.startsWith('fc') ||
+      lower.startsWith('fd') ||
+      lower.startsWith('fe80')
+    );
+  }
+
+  return false;
+}
+
+/**
+ * Validates that a webhook destination is safe to call. Resolves the hostname
+ * so that a public name pointing at an internal address is rejected too.
+ */
+export async function validateWebhookUrl(urlString: string): Promise<WebhookUrlCheck> {
+  const allowPrivateTargets = process.env.ALLOW_PRIVATE_WEBHOOK_URLS === 'true';
+  let parsed: URL;
+
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    return { safe: false, reason: 'Invalid webhook URL format' };
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { safe: false, reason: 'Only http and https webhook URLs are allowed' };
+  }
+
+  if (allowPrivateTargets) {
+    return { safe: true };
+  }
+
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+
+  let addresses: string[];
+  try {
+    if (net.isIP(hostname)) {
+      addresses = [hostname];
+    } else {
+      const results = await dns.lookup(hostname, { all: true });
+      addresses = results.map((result) => result.address);
+    }
+  } catch {
+    return { safe: false, reason: 'Could not resolve webhook hostname' };
+  }
+
+  if (addresses.length === 0) {
+    return { safe: false, reason: 'Could not resolve webhook hostname' };
+  }
+
+  for (const address of addresses) {
+    if (isPrivateIp(address)) {
+      return {
+        safe: false,
+        reason: `Webhook URL resolves to a private or reserved address (${address})`,
+      };
+    }
+  }
+
+  return { safe: true };
+}
+
+/**
+ * Shared axios options for every outbound webhook call. Redirects are refused
+ * so that a validated public URL cannot forward the request to an internal one.
+ */
+export const WEBHOOK_REQUEST_OPTIONS = {
+  maxRedirects: 0,
+};

--- a/server/src/utils/webhook-url.ts
+++ b/server/src/utils/webhook-url.ts
@@ -1,10 +1,15 @@
-import * as dns from 'dns/promises';
+import * as dns from 'dns';
+import * as dnsPromises from 'dns/promises';
+import * as http from 'http';
+import * as https from 'https';
 import * as net from 'net';
 
 export interface WebhookUrlCheck {
   safe: boolean;
   reason?: string;
 }
+
+const allowPrivateTargets = (): boolean => process.env.ALLOW_PRIVATE_WEBHOOK_URLS === 'true';
 
 /**
  * Blocks addresses that a webhook has no legitimate reason to reach:
@@ -27,18 +32,18 @@ function isPrivateIp(ip: string): boolean {
 
   if (net.isIPv6(ip)) {
     const lower = ip.toLowerCase();
+
     if (lower.startsWith('::ffff:')) {
       const mapped = lower.slice('::ffff:'.length);
       if (net.isIPv4(mapped)) return isPrivateIp(mapped);
       return true;
     }
-    return (
-      lower === '::' ||
-      lower === '::1' ||
-      lower.startsWith('fc') ||
-      lower.startsWith('fd') ||
-      lower.startsWith('fe80')
-    );
+
+    const firstHextet = Number.parseInt(lower.split(':', 1)[0] || '0', 16);
+    const isLinkLocal = (firstHextet & 0xffc0) === 0xfe80;
+    const isUniqueLocal = (firstHextet & 0xfe00) === 0xfc00;
+
+    return lower === '::' || lower === '::1' || isLinkLocal || isUniqueLocal;
   }
 
   return false;
@@ -46,10 +51,15 @@ function isPrivateIp(ip: string): boolean {
 
 /**
  * Validates that a webhook destination is safe to call. Resolves the hostname
- * so that a public name pointing at an internal address is rejected too.
+ * so that a public name pointing at an internal address is rejected too. This
+ * is a fast rejection for the API surface; the authoritative check happens at
+ * connection time in safeLookup.
  */
-export async function validateWebhookUrl(urlString: string): Promise<WebhookUrlCheck> {
-  const allowPrivateTargets = process.env.ALLOW_PRIVATE_WEBHOOK_URLS === 'true';
+export async function validateWebhookUrl(urlString: unknown): Promise<WebhookUrlCheck> {
+  if (typeof urlString !== 'string' || !urlString.trim()) {
+    return { safe: false, reason: 'Webhook URL is required' };
+  }
+
   let parsed: URL;
 
   try {
@@ -62,7 +72,7 @@ export async function validateWebhookUrl(urlString: string): Promise<WebhookUrlC
     return { safe: false, reason: 'Only http and https webhook URLs are allowed' };
   }
 
-  if (allowPrivateTargets) {
+  if (allowPrivateTargets()) {
     return { safe: true };
   }
 
@@ -73,7 +83,7 @@ export async function validateWebhookUrl(urlString: string): Promise<WebhookUrlC
     if (net.isIP(hostname)) {
       addresses = [hostname];
     } else {
-      const results = await dns.lookup(hostname, { all: true });
+      const results = await dnsPromises.lookup(hostname, { all: true });
       addresses = results.map((result) => result.address);
     }
   } catch {
@@ -97,9 +107,60 @@ export async function validateWebhookUrl(urlString: string): Promise<WebhookUrlC
 }
 
 /**
+ * Resolution used by the outbound webhook agents. Validating here rather than
+ * only at request time binds the check to the address the socket actually
+ * connects to, which closes the DNS rebinding window left open by validating
+ * once up front. The hostname is still passed through for TLS and SNI.
+ */
+const safeLookup = (
+  hostname: string,
+  options: dns.LookupAllOptions,
+  callback: (err: NodeJS.ErrnoException | null, addresses: any, family?: number) => void
+): void => {
+  dns.lookup(hostname, { ...options, all: true }, (err, addresses) => {
+    if (err) {
+      callback(err, '', 0);
+      return;
+    }
+
+    const resolved = Array.isArray(addresses) ? addresses : [addresses];
+
+    if (!allowPrivateTargets()) {
+      const blocked = resolved.find((entry) => isPrivateIp(entry.address));
+      if (blocked) {
+        callback(
+          new Error(`Refusing to connect to private or reserved address (${blocked.address})`),
+          '',
+          0
+        );
+        return;
+      }
+    }
+
+    if (resolved.length === 0) {
+      callback(new Error(`Could not resolve ${hostname}`), '', 0);
+      return;
+    }
+
+    if (options && options.all) {
+      callback(null, resolved);
+      return;
+    }
+
+    callback(null, resolved[0].address, resolved[0].family);
+  });
+};
+
+const webhookHttpAgent = new http.Agent({ lookup: safeLookup } as http.AgentOptions);
+const webhookHttpsAgent = new https.Agent({ lookup: safeLookup } as https.AgentOptions);
+
+/**
  * Shared axios options for every outbound webhook call. Redirects are refused
- * so that a validated public URL cannot forward the request to an internal one.
+ * so that a validated public URL cannot forward the request to an internal one,
+ * and the agents re-validate the address at connection time.
  */
 export const WEBHOOK_REQUEST_OPTIONS = {
   maxRedirects: 0,
+  httpAgent: webhookHttpAgent,
+  httpsAgent: webhookHttpsAgent,
 };


### PR DESCRIPTION
What this PR does?

Adds validation for all webhook URL endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook URL validation when adding, updating, testing, and retrying deliveries.
  * Blocked unsafe destinations, including private, loopback, link-local, reserved, and unresolved network addresses.
  * Added protection against DNS rebinding during webhook connections.
  * Prevented webhook requests from following redirects.
  * Test requests now require a valid HTTP or HTTPS URL before sending.
  * Ensured retry metadata is updated only after URL validation succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->