### PR TITLE
fix(maxun-core): prevent orphaned crawl loops after timeout (#1183)

### DIFF
--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -3223,6 +3223,7 @@ export default class Interpreter extends EventEmitter {
    */
   public async run(page: Page, params?: ParamType): Promise<void> {
     this.log('Starting the workflow.', Level.LOG);
+    this.isAborted = false;
     const context = page.context();
 
     page.setDefaultNavigationTimeout(100000);
@@ -3294,8 +3295,9 @@ export default class Interpreter extends EventEmitter {
       this.namedResults = {};
       this.serializableDataByType = { scrapeList: {}, scrapeSchema: {}, crawl: {}, search: {} };
 
-      // Reset state
-      this.isAborted = false;
+      // Reset state (isAborted is intentionally NOT reset here — it must
+      // remain true so that in-flight crawl loops see the abort flag and exit.
+      // It is reset at the start of run() instead.)
       this.initializedWorkflow = null;
 
       this.log('Interpreter cleanup completed', Level.DEBUG);

--- a/maxun-core/src/interpret.ts
+++ b/maxun-core/src/interpret.ts
@@ -3222,8 +3222,11 @@ export default class Interpreter extends EventEmitter {
    *  for the `{$param: nameofparam}` fields.
    */
   public async run(page: Page, params?: ParamType): Promise<void> {
-    this.log('Starting the workflow.', Level.LOG);
+    if (this.stopper) {
+      throw new Error('This Interpreter is already running a workflow. To run another workflow, please, spawn another Interpreter.');
+    }
     this.isAborted = false;
+    this.log('Starting the workflow.', Level.LOG);
     const context = page.context();
 
     page.setDefaultNavigationTimeout(100000);
@@ -3238,9 +3241,6 @@ export default class Interpreter extends EventEmitter {
         if (contextOptions.proxy.username) {
             this.log(`Proxy authenticated...`);
         }
-    }
-    if (this.stopper) {
-      throw new Error('This Interpreter is already running a workflow. To run another workflow, please, spawn another Interpreter.');
     }
     /**
      * `this.workflow` with the parameters initialized.


### PR DESCRIPTION
## Fixes #1183

### Problem
When a workflow run times out (600s `INTERPRETATION_TIMEOUT`), the `Promise.race` in the task-runner / scheduler / API record handler rejects, but the `maxun-core` `Interpreter` crawl loop continues running in the background against a closed Playwright browser context. This causes high CPU/RAM usage and floods server logs with error messages.

### Root Cause
`cleanup()` in `maxun-core/src/interpret.ts` was setting `this.isAborted = false` during teardown, which prematurely un-aborted active async crawl loops while they were mid-execution.

### Proposed Fix
- Removed `this.isAborted = false` from `cleanup()` so that in-flight crawl loops continue seeing `isAborted = true` during teardown and break out clean on their next iteration check.
- Added `this.isAborted = false` at the start of `run()`, ensuring fresh workflow runs start with a clean state.

### Verification
- Audited all `isAborted` references in `maxun-core/src/interpret.ts` to ensure no other unwanted flag resets occur.
- Verified that `stopInterpretation()` and manual abortion flows remain intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow cancellation handling.
  * In-progress operations now reliably observe cancellation requests, while subsequent workflow runs start cleanly.
  * Prevented concurrent workflow executions from starting while another run is already in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->