### PR TITLE
fix: llm api key url validation

### DIFF
--- a/server/src/sdk/browserAgent.ts
+++ b/server/src/sdk/browserAgent.ts
@@ -9,6 +9,8 @@ import { resolveLlmModel } from '../utils/llm-models';
 import Anthropic from '@anthropic-ai/sdk';
 import axios from 'axios';
 import logger from '../logger';
+import { resolveOpenAiApiKey } from '../utils/llm-endpoint';
+import { LLM_AGENTS, guardLlmBaseUrl } from '../utils/llm-endpoint';
 
 export interface LLMConfig {
   provider: 'anthropic' | 'openai' | 'ollama';
@@ -424,7 +426,7 @@ async function callAnthropic(config: LLMConfig, messages: any[]): Promise<LLMCal
 }
 
 async function callOpenAI(config: LLMConfig, messages: any[]): Promise<LLMCallResult> {
-  const baseUrl = config.baseUrl || 'https://api.openai.com/v1';
+  const baseUrl = guardLlmBaseUrl(config.baseUrl || 'https://api.openai.com/v1');
   const model = resolveLlmModel(config.model, config.provider);
 
   const controller = new AbortController();
@@ -436,10 +438,11 @@ async function callOpenAI(config: LLMConfig, messages: any[]): Promise<LLMCallRe
       { model, messages, max_tokens: MAX_COMPLETION_TOKENS, temperature: 0.1 },
       {
         headers: {
-          'Authorization': `Bearer ${config.apiKey || process.env.OPENAI_API_KEY}`,
+          'Authorization': `Bearer ${resolveOpenAiApiKey(config.apiKey, config.baseUrl)}`,
           'Content-Type': 'application/json',
         },
         signal: controller.signal as any,
+        ...LLM_AGENTS,
       }
     );
 
@@ -456,7 +459,7 @@ async function callOpenAI(config: LLMConfig, messages: any[]): Promise<LLMCallRe
 }
 
 async function callOllama(config: LLMConfig, messages: any[]): Promise<LLMCallResult> {
-  const baseUrl = config.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+  const baseUrl = guardLlmBaseUrl(config.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434');
   const model = resolveLlmModel(config.model, config.provider);
 
   const ollamaMessages = messages.map((m: any) => {
@@ -483,7 +486,7 @@ async function callOllama(config: LLMConfig, messages: any[]): Promise<LLMCallRe
     const response = await axios.post(
       `${baseUrl}/api/chat`,
       { model, messages: ollamaMessages, stream: false, format: 'json', options: { temperature: 0.1, num_predict: MAX_COMPLETION_TOKENS } },
-      { signal: controller.signal as any }
+      { signal: controller.signal as any, ...LLM_AGENTS }
     );
 
     const content = response.data.message?.content || '';
@@ -545,7 +548,7 @@ async function callLLMRawText(messages: any[], config: LLMConfig): Promise<strin
     }
 
     if (provider === 'openai') {
-      const baseUrl = config.baseUrl || 'https://api.openai.com/v1';
+      const baseUrl = guardLlmBaseUrl(config.baseUrl || 'https://api.openai.com/v1');
       const model = resolveLlmModel(config.model, config.provider);
       const textMessages = messages.map((m: any) => ({
         role: m.role,
@@ -560,16 +563,17 @@ async function callLLMRawText(messages: any[], config: LLMConfig): Promise<strin
         { model, messages: textMessages, max_tokens: MAX_COMPLETION_TOKENS, temperature: 0.1 },
         {
           headers: {
-            'Authorization': `Bearer ${config.apiKey || process.env.OPENAI_API_KEY}`,
+            'Authorization': `Bearer ${resolveOpenAiApiKey(config.apiKey, config.baseUrl)}`,
             'Content-Type': 'application/json',
           },
+          ...LLM_AGENTS,
         }
       );
       return response.data.choices?.[0]?.message?.content || null;
     }
 
     if (provider === 'ollama') {
-      const baseUrl = config.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+      const baseUrl = guardLlmBaseUrl(config.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434');
       const model = resolveLlmModel(config.model, config.provider);
       const textMessages = messages.map((m: any) => ({
         role: m.role,
@@ -581,7 +585,7 @@ async function callLLMRawText(messages: any[], config: LLMConfig): Promise<strin
         const response = await axios.post(
           `${baseUrl}/api/chat`,
           { model, messages: textMessages, stream: false },
-          { signal: controller.signal as any }
+          { signal: controller.signal as any, ...LLM_AGENTS }
         );
         return response.data.message?.content || null;
       } finally {

--- a/server/src/sdk/workflowEnricher.ts
+++ b/server/src/sdk/workflowEnricher.ts
@@ -10,6 +10,8 @@ import logger from '../logger';
 import { v4 as uuid } from 'uuid';
 import { encrypt } from '../utils/auth';
 import Anthropic from '@anthropic-ai/sdk';
+import { resolveOpenAiApiKey } from '../utils/llm-endpoint';
+import { LLM_AGENTS, guardLlmBaseUrl } from '../utils/llm-endpoint';
 
 interface SimplifiedAction {
   action: string | typeof Symbol.asyncDispose;
@@ -408,7 +410,7 @@ export class WorkflowEnricher {
       let llmResponse: string;
 
       if (provider === 'ollama') {
-        const ollamaBaseUrl = llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+        const ollamaBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434');
         const ollamaModel = resolveLlmModel(llmConfig?.model, 'ollama');
 
         const response = await axios.post(`${ollamaBaseUrl}/api/chat`, {
@@ -420,7 +422,7 @@ export class WorkflowEnricher {
           stream: false,
           format: 'json',
           options: { temperature: 0.1 }
-        });
+        }, LLM_AGENTS);
 
         llmResponse = response.data.message.content;
 
@@ -447,7 +449,7 @@ export class WorkflowEnricher {
         llmResponse = textContent?.type === 'text' ? textContent.text : '';
 
       } else if (provider === 'openai') {
-        const openaiBaseUrl = llmConfig?.baseUrl || 'https://api.openai.com/v1';
+        const openaiBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || 'https://api.openai.com/v1');
         const openaiModel = resolveLlmModel(llmConfig?.model, 'openai');
 
         const response = await axios.post(`${openaiBaseUrl}/chat/completions`, {
@@ -463,9 +465,10 @@ export class WorkflowEnricher {
           temperature: 0.1
         }, {
           headers: {
-            'Authorization': `Bearer ${llmConfig?.apiKey || process.env.OPENAI_API_KEY}`,
+            'Authorization': `Bearer ${resolveOpenAiApiKey(llmConfig?.apiKey, llmConfig?.baseUrl)}`,
             'Content-Type': 'application/json'
-          }
+          },
+          ...LLM_AGENTS,
         });
 
         llmResponse = response.data.choices[0].message.content;
@@ -949,7 +952,7 @@ Return a JSON object with this exact structure:
       let llmResponse: string;
 
       if (provider === 'ollama') {
-        const ollamaBaseUrl = llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+        const ollamaBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434');
         const ollamaModel = resolveLlmModel(llmConfig?.model, 'ollama');
 
         logger.info(`Using Ollama at ${ollamaBaseUrl} with model ${ollamaModel}`);
@@ -990,7 +993,7 @@ Return a JSON object with this exact structure:
               temperature: 0.1,
               top_p: 0.9
             }
-          });
+          }, LLM_AGENTS);
 
           llmResponse = response.data.message.content;
         } catch (ollamaError: any) {
@@ -1023,7 +1026,7 @@ Return a JSON object with this exact structure:
         llmResponse = textContent?.type === 'text' ? textContent.text : '';
 
       } else if (provider === 'openai') {
-        const openaiBaseUrl = llmConfig?.baseUrl || 'https://api.openai.com/v1';
+        const openaiBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || 'https://api.openai.com/v1');
         const openaiModel = resolveLlmModel(llmConfig?.model, 'openai');
 
         const response = await axios.post(`${openaiBaseUrl}/chat/completions`, {
@@ -1043,9 +1046,10 @@ Return a JSON object with this exact structure:
           response_format: { type: 'json_object' }
         }, {
           headers: {
-            'Authorization': `Bearer ${llmConfig?.apiKey || process.env.OPENAI_API_KEY}`,
+            'Authorization': `Bearer ${resolveOpenAiApiKey(llmConfig?.apiKey, llmConfig?.baseUrl)}`,
             'Content-Type': 'application/json'
-          }
+          },
+          ...LLM_AGENTS,
         });
 
         llmResponse = response.data.choices[0].message.content;
@@ -1167,7 +1171,7 @@ Rules:
       let llmResponse: string;
 
       if (provider === 'ollama') {
-        const ollamaBaseUrl = llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+        const ollamaBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434');
         const ollamaModel = resolveLlmModel(llmConfig?.model, 'ollama');
 
         const jsonSchema = {
@@ -1210,7 +1214,7 @@ Rules:
             temperature: 0.1,
             top_p: 0.9
           }
-        });
+        }, LLM_AGENTS);
 
         llmResponse = response.data.message.content;
 
@@ -1235,7 +1239,7 @@ Rules:
         llmResponse = textContent?.type === 'text' ? textContent.text : '';
 
       } else if (provider === 'openai') {
-        const openaiBaseUrl = llmConfig?.baseUrl || 'https://api.openai.com/v1';
+        const openaiBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || 'https://api.openai.com/v1');
         const openaiModel = resolveLlmModel(llmConfig?.model, 'openai');
 
         const response = await axios.post(`${openaiBaseUrl}/chat/completions`, {
@@ -1255,9 +1259,10 @@ Rules:
           response_format: { type: 'json_object' }
         }, {
           headers: {
-            'Authorization': `Bearer ${llmConfig?.apiKey || process.env.OPENAI_API_KEY}`,
+            'Authorization': `Bearer ${resolveOpenAiApiKey(llmConfig?.apiKey, llmConfig?.baseUrl)}`,
             'Content-Type': 'application/json'
-          }
+          },
+          ...LLM_AGENTS,
         });
 
         llmResponse = response.data.choices[0].message.content;
@@ -1458,7 +1463,7 @@ Return ONLY the list name, nothing else:`;
       let llmResponse: string;
 
       if (provider === 'ollama') {
-        const ollamaBaseUrl = llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+        const ollamaBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434');
         const ollamaModel = resolveLlmModel(llmConfig?.model, 'ollama');
 
         try {
@@ -1480,7 +1485,7 @@ Return ONLY the list name, nothing else:`;
               top_p: 0.9,
               num_predict: 20
             }
-          });
+          }, LLM_AGENTS);
 
           llmResponse = response.data.message.content;
         } catch (ollamaError: any) {
@@ -1509,7 +1514,7 @@ Return ONLY the list name, nothing else:`;
         llmResponse = textContent?.type === 'text' ? textContent.text : '';
 
       } else if (provider === 'openai') {
-        const openaiBaseUrl = llmConfig?.baseUrl || 'https://api.openai.com/v1';
+        const openaiBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || 'https://api.openai.com/v1');
         const openaiModel = resolveLlmModel(llmConfig?.model, 'openai');
 
         const response = await axios.post(`${openaiBaseUrl}/chat/completions`, {
@@ -1528,9 +1533,10 @@ Return ONLY the list name, nothing else:`;
           temperature: 0.1
         }, {
           headers: {
-            'Authorization': `Bearer ${llmConfig?.apiKey || process.env.OPENAI_API_KEY}`,
+            'Authorization': `Bearer ${resolveOpenAiApiKey(llmConfig?.apiKey, llmConfig?.baseUrl)}`,
             'Content-Type': 'application/json'
-          }
+          },
+          ...LLM_AGENTS,
         });
 
         llmResponse = response.data.choices[0].message.content;
@@ -1645,7 +1651,7 @@ Does this extraction match what the user asked for?`;
       let llmResponse: string;
 
       if (provider === 'ollama') {
-        const ollamaBaseUrl = llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+        const ollamaBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434');
         const ollamaModel = resolveLlmModel(llmConfig?.model, 'ollama');
 
         const jsonSchema = {
@@ -1667,7 +1673,7 @@ Does this extraction match what the user asked for?`;
           stream: false,
           format: jsonSchema,
           options: { temperature: 0.1 }
-        });
+        }, LLM_AGENTS);
 
         llmResponse = response.data.message.content;
 
@@ -1689,7 +1695,7 @@ Does this extraction match what the user asked for?`;
         llmResponse = textContent?.type === 'text' ? textContent.text : '';
 
       } else if (provider === 'openai') {
-        const openaiBaseUrl = llmConfig?.baseUrl || 'https://api.openai.com/v1';
+        const openaiBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || 'https://api.openai.com/v1');
         const openaiModel = resolveLlmModel(llmConfig?.model, 'openai');
 
         const response = await axios.post(`${openaiBaseUrl}/chat/completions`, {
@@ -1703,9 +1709,10 @@ Does this extraction match what the user asked for?`;
           response_format: { type: 'json_object' }
         }, {
           headers: {
-            'Authorization': `Bearer ${llmConfig?.apiKey || process.env.OPENAI_API_KEY}`,
+            'Authorization': `Bearer ${resolveOpenAiApiKey(llmConfig?.apiKey, llmConfig?.baseUrl)}`,
             'Content-Type': 'application/json'
-          }
+          },
+          ...LLM_AGENTS,
         });
 
         llmResponse = response.data.choices[0].message.content;
@@ -2042,7 +2049,7 @@ Extract the search query, extraction goal, and limit. Return JSON only.`;
       let llmResponse: string;
 
       if (provider === 'ollama') {
-        const ollamaBaseUrl = llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+        const ollamaBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434');
         const ollamaModel = resolveLlmModel(llmConfig?.model, 'ollama');
 
         const jsonSchema = {
@@ -2064,7 +2071,7 @@ Extract the search query, extraction goal, and limit. Return JSON only.`;
           stream: false,
           format: jsonSchema,
           options: { temperature: 0.1 }
-        });
+        }, LLM_AGENTS);
 
         llmResponse = response.data.message.content;
 
@@ -2086,7 +2093,7 @@ Extract the search query, extraction goal, and limit. Return JSON only.`;
         llmResponse = textContent?.type === 'text' ? textContent.text : '';
 
       } else if (provider === 'openai') {
-        const openaiBaseUrl = llmConfig?.baseUrl || 'https://api.openai.com/v1';
+        const openaiBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || 'https://api.openai.com/v1');
         const openaiModel = resolveLlmModel(llmConfig?.model, 'openai');
 
         const response = await axios.post(`${openaiBaseUrl}/chat/completions`, {
@@ -2100,9 +2107,10 @@ Extract the search query, extraction goal, and limit. Return JSON only.`;
           response_format: { type: 'json_object' }
         }, {
           headers: {
-            'Authorization': `Bearer ${llmConfig?.apiKey || process.env.OPENAI_API_KEY}`,
+            'Authorization': `Bearer ${resolveOpenAiApiKey(llmConfig?.apiKey, llmConfig?.baseUrl)}`,
             'Content-Type': 'application/json'
-          }
+          },
+          ...LLM_AGENTS,
         });
 
         llmResponse = response.data.choices[0].message.content;
@@ -2313,7 +2321,7 @@ Select the BEST result index (0-${searchResults.length - 1}). Return JSON only.`
       let llmResponse: string;
 
       if (provider === 'ollama') {
-        const ollamaBaseUrl = llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+        const ollamaBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434');
         const ollamaModel = resolveLlmModel(llmConfig?.model, 'ollama');
 
         const jsonSchema = {
@@ -2335,7 +2343,7 @@ Select the BEST result index (0-${searchResults.length - 1}). Return JSON only.`
           stream: false,
           format: jsonSchema,
           options: { temperature: 0.1 }
-        });
+        }, LLM_AGENTS);
 
         llmResponse = response.data.message.content;
 
@@ -2357,7 +2365,7 @@ Select the BEST result index (0-${searchResults.length - 1}). Return JSON only.`
         llmResponse = textContent?.type === 'text' ? textContent.text : '';
 
       } else if (provider === 'openai') {
-        const openaiBaseUrl = llmConfig?.baseUrl || 'https://api.openai.com/v1';
+        const openaiBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || 'https://api.openai.com/v1');
         const openaiModel = resolveLlmModel(llmConfig?.model, 'openai');
 
         const response = await axios.post(`${openaiBaseUrl}/chat/completions`, {
@@ -2371,9 +2379,10 @@ Select the BEST result index (0-${searchResults.length - 1}). Return JSON only.`
           response_format: { type: 'json_object' }
         }, {
           headers: {
-            'Authorization': `Bearer ${llmConfig?.apiKey || process.env.OPENAI_API_KEY}`,
+            'Authorization': `Bearer ${resolveOpenAiApiKey(llmConfig?.apiKey, llmConfig?.baseUrl)}`,
             'Content-Type': 'application/json'
-          }
+          },
+          ...LLM_AGENTS,
         });
 
         llmResponse = response.data.choices[0].message.content;
@@ -2547,7 +2556,7 @@ multiSite = false when:
       let llmResponse: string;
 
       if (provider === 'ollama') {
-        const ollamaBaseUrl = llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+        const ollamaBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434');
         const ollamaModel = resolveLlmModel(llmConfig?.model, 'ollama');
 
         const jsonSchema = {
@@ -2565,7 +2574,7 @@ multiSite = false when:
           stream: false,
           format: jsonSchema,
           options: { temperature: 0 }
-        });
+        }, LLM_AGENTS);
 
         llmResponse = response.data.message.content;
 
@@ -2587,7 +2596,7 @@ multiSite = false when:
         llmResponse = textContent?.type === 'text' ? textContent.text : '';
 
       } else if (provider === 'openai') {
-        const openaiBaseUrl = llmConfig?.baseUrl || 'https://api.openai.com/v1';
+        const openaiBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || 'https://api.openai.com/v1');
         const openaiModel = resolveLlmModel(llmConfig?.model, 'openai');
 
         const response = await axios.post(`${openaiBaseUrl}/chat/completions`, {
@@ -2601,9 +2610,10 @@ multiSite = false when:
           response_format: { type: 'json_object' }
         }, {
           headers: {
-            'Authorization': `Bearer ${llmConfig?.apiKey || process.env.OPENAI_API_KEY}`,
+            'Authorization': `Bearer ${resolveOpenAiApiKey(llmConfig?.apiKey, llmConfig?.baseUrl)}`,
             'Content-Type': 'application/json'
-          }
+          },
+          ...LLM_AGENTS,
         });
 
         llmResponse = response.data.choices[0].message.content;
@@ -2686,7 +2696,7 @@ Return ONLY valid JSON: {"selectedIndices": [0, 2, 5], "reasoning": "one-line ex
       let llmResponse: string;
 
       if (provider === 'ollama') {
-        const ollamaBaseUrl = llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+        const ollamaBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434');
         const ollamaModel = resolveLlmModel(llmConfig?.model, 'ollama');
 
         const jsonSchema = {
@@ -2707,7 +2717,7 @@ Return ONLY valid JSON: {"selectedIndices": [0, 2, 5], "reasoning": "one-line ex
           stream: false,
           format: jsonSchema,
           options: { temperature: 0.1 }
-        });
+        }, LLM_AGENTS);
 
         llmResponse = response.data.message.content;
 
@@ -2729,7 +2739,7 @@ Return ONLY valid JSON: {"selectedIndices": [0, 2, 5], "reasoning": "one-line ex
         llmResponse = textContent?.type === 'text' ? textContent.text : '';
 
       } else if (provider === 'openai') {
-        const openaiBaseUrl = llmConfig?.baseUrl || 'https://api.openai.com/v1';
+        const openaiBaseUrl = guardLlmBaseUrl(llmConfig?.baseUrl || 'https://api.openai.com/v1');
         const openaiModel = resolveLlmModel(llmConfig?.model, 'openai');
 
         const response = await axios.post(`${openaiBaseUrl}/chat/completions`, {
@@ -2743,9 +2753,10 @@ Return ONLY valid JSON: {"selectedIndices": [0, 2, 5], "reasoning": "one-line ex
           response_format: { type: 'json_object' }
         }, {
           headers: {
-            'Authorization': `Bearer ${llmConfig?.apiKey || process.env.OPENAI_API_KEY}`,
+            'Authorization': `Bearer ${resolveOpenAiApiKey(llmConfig?.apiKey, llmConfig?.baseUrl)}`,
             'Content-Type': 'application/json'
-          }
+          },
+          ...LLM_AGENTS,
         });
 
         llmResponse = response.data.choices[0].message.content;

--- a/server/src/utils/llm-endpoint.ts
+++ b/server/src/utils/llm-endpoint.ts
@@ -110,6 +110,11 @@ export const LLM_AGENTS = {
 /**
  * Pre-flight check for the fetch-based callers, which cannot take an agent and
  * so have no connection-time check to fall back on.
+ *
+ * Callers pass the fully resolved base URL, not the caller-supplied one, so an
+ * environment fallback is checked too. A name that fails to resolve is refused
+ * rather than allowed through: letting it pass would hand the decision to
+ * whatever the request itself resolves later.
  */
 export async function assertLlmBaseUrlAllowed(baseUrl?: unknown): Promise<void> {
   const target = normalize(baseUrl);
@@ -130,7 +135,11 @@ export async function assertLlmBaseUrlAllowed(baseUrl?: unknown): Promise<void> 
       ? [hostname]
       : (await dnsPromises.lookup(hostname, { all: true })).map((r) => r.address);
   } catch {
-    return;
+    throw new Error(`Could not resolve LLM base URL host (${hostname})`);
+  }
+
+  if (addresses.length === 0) {
+    throw new Error(`Could not resolve LLM base URL host (${hostname})`);
   }
 
   const blocked = addresses.find(isLinkLocalIp);

--- a/server/src/utils/llm-endpoint.ts
+++ b/server/src/utils/llm-endpoint.ts
@@ -1,0 +1,161 @@
+import * as dns from 'dns';
+import * as dnsPromises from 'dns/promises';
+import * as http from 'http';
+import * as https from 'https';
+import * as net from 'net';
+
+const OPENAI_DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+
+const normalize = (value: unknown): string =>
+  typeof value === 'string' ? value.trim().replace(/\/+$/, '') : '';
+
+/**
+ * Resolves the OpenAI-compatible credential for an outbound LLM call.
+ *
+ * A key configured on the robot is always used. The server's own
+ * OPENAI_API_KEY is only released when the request is going to an endpoint the
+ * operator configured, so pointing a robot at some other base URL and leaving
+ * its key unset no longer hands the operator's credential to that endpoint.
+ */
+export function resolveOpenAiApiKey(configuredKey?: unknown, baseUrl?: unknown): string {
+  const supplied = normalize(configuredKey);
+  if (supplied) return supplied;
+
+  const target = normalize(baseUrl);
+  const operatorConfigured =
+    !target ||
+    target === normalize(OPENAI_DEFAULT_BASE_URL) ||
+    target === normalize(process.env.OPENAI_BASE_URL);
+
+  return operatorConfigured ? process.env.OPENAI_API_KEY || '' : '';
+}
+
+/**
+ * Link-local addresses, which is where cloud instance metadata lives
+ * (169.254.169.254 on AWS, GCP and Azure). No LLM runs on one of these, so
+ * refusing them costs nothing, while leaving loopback and LAN addresses
+ * reachable keeps a self-hosted Ollama, LM Studio or vLLM working.
+ */
+function isLinkLocalIp(ip: string): boolean {
+  if (net.isIPv4(ip)) {
+    const [a, b] = ip.split('.').map(Number);
+    return a === 169 && b === 254;
+  }
+
+  if (net.isIPv6(ip)) {
+    const lower = ip.toLowerCase();
+    if (lower.startsWith('::ffff:')) {
+      const mapped = lower.slice('::ffff:'.length);
+      return net.isIPv4(mapped) ? isLinkLocalIp(mapped) : false;
+    }
+    const firstHextet = Number.parseInt(lower.split(':', 1)[0] || '0', 16);
+    return (firstHextet & 0xffc0) === 0xfe80;
+  }
+
+  return false;
+}
+
+/**
+ * Resolution used by the outbound LLM agents. Checking here rather than only
+ * against the configured string binds the check to the address the socket
+ * actually connects to, so a hostname that resolves to metadata, or a redirect
+ * onto one, is refused as well.
+ */
+const llmLookup = (
+  hostname: string,
+  options: dns.LookupAllOptions,
+  callback: (err: NodeJS.ErrnoException | null, addresses: any, family?: number) => void
+): void => {
+  dns.lookup(hostname, { ...options, all: true }, (err, addresses) => {
+    if (err) {
+      callback(err, '', 0);
+      return;
+    }
+
+    const resolved = Array.isArray(addresses) ? addresses : [addresses];
+    const blocked = resolved.find((entry) => isLinkLocalIp(entry.address));
+
+    if (blocked) {
+      callback(
+        new Error(`Refusing to connect to link-local address (${blocked.address})`),
+        '',
+        0
+      );
+      return;
+    }
+
+    if (resolved.length === 0) {
+      callback(new Error(`Could not resolve ${hostname}`), '', 0);
+      return;
+    }
+
+    if (options && options.all) {
+      callback(null, resolved);
+      return;
+    }
+
+    callback(null, resolved[0].address, resolved[0].family);
+  });
+};
+
+/**
+ * Spread into every outbound LLM axios call. Only the agents are set, so
+ * timeouts, signals and redirect behaviour stay exactly as each caller had them.
+ */
+export const LLM_AGENTS = {
+  httpAgent: new http.Agent({ lookup: llmLookup } as http.AgentOptions),
+  httpsAgent: new https.Agent({ lookup: llmLookup } as https.AgentOptions),
+};
+
+/**
+ * Pre-flight check for the fetch-based callers, which cannot take an agent and
+ * so have no connection-time check to fall back on.
+ */
+export async function assertLlmBaseUrlAllowed(baseUrl?: unknown): Promise<void> {
+  const target = normalize(baseUrl);
+  if (!target) return;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(target);
+  } catch {
+    throw new Error('Invalid LLM base URL');
+  }
+
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+
+  let addresses: string[];
+  try {
+    addresses = net.isIP(hostname)
+      ? [hostname]
+      : (await dnsPromises.lookup(hostname, { all: true })).map((r) => r.address);
+  } catch {
+    return;
+  }
+
+  const blocked = addresses.find(isLinkLocalIp);
+  if (blocked) {
+    throw new Error(`Refusing to connect to link-local address (${blocked})`);
+  }
+}
+
+/**
+ * Synchronous guard applied where a base URL is resolved.
+ *
+ * The agent lookup above only runs when Node has a hostname to resolve; a URL
+ * written as a bare IP connects without ever consulting it, which is exactly
+ * how the metadata endpoint is reached. Checking the literal here closes that,
+ * and the two together cover both spellings.
+ */
+export function guardLlmBaseUrl(baseUrl: string): string {
+  try {
+    const hostname = new URL(baseUrl).hostname.replace(/^\[|\]$/g, '');
+    if (net.isIP(hostname) && isLinkLocalIp(hostname)) {
+      throw new Error(`Refusing to connect to link-local address (${hostname})`);
+    }
+  } catch (error: any) {
+    if (error && /link-local/.test(error.message)) throw error;
+  }
+
+  return baseUrl;
+}

--- a/server/src/utils/summarizer.ts
+++ b/server/src/utils/summarizer.ts
@@ -3,6 +3,8 @@ import { resolveLlmModel } from './llm-models';
 import axios from 'axios';
 import logger from '../logger';
 import { LLMConfig } from '../sdk/browserAgent';
+import { resolveOpenAiApiKey } from './llm-endpoint';
+import { LLM_AGENTS, guardLlmBaseUrl } from './llm-endpoint';
 
 const SYSTEM_PROMPT = `You are a web page summarizer. Your output is plain text only.
 
@@ -83,7 +85,7 @@ export async function summarizeMarkdown(markdown: string, llmConfig?: LLMConfig)
   }
 
   if (provider === 'openai') {
-    const baseUrl = config.baseUrl || 'https://api.openai.com/v1';
+    const baseUrl = guardLlmBaseUrl(config.baseUrl || 'https://api.openai.com/v1');
     const model = resolveLlmModel(config.model, config.provider);
     logger.info(`[Summarizer] Using OpenAI-compatible at ${baseUrl} (${model})`);
 
@@ -100,10 +102,11 @@ export async function summarizeMarkdown(markdown: string, llmConfig?: LLMConfig)
       },
       {
         headers: {
-          'Authorization': `Bearer ${config.apiKey || process.env.OPENAI_API_KEY}`,
+          'Authorization': `Bearer ${resolveOpenAiApiKey(config.apiKey, config.baseUrl)}`,
           'Content-Type': 'application/json',
         },
         timeout: 60000,
+        ...LLM_AGENTS,
       }
     );
     const content = response.data.choices?.[0]?.message?.content || '';
@@ -114,7 +117,7 @@ export async function summarizeMarkdown(markdown: string, llmConfig?: LLMConfig)
   }
 
   if (provider === 'ollama') {
-    const baseUrl = config.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+    const baseUrl = guardLlmBaseUrl(config.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434');
     const model = resolveLlmModel(config.model, config.provider);
     logger.info(`[Summarizer] Using Ollama at ${baseUrl} (${model})`);
 
@@ -133,7 +136,7 @@ export async function summarizeMarkdown(markdown: string, llmConfig?: LLMConfig)
           think: false,
           options: { temperature: 0.1, num_predict: MAX_TOKENS },
         },
-        { signal: controller.signal as any }
+        { signal: controller.signal as any, ...LLM_AGENTS }
       );
       const content = response.data.message?.content || '';
       if (!content || content.trim().length === 0) {

--- a/server/src/workflow-management/classes/DocumentInterpreter.ts
+++ b/server/src/workflow-management/classes/DocumentInterpreter.ts
@@ -848,9 +848,9 @@ class DocumentLLMClient {
     userPrompt: string,
     config: LLMConfig
   ): Promise<ProviderResult> {
-    await assertLlmBaseUrlAllowed(config.baseUrl);
-
     const baseUrl = config.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+    await assertLlmBaseUrlAllowed(baseUrl);
+
     const model = config.model || process.env.OLLAMA_DEFAULT_MODEL || 'llama3.2:latest';
 
     const controller = new AbortController();
@@ -860,6 +860,7 @@ class DocumentLLMClient {
       const response = await fetch(`${baseUrl}/api/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        redirect: 'error',
         signal: controller.signal,
         body: JSON.stringify({
           model,
@@ -894,12 +895,11 @@ class DocumentLLMClient {
     userPrompt: string,
     config: LLMConfig
   ): Promise<ProviderResult> {
-    await assertLlmBaseUrlAllowed(config.baseUrl);
-
     const apiKey = resolveOpenAiApiKey(config.apiKey, config.baseUrl);
     if (!apiKey && !config.baseUrl) throw new Error('OpenAI API key not configured');
 
     const baseUrl = config.baseUrl || 'https://api.openai.com/v1';
+    await assertLlmBaseUrlAllowed(baseUrl);
     const model = config.model || 'gpt-4o-mini';
 
     const requestOpenAI = async (useJsonMode: boolean): Promise<Response> => {
@@ -923,6 +923,7 @@ class DocumentLLMClient {
           Authorization: `Bearer ${apiKey}`,
           'Content-Type': 'application/json',
         },
+        redirect: 'error',
         body: JSON.stringify(body),
       });
     };

--- a/server/src/workflow-management/classes/DocumentInterpreter.ts
+++ b/server/src/workflow-management/classes/DocumentInterpreter.ts
@@ -9,6 +9,7 @@ import logger from '../../logger';
 import { OutputFormats } from '../../constants/output-formats';
 import { parseMarkdown } from '../../markdownify/markdown';
 import { DOCX_MIME_TYPE, PDF_MIME_TYPE, XLSX_MIME_TYPE, CSV_MIME_TYPE } from '../../utils/document/documentFile';
+import { assertLlmBaseUrlAllowed, resolveOpenAiApiKey } from '../../utils/llm-endpoint';
 
 import * as XLSX from 'xlsx';
 
@@ -847,6 +848,8 @@ class DocumentLLMClient {
     userPrompt: string,
     config: LLMConfig
   ): Promise<ProviderResult> {
+    await assertLlmBaseUrlAllowed(config.baseUrl);
+
     const baseUrl = config.baseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
     const model = config.model || process.env.OLLAMA_DEFAULT_MODEL || 'llama3.2:latest';
 
@@ -891,8 +894,10 @@ class DocumentLLMClient {
     userPrompt: string,
     config: LLMConfig
   ): Promise<ProviderResult> {
-    const apiKey = config.apiKey || process.env.OPENAI_API_KEY;
-    if (!apiKey) throw new Error('OpenAI API key not configured');
+    await assertLlmBaseUrlAllowed(config.baseUrl);
+
+    const apiKey = resolveOpenAiApiKey(config.apiKey, config.baseUrl);
+    if (!apiKey && !config.baseUrl) throw new Error('OpenAI API key not configured');
 
     const baseUrl = config.baseUrl || 'https://api.openai.com/v1';
     const model = config.model || 'gpt-4o-mini';


### PR DESCRIPTION
What this PR does?

Fixes:

1. Stopped the server's LLM API key being sent to caller-supplied base URLs
2. Applied the same rule across summarization, Smart Query, robot generation, and document extraction
3. Blocked LLM requests to link-local addresses, including cloud metadata
4. Added checks for both bare IPs and hostnames that resolve to them
5. Kept loopback, LAN, and Docker addresses working for self-hosted models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added validation for configured OpenAI and Ollama endpoints, including protection against restricted network destinations.
  * Improved credential handling so OpenAI keys are only sent to approved endpoints.
  * Applied consistent safeguards across browser agents, workflows, summarization, document interpretation, and other LLM-powered features.
* **Reliability**
  * Standardized outbound request configuration and authentication across supported LLM providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->