### PR TITLE
feat: add Harness recorder and browser control seams

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -34,4 +34,4 @@ COPY --from=builder /app/public ./public
 
 EXPOSE ${BACKEND_PORT:-8080}
 
-CMD ["sh", "-c", "npm run migrate && npm run server"]
+CMD ["sh", "-c", "npm run prepare-schema && npm run migrate && npm run server"]

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -34,5 +34,4 @@ COPY --from=builder /app/public ./public
 
 EXPOSE ${BACKEND_PORT:-8080}
 
-CMD ["npm", "run", "server"]
-# CMD ["sh", "-c", "npm run migrate && npm run server"]
+CMD ["sh", "-c", "npm run migrate && npm run server"]

--- a/package.backend.json
+++ b/package.backend.json
@@ -93,6 +93,7 @@
   "scripts": {
     "build": "tsc -p server/tsconfig.json",
     "build:server": "tsc -p server/tsconfig.json",
+    "prepare-schema": "node server/dist/server/src/db/prepareSchema.js",
     "server": "cross-env NODE_OPTIONS='--max-old-space-size=4096' node server/dist/server/src/server.js",
     "migrate": "sequelize-cli db:migrate",
     "migrate:undo": "sequelize-cli db:migrate:undo",

--- a/package.backend.json
+++ b/package.backend.json
@@ -37,6 +37,7 @@
     "lodash": "4.17.21",
     "maxun-core": "0.0.37",
     "minio": "8.0.5",
+    "mammoth": "1.12.1",
     "moment-timezone": "0.5.48",
     "multer": "2.1.1",
     "node-cron": "3.0.3",

--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -8,6 +8,7 @@ import { createRemoteBrowserForRun, destroyRemoteBrowser } from "../browser-mana
 import logger from "../logger";
 import { browserPool, io as serverIo } from "../server";
 import { io, Socket } from "socket.io-client";
+import jwt from "jsonwebtoken";
 import { BinaryOutputService } from "../storage/mino";
 import { AuthenticatedRequest } from "../routes/record"
 import {capture} from "../utils/analytics";
@@ -1411,10 +1412,15 @@ export async function handleRunRecording(id: string, userId: string, runSource: 
 
         const CONNECTION_TIMEOUT = 30000;
 
+        const internalToken = process.env.JWT_SECRET
+            ? jwt.sign({ id: userId }, process.env.JWT_SECRET)
+            : undefined;
+
         socket = io(`${process.env.BACKEND_URL ? process.env.BACKEND_URL : 'http://localhost:8080'}/${browserId}`, {
             transports: ['websocket'],
             rejectUnauthorized: false,
             timeout: CONNECTION_TIMEOUT,
+            ...(internalToken ? { auth: { token: internalToken } } : {}),
         });
 
         const readyHandler = () => readyForRunHandler(browserId, newRunId, userId, socket!);

--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -1390,6 +1390,30 @@ async function executeRun(id: string, userId: string) {
     }
 }
 
+async function executeSdkRunWhenReady(runId: string, browserId: string, userId: string): Promise<void> {
+    const timeoutMs = 60_000;
+    const startedAt = Date.now();
+
+    while (true) {
+        const browser = browserPool.getRemoteBrowser(browserId);
+        if (browser) break;
+
+        const status = browserPool.getBrowserStatus(browserId);
+        if (status === null) throw new Error(`Browser slot ${browserId} does not exist in pool`);
+        if (status === 'failed') throw new Error(`Browser ${browserId} initialization failed`);
+        if (Date.now() - startedAt >= timeoutMs) {
+            throw new Error(`Browser ${browserId} was not ready within ${timeoutMs / 1000}s`);
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 500));
+    }
+
+    const result = await executeRun(runId, userId);
+    if (!result?.success) {
+        throw new Error(result?.error || `Failed to execute run ${runId}`);
+    }
+}
+
 export async function handleRunRecording(id: string, userId: string, runSource: 'api' | 'sdk' | 'mcp' | 'cli' = 'api', requestedFormats?: OutputFormats[], promptInstructions?: string) {
     let socket: Socket | null = null;
 
@@ -1408,6 +1432,15 @@ export async function handleRunRecording(id: string, userId: string, runSource: 
 
         if (!browserId) {
             throw new Error('browserId is undefined for non-document robot');
+        }
+
+        // SDK execution is server-to-server. Execute directly after the local
+        // browser pool reports readiness instead of racing a Socket.IO
+        // namespace that may not exist yet. UI/API runs retain the interactive
+        // socket path below.
+        if (runSource === 'sdk') {
+            await executeSdkRunWhenReady(newRunId, browserId, userId);
+            return newRunId;
         }
 
         const CONNECTION_TIMEOUT = 30000;

--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -1412,9 +1412,13 @@ export async function handleRunRecording(id: string, userId: string, runSource: 
 
         const CONNECTION_TIMEOUT = 30000;
 
-        const internalToken = process.env.JWT_SECRET
-            ? jwt.sign({ id: userId }, process.env.JWT_SECRET)
-            : undefined;
+        const jwtSecret = process.env.JWT_SECRET;
+        if (!jwtSecret) throw new Error('JWT_SECRET is required for internal browser run sockets');
+        const internalToken = jwt.sign({
+            id: userId,
+            purpose: 'maxun-internal-run',
+            browserId,
+        }, jwtSecret, { expiresIn: '60s' });
 
         socket = io(`${process.env.BACKEND_URL ? process.env.BACKEND_URL : 'http://localhost:8080'}/${browserId}`, {
             transports: ['websocket'],

--- a/server/src/api/sdk.ts
+++ b/server/src/api/sdk.ts
@@ -44,6 +44,7 @@ import { claimResource, releaseResource, requireResourceClaim, ResourceClaimErro
 import { createDocumentRobotRecord } from '../utils/document/createDocumentRobotRecord';
 import { createDocumentParseRobotRecord } from '../utils/document/createDocumentParseRobotRecord';
 import {
+    acknowledgeControlObservation,
     acquireControl,
     getControlCommandStatus,
     heartbeatControl,
@@ -61,6 +62,7 @@ import {
 } from '../sdk/browserControl';
 import type { ControlCommandMode } from '../models/ControlCommand';
 import type { ControlCommandKind } from '../browser-management/classes/RemoteBrowser';
+import { sanitizeBrowserUrl } from '../sdk/urlPrivacy';
 import { normalizeDocumentMimeType, PDF_MIME_TYPE } from '../utils/document/documentFile';
 import {
     createLlmRobot,
@@ -303,7 +305,7 @@ const CONTROL_MODES: readonly ControlCommandMode[] = ['assist', 'record'];
 
 const controlErrorStatus = (code: ControlLeaseError['code']): number => {
     if (code === 'control_conflict') return 409;
-    if (code === 'stale_control' || code === 'control_expired' || code === 'command_replay') return 409;
+    if (code === 'stale_control' || code === 'control_expired' || code === 'command_replay' || code === 'observation_required') return 409;
     return 400;
 };
 
@@ -361,10 +363,25 @@ router.post('/sdk/browser-sessions/:id/control/acquire', requireAPIKey, async (r
                 ...token,
                 streamUrl: (process.env.MAXUN_BROWSER_STREAM_URL || `${req.protocol}://${req.get('host')}`).replace(/\/api\/?$/, ''),
                 serviceInstanceId: getServiceInstanceId(),
-                currentUrl: getRemoteBrowserCurrentUrl(browserSessionId, String(req.user!.id)) || null,
+                currentUrl: sanitizeBrowserUrl(getRemoteBrowserCurrentUrl(browserSessionId, String(req.user!.id))) || null,
                 browserStatus: getRemoteBrowserStatus(browserSessionId) === 'failed' ? 'gone' : 'active',
             },
         });
+    } catch (error: unknown) {
+        return sendControlError(res, error);
+    }
+});
+
+/** Acknowledge the fresh rrweb full snapshot required after agent takeover. */
+router.post('/sdk/browser-sessions/:id/control/observation/ack', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        const lease = await acknowledgeControlObservation(Number(req.user!.id), {
+            browserSessionId: req.params.id,
+            ownerSessionId: req.body?.ownerSessionId,
+            actor: req.body?.actor,
+            controlEpoch: req.body?.controlEpoch,
+        });
+        return res.status(200).json({ success: true, data: lease });
     } catch (error: unknown) {
         return sendControlError(res, error);
     }
@@ -538,9 +555,12 @@ router.post('/sdk/browser-sessions/:id/screenshot', requireAPIKey, async (req: A
         if (getRemoteBrowserOwner(browserSessionId) !== String(req.user!.id)) {
             return res.status(404).json({ error: 'Browser session not found', code: 'resource_not_found' });
         }
-        await requireResourceClaim(Number(req.user!.id), {
-            resourceType: 'browser', resourceId: browserSessionId, ownerSessionId,
+        const claim = await requireResourceClaim(Number(req.user!.id), {
+            resourceType: 'browser', resourceId: browserSessionId, ownerSessionId, epoch,
         });
+        if (claim.epoch !== epoch) {
+            return res.status(409).json({ error: 'Browser resource claim is stale', code: 'stale_claim', epoch: claim.epoch });
+        }
         const browser = getRemoteBrowserStatus(browserSessionId) === 'ready'
             ? getRemoteBrowser(browserSessionId, String(req.user!.id))
             : undefined;
@@ -586,7 +606,7 @@ router.get('/sdk/browser-sessions/:id', requireAPIKey, async (req: Authenticated
             serviceInstanceId: getServiceInstanceId(),
             browserStatus: status === 'failed' ? 'gone' : 'active',
             status,
-            currentUrl: getRemoteBrowserCurrentUrl(browserSessionId, String(req.user!.id)) || null,
+            currentUrl: sanitizeBrowserUrl(getRemoteBrowserCurrentUrl(browserSessionId, String(req.user!.id))) || null,
         },
     });
 });

--- a/server/src/api/sdk.ts
+++ b/server/src/api/sdk.ts
@@ -7,12 +7,21 @@
 import { Router, Request, Response } from 'express';
 import { requireAPIKey } from "../middlewares/api";
 import Robot from "../models/Robot";
+import RecorderDraft from "../models/RecorderDraft";
 import Run from "../models/Run";
 import { v4 as uuid } from 'uuid';
 import { WorkflowFile } from "maxun-core";
 import logger from "../logger";
 import { capture } from "../utils/analytics";
 import { handleRunRecording } from "./record";
+import {
+    createRemoteBrowserForRun,
+    destroyRemoteBrowser,
+    getRemoteBrowser,
+    getRemoteBrowserCurrentUrl,
+    getRemoteBrowserOwner,
+    getRemoteBrowserStatus,
+} from '../browser-management/controller';
 import { WorkflowEnricher } from "../sdk/workflowEnricher";
 import { cancelScheduledWorkflow, scheduleWorkflow } from '../storage/schedule';
 import { encrypt } from '../utils/auth';
@@ -28,10 +37,48 @@ import sequelizeInstance from '../storage/db';
 import { Op } from 'sequelize';
 import { validateRequiredLlmConfig, formatsRequireLlm, readLlmConfig, toPromptLlmMeta } from '../utils/llm-config-validation';
 import multer from 'multer';
+import jwt from 'jsonwebtoken';
 import { MAX_FILE_SIZE_BYTES } from '../workflow-management/classes/DocumentInterpreter';
+import { getServiceInstanceId } from '../sdk/serviceIdentity';
+import { claimResource, releaseResource, requireResourceClaim, ResourceClaimError } from '../sdk/resourceClaims';
 import { createDocumentRobotRecord } from '../utils/document/createDocumentRobotRecord';
 import { createDocumentParseRobotRecord } from '../utils/document/createDocumentParseRobotRecord';
+import {
+    acquireControl,
+    getControlCommandStatus,
+    heartbeatControl,
+    releaseControl,
+    requireControlLease,
+    ControlLeaseError,
+    type ControlActor,
+} from '../sdk/controlLease';
+import {
+    abortWhenRequestCloses,
+    cancelBrowserControlCommand,
+    cancelBrowserControlCommands,
+    executeBrowserControlCommand,
+    normalizeControlCommand,
+} from '../sdk/browserControl';
+import type { ControlCommandMode } from '../models/ControlCommand';
+import type { ControlCommandKind } from '../browser-management/classes/RemoteBrowser';
 import { normalizeDocumentMimeType, PDF_MIME_TYPE } from '../utils/document/documentFile';
+import {
+    createLlmRobot,
+    getTrustedAgentLlmConfig,
+    LlmRobotError,
+    summarizeListWorkflow,
+} from '../sdk/llmRobot';
+import {
+    compileRecorderDraft,
+    createRecorderDraft,
+    RecorderDraftError,
+    serializeRecorderDraft,
+    selectRecorderDraftList,
+    previewRecorderDraft,
+    updateRecorderDraftField,
+    updateRecorderDraftOptions,
+    validateRecorderDraft,
+} from '../sdk/recorderDraft';
 
 const router = Router();
 
@@ -155,7 +202,8 @@ router.get("/sdk/status", requireAPIKey, async (req: AuthenticatedRequest, res: 
         return res.status(200).json({
             email: user.email,
             plan: 'OSS',
-            credits: 999999
+            credits: 999999,
+            serviceInstanceId: getServiceInstanceId(),
         });
     } catch (error: any) {
         logger.error("Error getting status:", error);
@@ -163,6 +211,402 @@ router.get("/sdk/status", requireAPIKey, async (req: AuthenticatedRequest, res: 
             error: "Failed to get status",
             message: error.message
         });
+    }
+});
+
+const resourceClaimErrorStatus = (code: ResourceClaimError['code']): number => (
+    code === 'claim_conflict' ? 409 : 400
+);
+
+const sendResourceClaimError = (res: Response, error: unknown) => {
+    if (error instanceof ResourceClaimError) {
+        return res.status(resourceClaimErrorStatus(error.code)).json({
+            error: error.message,
+            code: error.code,
+            ...(error.details ? { details: error.details } : {}),
+        });
+    }
+    logger.error(`[SDK] Resource claim error: ${error instanceof Error ? error.message : 'unknown error'}`);
+    return res.status(500).json({ error: 'Resource claim operation failed', code: 'internal_error' });
+};
+
+/** Explicitly claim one authenticated Maxun draft or browser for one Harness session. */
+router.post('/sdk/correlation/claims', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        const resourceType = req.body?.resourceType;
+        const resourceId = req.body?.resourceId;
+        const ownerSessionId = req.body?.ownerSessionId;
+        if (resourceType === 'draft') {
+            const draft = await RecorderDraft.findOne({ where: { id: resourceId, userId: Number(req.user!.id) } });
+            if (!draft) return res.status(404).json({ error: 'Recorder draft not found', code: 'resource_not_found' });
+        } else if (resourceType === 'browser') {
+            if (getRemoteBrowserOwner(String(resourceId)) !== String(req.user!.id)) {
+                return res.status(404).json({ error: 'Browser session not found', code: 'resource_not_found' });
+            }
+        }
+        const claim = await claimResource(Number(req.user!.id), { resourceType, resourceId, ownerSessionId });
+        return res.status(claim.existing ? 200 : 201).json({
+            success: true,
+            data: { ...claim, serviceInstanceId: getServiceInstanceId() },
+        });
+    } catch (error: unknown) {
+        return sendResourceClaimError(res, error);
+    }
+});
+
+/** Release a claim only from its owning Harness session and epoch. */
+router.delete('/sdk/correlation/claims', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        await releaseResource(Number(req.user!.id), {
+            resourceType: req.body?.resourceType,
+            resourceId: req.body?.resourceId,
+            ownerSessionId: req.body?.ownerSessionId,
+            epoch: req.body?.epoch,
+        });
+        return res.status(204).send();
+    } catch (error: unknown) {
+        return sendResourceClaimError(res, error);
+    }
+});
+
+/** Reserve a Maxun browser slot for an explicitly owned Harness session. */
+router.post('/sdk/browser-sessions', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    const ownerSessionId = typeof req.body?.ownerSessionId === 'string' ? req.body.ownerSessionId.trim() : '';
+    if (!ownerSessionId) return res.status(400).json({ error: 'ownerSessionId is required', code: 'invalid_claim' });
+    let browserSessionId: string | undefined;
+    try {
+        browserSessionId = createRemoteBrowserForRun(String(req.user!.id), true);
+        const claim = await claimResource(Number(req.user!.id), {
+            resourceType: 'browser', resourceId: browserSessionId, ownerSessionId,
+        });
+        return res.status(201).json({
+            success: true,
+            data: {
+                browserSessionId,
+                serviceInstanceId: getServiceInstanceId(),
+                browserStatus: 'active',
+                status: 'reserved',
+                ownerSessionId: claim.ownerSessionId,
+                epoch: claim.epoch,
+            },
+        });
+    } catch (error: unknown) {
+        if (browserSessionId) await destroyRemoteBrowser(browserSessionId, String(req.user!.id)).catch(() => undefined);
+        return sendResourceClaimError(res, error);
+    }
+});
+
+const CONTROL_CAPABILITY_TTL_SECONDS = 5 * 60;
+const CONTROL_ACTORS: readonly ControlActor[] = ['agent', 'human'];
+const CONTROL_COMMANDS: readonly ControlCommandKind[] = ['click', 'key', 'type', 'navigate', 'scroll', 'refresh', 'pause', 'resume', 'step', 'abort'];
+const CONTROL_MODES: readonly ControlCommandMode[] = ['assist', 'record'];
+
+const controlErrorStatus = (code: ControlLeaseError['code']): number => {
+    if (code === 'control_conflict') return 409;
+    if (code === 'stale_control' || code === 'control_expired' || code === 'command_replay') return 409;
+    return 400;
+};
+
+const sendControlError = (res: Response, error: unknown) => {
+    if (error instanceof ResourceClaimError) return sendResourceClaimError(res, error);
+    if (error instanceof ControlLeaseError) {
+        return res.status(controlErrorStatus(error.code)).json({
+            error: error.message,
+            code: error.code,
+            ...(error.details ? { details: error.details } : {}),
+        });
+    }
+    logger.error(`[SDK] Browser control error: ${error instanceof Error ? error.message : 'unknown error'}`);
+    return res.status(500).json({ error: 'Browser control operation failed', code: 'control_internal_error' });
+};
+
+const controlCapability = (req: AuthenticatedRequest, browserSessionId: string, lease: {
+    ownerSessionId: string;
+    actor: ControlActor;
+    controlEpoch: number;
+}) => {
+    const secret = process.env.JWT_SECRET;
+    if (!secret) throw new ControlLeaseError('invalid_control', 'Browser control is unavailable without JWT_SECRET');
+    const expiresAt = new Date(Date.now() + CONTROL_CAPABILITY_TTL_SECONDS * 1000);
+    const capability = jwt.sign({
+        id: String(req.user!.id),
+        purpose: 'maxun-browser-control',
+        browserId: browserSessionId,
+        ownerSessionId: lease.ownerSessionId,
+        controlEpoch: lease.controlEpoch,
+        actor: lease.actor,
+    }, secret, { expiresIn: CONTROL_CAPABILITY_TTL_SECONDS });
+    return { capability, expiresAt: expiresAt.toISOString() };
+};
+
+/** Acquire or transition the server-side browser control lease. */
+router.post('/sdk/browser-sessions/:id/control/acquire', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    const browserSessionId = req.params.id;
+    const ownerSessionId = typeof req.body?.ownerSessionId === 'string' ? req.body.ownerSessionId.trim() : '';
+    const actor = req.body?.actor;
+    if (!ownerSessionId || !CONTROL_ACTORS.includes(actor)) {
+        return res.status(400).json({ error: 'ownerSessionId and actor are required', code: 'invalid_control' });
+    }
+    try {
+        if (getRemoteBrowserOwner(browserSessionId) !== String(req.user!.id)) {
+            return res.status(404).json({ error: 'Browser session not found', code: 'resource_not_found' });
+        }
+        const lease = await acquireControl(Number(req.user!.id), { browserSessionId, ownerSessionId, actor });
+        if (!lease.existing) cancelBrowserControlCommands(Number(req.user!.id), browserSessionId);
+        const token = controlCapability(req, browserSessionId, lease);
+        return res.status(200).json({
+            success: true,
+            data: {
+                ...lease,
+                ...token,
+                streamUrl: (process.env.MAXUN_BROWSER_STREAM_URL || `${req.protocol}://${req.get('host')}`).replace(/\/api\/?$/, ''),
+                serviceInstanceId: getServiceInstanceId(),
+                currentUrl: getRemoteBrowserCurrentUrl(browserSessionId, String(req.user!.id)) || null,
+                browserStatus: getRemoteBrowserStatus(browserSessionId) === 'failed' ? 'gone' : 'active',
+            },
+        });
+    } catch (error: unknown) {
+        return sendControlError(res, error);
+    }
+});
+
+/** Extend a control lease without advancing its epoch. */
+router.post('/sdk/browser-sessions/:id/control/heartbeat', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        const lease = await heartbeatControl(Number(req.user!.id), {
+            browserSessionId: req.params.id,
+            ownerSessionId: req.body?.ownerSessionId,
+            actor: req.body?.actor,
+            controlEpoch: req.body?.controlEpoch,
+        });
+        return res.status(200).json({ success: true, data: lease });
+    } catch (error: unknown) {
+        return sendControlError(res, error);
+    }
+});
+
+/** Release a lease and cancel any command that was in flight for the old epoch. */
+router.post('/sdk/browser-sessions/:id/control/release', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        const result = await releaseControl(Number(req.user!.id), {
+            browserSessionId: req.params.id,
+            ownerSessionId: req.body?.ownerSessionId,
+            actor: req.body?.actor,
+            controlEpoch: req.body?.controlEpoch,
+        });
+        cancelBrowserControlCommands(Number(req.user!.id), req.params.id);
+        return res.status(200).json({ success: true, data: result });
+    } catch (error: unknown) {
+        return sendControlError(res, error);
+    }
+});
+
+/** Execute one epoch-bound browser/interpreter command. */
+router.post('/sdk/browser-sessions/:id/control/command', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    const browserSessionId = req.params.id;
+    const ownerSessionId = typeof req.body?.ownerSessionId === 'string' ? req.body.ownerSessionId.trim() : '';
+    const actor = req.body?.actor;
+    const controlEpoch = req.body?.controlEpoch;
+    const commandId = typeof req.body?.commandId === 'string' ? req.body.commandId.trim() : '';
+    if (!ownerSessionId || !CONTROL_ACTORS.includes(actor) || !Number.isSafeInteger(controlEpoch) || controlEpoch < 1 || !commandId) {
+        return res.status(400).json({ error: 'ownerSessionId, actor, positive controlEpoch, and commandId are required', code: 'invalid_control' });
+    }
+    try {
+        const command = normalizeControlCommand(req.body);
+        if (getRemoteBrowserOwner(browserSessionId) !== String(req.user!.id)) {
+            return res.status(404).json({ error: 'Browser session not found', code: 'resource_not_found' });
+        }
+        const browser = getRemoteBrowserStatus(browserSessionId) === 'ready'
+            ? getRemoteBrowser(browserSessionId, String(req.user!.id))
+            : undefined;
+        if (!browser) return res.status(404).json({ error: 'Browser session not found', code: 'resource_not_found' });
+        const abort = new AbortController();
+        const cleanup = abortWhenRequestCloses(req, abort, () => res.writableEnded);
+        try {
+            const result = await executeBrowserControlCommand(Number(req.user!.id), browser, {
+                browserSessionId,
+                ownerSessionId,
+                actor,
+                controlEpoch,
+                commandId,
+                commandType: command.kind,
+                mode: command.mode,
+            }, command, abort.signal);
+            return res.status(200).json({ success: true, data: result });
+        } finally {
+            cleanup();
+        }
+    } catch (error: unknown) {
+        if (error instanceof Error && /cancelled|disconnected/i.test(error.message)) {
+            return res.status(499).json({ error: 'Control command cancelled', code: 'control_cancelled' });
+        }
+        if (error instanceof ControlLeaseError) return sendControlError(res, error);
+        logger.error(`[SDK] Browser control command failed: ${error instanceof Error ? error.message : 'unknown error'}`);
+        return res.status(502).json({ error: 'Browser control command failed', code: 'control_command_failed' });
+    }
+});
+
+/** Read compact command outcome without exposing command arguments or text. */
+router.get('/sdk/browser-sessions/:id/control/command/:commandId', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        const result = await getControlCommandStatus(Number(req.user!.id), {
+            browserSessionId: req.params.id,
+            ownerSessionId: String(req.query.ownerSessionId ?? ''),
+            actor: req.query.actor === 'human' ? 'human' : 'agent',
+            controlEpoch: Number(req.query.controlEpoch),
+            commandId: req.params.commandId,
+        });
+        if (!result) return res.status(404).json({ error: 'Control command not found', code: 'control_command_not_found' });
+        return res.status(200).json({ success: true, data: result });
+    } catch (error: unknown) {
+        return sendControlError(res, error);
+    }
+});
+
+/** Cooperatively cancel one running command without accepting command arguments. */
+router.post('/sdk/browser-sessions/:id/control/command/:commandId/cancel', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        await requireControlLease(Number(req.user!.id), {
+            browserSessionId: req.params.id,
+            ownerSessionId: req.body?.ownerSessionId,
+            actor: req.body?.actor,
+            controlEpoch: req.body?.controlEpoch,
+        });
+        const cancelled = cancelBrowserControlCommand(Number(req.user!.id), req.params.id, req.params.commandId);
+        return res.status(200).json({ success: true, data: { commandId: req.params.commandId, cancelled } });
+    } catch (error: unknown) {
+        return sendControlError(res, error);
+    }
+});
+
+const BROWSER_STREAM_CAPABILITY_TTL_SECONDS = 60;
+
+/** Issue a short-lived claim-bound token for the read-only browser stream. */
+router.post('/sdk/browser-sessions/:id/stream-capability', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    const browserSessionId = req.params.id;
+    const ownerSessionId = typeof req.body?.ownerSessionId === 'string' ? req.body.ownerSessionId.trim() : '';
+    const epoch = req.body?.epoch;
+    if (!ownerSessionId || !Number.isSafeInteger(epoch) || epoch < 1) {
+        return res.status(400).json({ error: 'ownerSessionId and positive integer epoch are required', code: 'invalid_claim' });
+    }
+    try {
+        if (getRemoteBrowserOwner(browserSessionId) !== String(req.user!.id)) {
+            return res.status(404).json({ error: 'Browser session not found', code: 'resource_not_found' });
+        }
+        await requireResourceClaim(Number(req.user!.id), {
+            resourceType: 'browser', resourceId: browserSessionId, ownerSessionId,
+        });
+        const secret = process.env.JWT_SECRET;
+        if (!secret) {
+            logger.error('[SDK] Cannot issue browser stream capability without JWT_SECRET');
+            return res.status(503).json({ error: 'Browser stream is unavailable', code: 'service_unavailable' });
+        }
+        const expiresAt = new Date(Date.now() + BROWSER_STREAM_CAPABILITY_TTL_SECONDS * 1000);
+        const capability = jwt.sign({
+            id: String(req.user!.id),
+            purpose: 'maxun-browser-stream',
+            browserId: browserSessionId,
+            ownerSessionId,
+            epoch,
+        }, secret, { expiresIn: BROWSER_STREAM_CAPABILITY_TTL_SECONDS });
+        return res.status(200).json({
+            success: true,
+            data: {
+                capability,
+                expiresAt: expiresAt.toISOString(),
+                streamUrl: (process.env.MAXUN_BROWSER_STREAM_URL || `${req.protocol}://${req.get('host')}`).replace(/\/api\/?$/, ''),
+                serviceInstanceId: getServiceInstanceId(),
+                browserSessionId,
+                ownerSessionId,
+                epoch,
+            },
+        });
+    } catch (error: unknown) {
+        return sendResourceClaimError(res, error);
+    }
+});
+
+/** Capture a current-browser screenshot for the authenticated owner. */
+router.post('/sdk/browser-sessions/:id/screenshot', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    const browserSessionId = req.params.id;
+    const ownerSessionId = typeof req.body?.ownerSessionId === 'string' ? req.body.ownerSessionId.trim() : '';
+    const epoch = req.body?.epoch;
+    if (!ownerSessionId || !Number.isSafeInteger(epoch) || epoch < 1) {
+        return res.status(400).json({ error: 'ownerSessionId and positive integer epoch are required', code: 'invalid_claim' });
+    }
+    try {
+        if (getRemoteBrowserOwner(browserSessionId) !== String(req.user!.id)) {
+            return res.status(404).json({ error: 'Browser session not found', code: 'resource_not_found' });
+        }
+        await requireResourceClaim(Number(req.user!.id), {
+            resourceType: 'browser', resourceId: browserSessionId, ownerSessionId,
+        });
+        const browser = getRemoteBrowserStatus(browserSessionId) === 'ready'
+            ? getRemoteBrowser(browserSessionId, String(req.user!.id))
+            : undefined;
+        if (!browser) return res.status(404).json({ error: 'Browser session not found', code: 'resource_not_found' });
+        const image = await browser.captureCurrentScreenshot({
+            fullPage: req.body?.fullPage === true,
+            type: req.body?.type === 'jpeg' ? 'jpeg' : 'png',
+            timeout: 30000,
+            animations: 'disabled',
+            caret: 'hide',
+            scale: 'css',
+        });
+        res.setHeader('content-type', req.body?.type === 'jpeg' ? 'image/jpeg' : 'image/png');
+        res.setHeader('cache-control', 'no-store');
+        return res.status(200).send(image);
+    } catch (error: unknown) {
+        if (error instanceof ResourceClaimError) return sendResourceClaimError(res, error);
+        logger.error(`[SDK] Browser screenshot failed: ${error instanceof Error ? error.message : 'unknown error'}`);
+        return res.status(502).json({ error: 'Browser screenshot unavailable', code: 'screenshot_unavailable' });
+    }
+});
+
+/** Read process-local browser health for its authenticated owner. */
+router.get('/sdk/browser-sessions/:id', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    const browserSessionId = req.params.id;
+    if (getRemoteBrowserOwner(browserSessionId) !== String(req.user!.id)) {
+        return res.status(404).json({ error: 'Browser session not found', code: 'resource_not_found' });
+    }
+    const status = getRemoteBrowserStatus(browserSessionId);
+    if (!status) return res.status(404).json({ error: 'Browser session not found', code: 'resource_not_found' });
+    try {
+        await requireResourceClaim(Number(req.user!.id), {
+            resourceType: 'browser', resourceId: browserSessionId,
+            ownerSessionId: req.query.ownerSessionId,
+        });
+    } catch (error: unknown) {
+        return sendResourceClaimError(res, error);
+    }
+    return res.status(200).json({
+        success: true,
+        data: {
+            browserSessionId,
+            serviceInstanceId: getServiceInstanceId(),
+            browserStatus: status === 'failed' ? 'gone' : 'active',
+            status,
+            currentUrl: getRemoteBrowserCurrentUrl(browserSessionId, String(req.user!.id)) || null,
+        },
+    });
+});
+
+/** Explicitly release ownership and destroy one browser session. */
+router.delete('/sdk/browser-sessions/:id', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    const browserSessionId = req.params.id;
+    try {
+        await requireResourceClaim(Number(req.user!.id), {
+            resourceType: 'browser', resourceId: browserSessionId,
+            ownerSessionId: req.body?.ownerSessionId,
+        });
+        await releaseResource(Number(req.user!.id), {
+            resourceType: 'browser', resourceId: browserSessionId,
+            ownerSessionId: req.body?.ownerSessionId, epoch: req.body?.epoch,
+        });
+        await destroyRemoteBrowser(browserSessionId, String(req.user!.id));
+        return res.status(204).send();
+    } catch (error: unknown) {
+        return sendResourceClaimError(res, error);
     }
 });
 
@@ -1520,6 +1964,207 @@ router.post("/sdk/extract/llm", requireAPIKey, async (req: AuthenticatedRequest,
             error: "Failed to perform LLM extraction",
             message: error.message
         });
+    }
+});
+
+/**
+ * Create and persist a native list robot from a URL and natural-language request.
+ * The generator LLM configuration is read from trusted Maxun server environment.
+ */
+router.post("/sdk/robots/list", requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    const url = typeof req.body?.url === 'string' ? req.body.url.trim() : '';
+    const prompt = typeof req.body?.prompt === 'string' ? req.body.prompt.trim() : '';
+    const robotName = typeof req.body?.name === 'string' ? req.body.name.trim() : undefined;
+    const llmConfig = getTrustedAgentLlmConfig();
+
+    if (!url) return res.status(400).json({ error: 'url is required', code: 'invalid_request' });
+    if (!prompt) return res.status(400).json({ error: 'prompt is required', code: 'invalid_request' });
+    if (!llmConfig.provider || !llmConfig.apiKey) {
+        return res.status(503).json({
+            error: 'Maxun agent LLM is not configured',
+            code: 'agent_llm_not_configured',
+        });
+    }
+
+    try {
+        const result = await createLlmRobot({
+            url,
+            prompt,
+            userId: req.user!.id,
+            robotName,
+            llmConfig,
+        });
+        const summary = summarizeListWorkflow(result.workflow);
+        const meta = result.robot.recording_meta;
+
+        return res.status(result.existing ? 200 : 201).json({
+            success: true,
+            existing: result.existing,
+            data: {
+                robotId: meta.id,
+                name: meta.name,
+                url: meta.url,
+                type: meta.type,
+                ...summary,
+            },
+        });
+    } catch (error: unknown) {
+        if (error instanceof LlmRobotError) {
+            const status = error.code === 'robot_name_conflict' ? 409 : error.code === 'invalid_url' ? 400 : 422;
+            return res.status(status).json({
+                error: error.message,
+                code: error.code,
+                ...(error.details ? { details: error.details } : {}),
+            });
+        }
+
+        const message = error instanceof Error ? error.message.replaceAll(llmConfig.apiKey, '[redacted]') : 'unknown error';
+        logger.error(`[SDK] Error creating list robot: ${message}`);
+        return res.status(500).json({ error: 'Failed to create list robot', code: 'internal_error' });
+    }
+});
+
+const recorderDraftErrorStatus = (code: RecorderDraftError['code']): number => {
+    if (code === 'draft_not_found' || code === 'candidate_not_found' || code === 'field_not_found') return 404;
+    if (code === 'validation_failed') return 422;
+    if (code === 'robot_name_conflict') return 409;
+    return 400;
+};
+
+const sendRecorderDraftError = (res: Response, error: unknown) => {
+    if (error instanceof RecorderDraftError) {
+        return res.status(recorderDraftErrorStatus(error.code)).json({
+            error: error.message,
+            code: error.code,
+            ...(error.details ? { details: error.details } : {}),
+        });
+    }
+    if (error instanceof LlmRobotError) {
+        const status = error.code === 'robot_name_conflict' ? 409 : error.code === 'invalid_url' ? 400 : 422;
+        return res.status(status).json({
+            error: error.message,
+            code: error.code,
+            ...(error.details ? { details: error.details } : {}),
+        });
+    }
+    const message = error instanceof Error ? error.message : 'unknown error';
+    logger.error(`[SDK] Recorder Draft error: ${message}`);
+    return res.status(500).json({ error: 'Recorder Draft operation failed', code: 'internal_error' });
+};
+
+/**
+ * Create a semantic Recorder Draft. Maxun discovers repeated lists and owns
+ * all selectors; the API returns only opaque candidate IDs and metadata.
+ */
+router.post('/sdk/recorder/drafts', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    const url = typeof req.body?.url === 'string' ? req.body.url.trim() : '';
+    if (!url) return res.status(400).json({ error: 'url is required', code: 'invalid_request' });
+    try {
+        const draft = await createRecorderDraft({
+            url,
+            userId: req.user!.id,
+            name: typeof req.body?.name === 'string' ? req.body.name : undefined,
+            description: typeof req.body?.description === 'string' ? req.body.description : undefined,
+        });
+        return res.status(201).json({ success: true, data: serializeRecorderDraft(draft) });
+    } catch (error: unknown) {
+        return sendRecorderDraftError(res, error);
+    }
+});
+
+router.get('/sdk/recorder/drafts/:id', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        const draft = await RecorderDraft.findOne({
+            where: { id: req.params.id, userId: Number(req.user!.id) },
+        });
+        if (!draft) return res.status(404).json({ error: 'Recorder draft not found', code: 'draft_not_found' });
+        return res.status(200).json({ success: true, data: serializeRecorderDraft(draft) });
+    } catch (error: unknown) {
+        return sendRecorderDraftError(res, error);
+    }
+});
+
+router.post('/sdk/recorder/drafts/:id/select-list', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        const listCandidateId = typeof req.body?.listCandidateId === 'string' ? req.body.listCandidateId : '';
+        if (!listCandidateId) throw new RecorderDraftError('invalid_request', 'listCandidateId is required');
+        const draft = await selectRecorderDraftList(req.params.id, req.user!.id, listCandidateId, req.body?.limit);
+        return res.status(200).json({ success: true, data: serializeRecorderDraft(draft) });
+    } catch (error: unknown) {
+        return sendRecorderDraftError(res, error);
+    }
+});
+
+router.post('/sdk/recorder/drafts/:id/fields', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        const fieldId = typeof req.body?.fieldId === 'string' ? req.body.fieldId : '';
+        const action = req.body?.action;
+        if (!fieldId || !['include', 'exclude', 'rename'].includes(action)) {
+            throw new RecorderDraftError('invalid_request', 'fieldId and action (include, exclude, or rename) are required');
+        }
+        const draft = await updateRecorderDraftField(req.params.id, req.user!.id, { fieldId, action, name: req.body?.name });
+        return res.status(200).json({ success: true, data: serializeRecorderDraft(draft) });
+    } catch (error: unknown) {
+        return sendRecorderDraftError(res, error);
+    }
+});
+
+router.post('/sdk/recorder/drafts/:id/options', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        const draft = await updateRecorderDraftOptions(req.params.id, req.user!.id, { limit: req.body?.limit });
+        return res.status(200).json({ success: true, data: serializeRecorderDraft(draft) });
+    } catch (error: unknown) {
+        return sendRecorderDraftError(res, error);
+    }
+});
+
+router.post('/sdk/recorder/drafts/:id/preview', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        const preview = await previewRecorderDraft(req.params.id, req.user!.id, {
+            followPagination: req.body?.followPagination !== false,
+            limit: req.body?.limit,
+        });
+        return res.status(200).json({ success: true, data: preview });
+    } catch (error: unknown) {
+        return sendRecorderDraftError(res, error);
+    }
+});
+
+router.post('/sdk/recorder/drafts/:id/validate', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        const scope = req.body?.scope === 'multi-page' ? 'multi-page' : 'current-page';
+        const validation = await validateRecorderDraft(req.params.id, req.user!.id, scope);
+        return res.status(validation.valid ? 200 : 422).json({ success: validation.valid, data: validation });
+    } catch (error: unknown) {
+        return sendRecorderDraftError(res, error);
+    }
+});
+
+router.post('/sdk/recorder/drafts/:id/compile', requireAPIKey, async (req: AuthenticatedRequest, res: Response) => {
+    try {
+        const result = await compileRecorderDraft(req.params.id, req.user!.id, {
+            robotName: typeof req.body?.robotName === 'string' ? req.body.robotName : undefined,
+        });
+        const meta = result.robot.recording_meta;
+        const summary = summarizeListWorkflow(result.workflow);
+        return res.status(result.existing ? 200 : 201).json({
+            success: true,
+            existing: result.existing,
+            data: {
+                draftId: result.draft.id,
+                robotId: meta.id,
+                name: meta.name,
+                url: meta.url,
+                type: meta.type,
+                fields: summary.fields,
+                pagination: summary.pagination
+                    ? { type: summary.pagination.type, tested: true }
+                    : null,
+                limit: summary.limit,
+            },
+        });
+    } catch (error: unknown) {
+        return sendRecorderDraftError(res, error);
     }
 });
 

--- a/server/src/browser-management/browserConnection.ts
+++ b/server/src/browser-management/browserConnection.ts
@@ -28,8 +28,7 @@ async function getBrowserServiceEndpoint(): Promise<string> {
         if (data.status === 'healthy' && data.wsEndpoint) {
             const wsEndpoint = new URL(data.wsEndpoint);
             const configuredHost = process.env.BROWSER_WS_HOST || healthHost;
-            const loopbackHosts = new Set(['localhost', '127.0.0.1', '::1']);
-            if (loopbackHosts.has(wsEndpoint.hostname) && !loopbackHosts.has(configuredHost)) {
+            if (wsEndpoint.hostname !== configuredHost) {
                 wsEndpoint.hostname = configuredHost;
             }
             const resolvedEndpoint = wsEndpoint.toString();

--- a/server/src/browser-management/browserConnection.ts
+++ b/server/src/browser-management/browserConnection.ts
@@ -26,8 +26,15 @@ async function getBrowserServiceEndpoint(): Promise<string> {
         const data = await response.json();
 
         if (data.status === 'healthy' && data.wsEndpoint) {
-            logger.debug(`Got WebSocket endpoint: ${data.wsEndpoint}`);
-            return data.wsEndpoint;
+            const wsEndpoint = new URL(data.wsEndpoint);
+            const configuredHost = process.env.BROWSER_WS_HOST || healthHost;
+            const loopbackHosts = new Set(['localhost', '127.0.0.1', '::1']);
+            if (loopbackHosts.has(wsEndpoint.hostname) && !loopbackHosts.has(configuredHost)) {
+                wsEndpoint.hostname = configuredHost;
+            }
+            const resolvedEndpoint = wsEndpoint.toString();
+            logger.debug(`Got WebSocket endpoint: ${resolvedEndpoint}`);
+            return resolvedEndpoint;
         }
 
         throw new Error('Health check did not return a valid wsEndpoint');

--- a/server/src/browser-management/classes/BrowserPool.ts
+++ b/server/src/browser-management/classes/BrowserPool.ts
@@ -604,8 +604,12 @@ export class BrowserPool {
             this.reservationLocks.set(lockKey, Date.now());
             
             if (!this.hasAvailableBrowserSlots(userId, state)) {
-                logger.log('debug', `Cannot reserve slot for user ${userId}: no available slots`);
-                return false;
+                // Try to reclaim leaked ready run slots before failing
+                this.cleanupStaleBrowserSlots();
+                if (!this.hasAvailableBrowserSlots(userId, state)) {
+                    logger.log('debug', `Cannot reserve slot for user ${userId}: no available slots`);
+                    return false;
+                }
             }
 
             if (this.pool[id]) {
@@ -665,6 +669,7 @@ export class BrowserPool {
 
         this.pool[id].browser = browser;
         this.pool[id].status = "ready";
+        this.pool[id].lastAccessed = Date.now();
         logger.log('info', `Upgraded browser slot ${id} to ready state`);
         return true;
     };
@@ -702,15 +707,20 @@ export class BrowserPool {
     public cleanupStaleBrowserSlots = (): void => {
         const now = Date.now();
         const staleThreshold = 5 * 60 * 1000; // 5 minutes
+        const readyRunThreshold = 3 * 60 * 1000; // 3 minutes for leaked ready run slots
         
         const staleSlots: string[] = [];
         
         for (const [id, info] of Object.entries(this.pool)) {
-            const isStale = info.status === "reserved" || info.status === "initializing";
             const createdAt = info.createdAt || 0;
             const age = now - createdAt;
+            const lastAccessed = info.lastAccessed || createdAt;
+            const idle = now - lastAccessed;
             
-            if (isStale && info.browser === null && age > staleThreshold) {
+            const isStaleReserved = (info.status === "reserved" || info.status === "initializing") && info.browser === null && age > staleThreshold;
+            const isLeakedReadyRun = info.status === "ready" && info.state === "run" && idle > readyRunThreshold;
+            
+            if (isStaleReserved || isLeakedReadyRun) {
                 staleSlots.push(id);
             }
         }

--- a/server/src/browser-management/classes/RemoteBrowser.ts
+++ b/server/src/browser-management/classes/RemoteBrowser.ts
@@ -10,6 +10,7 @@ import { PlaywrightBlocker } from '@cliqz/adblocker-playwright';
 import fetch from 'cross-fetch';
 import logger from '../../logger';
 import { readFileSync } from "fs";
+import { dirname, join } from "path";
 import { InterpreterSettings } from "../../types";
 import { WorkflowGenerator } from "../../workflow-management/classes/Generator";
 import { WorkflowInterpreter } from "../../workflow-management/classes/Interpreter";
@@ -19,10 +20,22 @@ import { FingerprintInjector } from "fingerprint-injector";
 import { FingerprintGenerator } from "fingerprint-generator";
 import { connectToRemoteBrowser } from '../browserConnection';
 
+const RRWEB_MASK_TEXT_SELECTOR = [
+  '[data-sensitive]',
+  '[data-private]',
+  '[autocomplete="current-password"]',
+  '[autocomplete="new-password"]',
+  '[autocomplete="cc-number"]',
+  '[autocomplete="cc-csc"]',
+  '[autocomplete="cc-exp"]',
+  '.rr-mask',
+].join(', ');
+
 declare global {
   interface Window {
     rrweb?: any;
     isRecording?: boolean;
+    rrwebRecordHandle?: { takeFullSnapshot?: () => void };
     emitEventToBackend?: (event: any) => Promise<void>;
   }
 }
@@ -30,6 +43,28 @@ declare global {
 interface PageNavigationState {
     version: number;
     queue: Promise<unknown>;
+}
+
+export type ControlCommandKind = 'click' | 'key' | 'type' | 'navigate' | 'scroll' | 'refresh' | 'pause' | 'resume' | 'step' | 'abort';
+export type ControlCommandMode = 'assist' | 'record';
+
+export interface RemoteBrowserControlCommand {
+    readonly kind: ControlCommandKind;
+    readonly mode: ControlCommandMode;
+    readonly coordinates?: { x: number; y: number };
+    readonly key?: string;
+    /** Human-entered text is intentionally never logged or persisted. */
+    readonly text?: string;
+    readonly url?: string;
+    /** Server-owned selector used only for an explicit recorded key action. */
+    readonly selector?: string;
+}
+
+export interface RemoteBrowserControlResult {
+    readonly applied: boolean;
+    readonly recorded: boolean;
+    readonly browserStatus: 'active' | 'gone';
+    readonly currentUrl: string | null;
 }
 
 // const MEMORY_CONFIG = {
@@ -90,6 +125,7 @@ export class RemoteBrowser {
      * @private
      */
     private userId: string;
+    private poolId: string;
 
     private lastEmittedUrl: string | null = null;
     private pageNavigationStates = new WeakMap<Page, PageNavigationState>();
@@ -125,6 +161,7 @@ export class RemoteBrowser {
     public constructor(socket: Socket, userId: string, poolId: string, isRecordingMode: boolean = false) {
         this.socket = socket;
         this.userId = userId;
+        this.poolId = poolId;
         this.interpreter = new WorkflowInterpreter(socket);
         this.generator = new WorkflowGenerator(socket, poolId);
         this.isRecordingMode = isRecordingMode;
@@ -405,7 +442,9 @@ export class RemoteBrowser {
       }
 
       try {
-        const rrwebJsPath = require.resolve('rrweb/dist/rrweb.min.js');
+        const rrwebEntryPath = require.resolve('rrweb');
+        const rrwebPackageRoot = dirname(dirname(rrwebEntryPath));
+        const rrwebJsPath = join(rrwebPackageRoot, 'umd', 'rrweb.min.js');
         const rrwebScriptContent = readFileSync(rrwebJsPath, 'utf8');
         const navigationState = this.getPageNavigationState(page);
         const navigationVersion = navigationState.version;
@@ -448,6 +487,9 @@ export class RemoteBrowser {
           await page.exposeFunction('emitEventToBackend', (event: any) => {
             this.socket.emit('rrweb-event', event);
 
+            if (event.type === 2) {
+              logger.debug(`[rrweb] Full snapshot emitted for browser ${this.poolId} via socket ${this.socket.id}`);
+            }
             if (event.type === 2 && !hasEmittedFullSnapshot) {
               hasEmittedFullSnapshot = true;
               this.emitLoadingProgress(100, 0);
@@ -456,7 +498,7 @@ export class RemoteBrowser {
           });
         }
 
-        const rrwebStatus = await page.evaluate(() => {
+        const rrwebStatus = await page.evaluate((maskTextSelector) => {
           if (!window.rrweb) {
             console.error('[rrweb] window.rrweb is not defined!');
             return { success: false, error: 'window.rrweb is not defined' };
@@ -475,7 +517,15 @@ export class RemoteBrowser {
                   window.emitEventToBackend(event).catch(() => { });
                 }
               },
-              maskAllInputs: false,
+              // Goal 4 privacy boundary: inputs are masked by default and
+              // explicitly marked sensitive text is masked in rrweb snapshots
+              // and mutation events before they leave Maxun.
+              maskAllInputs: true,
+              maskTextSelector,
+              // Iframe srcdoc attributes can contain raw secrets before the
+              // nested document serializer applies text masking. Block the
+              // iframe subtree entirely for the read-only stream.
+              blockSelector: 'iframe',
               recordCanvas: false,
               sampling: {
                 mousemove: false,
@@ -495,7 +545,7 @@ export class RemoteBrowser {
             console.error('[rrweb] Failed to start recording:', error);
             return { success: false, error: error.message };
           }
-        });
+        }, RRWEB_MASK_TEXT_SELECTOR);
 
         if (rrwebStatus.success) {
           this.isDOMStreamingActive = true;
@@ -711,9 +761,33 @@ export class RemoteBrowser {
     };
 
     /**
-     * Captures a screenshot directly without running the workflow interpreter
-     * @param settings Screenshot settings containing fullPage, type, etc.
-     * @returns Promise<void>
+     * Captures a screenshot directly without running the workflow interpreter.
+     * The returned bytes are for an authenticated ephemeral SDK response; they
+     * are never appended to the Harness session or model transcript.
+     */
+    public captureCurrentScreenshot = async (settings: {
+      fullPage: boolean;
+      type: 'png' | 'jpeg';
+      timeout?: number;
+      animations?: 'disabled' | 'allow';
+      caret?: 'hide' | 'initial';
+      scale?: 'css' | 'device';
+    }): Promise<Buffer> => {
+      if (!this.currentPage || this.currentPage.isClosed()) {
+        throw new Error('No active page available');
+      }
+      return this.currentPage.screenshot({
+        fullPage: settings.fullPage,
+        type: settings.type || 'png',
+        timeout: settings.timeout || 30000,
+        animations: settings.animations || 'allow',
+        caret: settings.caret || 'hide',
+        scale: settings.scale || 'device',
+      });
+    };
+
+    /**
+     * Captures a screenshot and preserves the existing editor socket events.
      */
     public captureDirectScreenshot = async (settings: {
       fullPage: boolean;
@@ -723,38 +797,17 @@ export class RemoteBrowser {
       caret?: 'hide' | 'initial';
       scale?: 'css' | 'device';
     }): Promise<void> => {
-      if (!this.currentPage) {
-        logger.error("No current page available for screenshot");
-        this.socket.emit('screenshotError', {
-          userId: this.userId,
-          error: 'No active page available'
-        });
-        return;
-      }
-
       try {
         this.socket.emit('screenshotCaptureStarted', {
           userId: this.userId,
           fullPage: settings.fullPage
         });
-
-        const screenshotBuffer = await this.currentPage.screenshot({
-          fullPage: settings.fullPage,
-          type: settings.type || 'png',
-          timeout: settings.timeout || 30000,
-          animations: settings.animations || 'allow',
-          caret: settings.caret || 'hide',
-          scale: settings.scale || 'device'
-        });
-
-        const base64Data = screenshotBuffer.toString('base64');
+        const screenshotBuffer = await this.captureCurrentScreenshot(settings);
         const mimeType = `image/${settings.type || 'png'}`;
-        const dataUrl = `data:${mimeType};base64,${base64Data}`;
-
         this.socket.emit('directScreenshotCaptured', {
           userId: this.userId,
-          screenshot: dataUrl,
-          mimeType: mimeType,
+          screenshot: `data:${mimeType};base64,${screenshotBuffer.toString('base64')}`,
+          mimeType,
           fullPage: settings.fullPage,
           timestamp: Date.now()
         });
@@ -778,6 +831,7 @@ export class RemoteBrowser {
         this.socket.removeAllListeners('addTab');
         this.socket.removeAllListeners('closeTab');
         this.socket.removeAllListeners('dom:scroll');
+        this.socket.removeAllListeners('request-refresh');
 
         logger.debug(`Removed all socket listeners for user ${this.userId}`);
       } catch (error: any) {
@@ -973,6 +1027,137 @@ export class RemoteBrowser {
         if (this.isDOMStreamingActive) {
           this.setupScrollEventListener();
         }
+    };
+
+    /**
+     * Reattach a read-only Goal 4 stream socket without installing editor,
+     * navigation, scroll, or other browser-mutating handlers.
+     */
+    public updateStreamSocket = (socket: Socket): void => {
+        logger.debug(`[rrweb] Stream socket attached for browser ${this.poolId}: ${socket.id}`);
+        this.socket = socket;
+        socket.removeAllListeners('request-refresh');
+        socket.on('request-refresh', () => {
+          void this.requestStreamRefresh();
+        });
+    };
+
+    /**
+     * Execute one server-authorized human/agent command. The caller validates
+     * the control lease and replay identity before reaching this method.
+     * Text is used only in memory for the Playwright action and is never logged,
+     * emitted, or added to the generated workflow.
+     */
+    public executeControlCommand = async (
+      command: RemoteBrowserControlCommand,
+      signal: AbortSignal,
+    ): Promise<RemoteBrowserControlResult> => {
+      const page = this.currentPage;
+      if (!page || page.isClosed()) throw new Error('Browser page is unavailable');
+      if (signal.aborted) throw new Error('Control command cancelled before dispatch');
+
+      const abortInterpreter = () => {
+        void this.interpreter.stopInterpretation().catch(() => undefined);
+      };
+      signal.addEventListener('abort', abortInterpreter, { once: true });
+      let recorded = false;
+      try {
+        switch (command.kind) {
+          case 'click': {
+            const coordinates = command.coordinates;
+            if (!coordinates || !Number.isFinite(coordinates.x) || !Number.isFinite(coordinates.y)) {
+              throw new Error('click requires finite coordinates');
+            }
+            await page.mouse.click(coordinates.x, coordinates.y);
+            if (command.mode === 'record') {
+              await this.generator.onClick(coordinates, page);
+              recorded = true;
+            }
+            break;
+          }
+          case 'key': {
+            const key = typeof command.key === 'string' ? command.key.trim() : '';
+            if (!key || key.length > 100) throw new Error('key must be a non-empty short string');
+            await page.keyboard.press(key);
+            if (command.mode === 'record' && command.selector) {
+              await this.generator.onDOMKeyboardAction(page, {
+                selector: command.selector,
+                key,
+                url: page.url(),
+                userId: this.userId,
+              });
+              recorded = true;
+            }
+            break;
+          }
+          case 'type': {
+            if (command.mode !== 'assist') throw new Error('text entry is transient assist-only work');
+            if (typeof command.text !== 'string' || command.text.length > 16_384) throw new Error('text is invalid');
+            await page.keyboard.insertText(command.text);
+            break;
+          }
+          case 'navigate': {
+            if (typeof command.url !== 'string') throw new Error('navigate requires a URL');
+            const target = new URL(command.url);
+            if (target.protocol !== 'http:' && target.protocol !== 'https:') throw new Error('Only http(s) URLs are allowed');
+            if (command.mode === 'record') {
+              await this.generator.onChangeUrl(target.toString(), page);
+              recorded = true;
+            }
+            await this.navigateTo(page, target.toString(), { waitUntil: 'domcontentloaded', timeout: 30_000 });
+            break;
+          }
+          case 'scroll': {
+            const x = Number(command.coordinates?.x ?? 0);
+            const y = Number(command.coordinates?.y ?? 0);
+            if (!Number.isFinite(x) || !Number.isFinite(y)) throw new Error('scroll requires finite deltas');
+            await page.mouse.wheel(x, y);
+            break;
+          }
+          case 'refresh':
+            await page.reload({ waitUntil: 'domcontentloaded', timeout: 30_000 });
+            break;
+          case 'pause':
+            this.interpreter.pauseInterpretation();
+            break;
+          case 'resume':
+            this.interpreter.resumeInterpretation();
+            break;
+          case 'step':
+            this.interpreter.stepInterpretation();
+            break;
+          case 'abort':
+            await this.interpreter.stopInterpretation();
+            break;
+          default:
+            throw new Error('Unsupported control command');
+        }
+        if (signal.aborted) throw new Error('Control command cancelled after dispatch');
+        return {
+          applied: true,
+          recorded,
+          browserStatus: 'active',
+          currentUrl: page.url() || null,
+        };
+      } finally {
+        signal.removeEventListener('abort', abortInterpreter);
+      }
+    };
+
+    /** Ask rrweb to emit a fresh full snapshot to the ephemeral namespace. */
+    public requestStreamRefresh = async (): Promise<void> => {
+        if (!this.isRecordingMode || !this.currentPage || this.currentPage.isClosed()) {
+          logger.debug(`[rrweb] Refresh ignored for browser ${this.poolId}: recording=${this.isRecordingMode}`);
+          return;
+        }
+        logger.debug(`[rrweb] Refresh requested for browser ${this.poolId}`);
+        await this.currentPage.evaluate(() => {
+          if (window.rrwebRecordHandle?.takeFullSnapshot) {
+            window.rrwebRecordHandle.takeFullSnapshot();
+          } else {
+            window.rrweb?.record?.takeFullSnapshot?.();
+          }
+        }).catch(() => undefined);
     };
 
     /**

--- a/server/src/browser-management/classes/RemoteBrowser.ts
+++ b/server/src/browser-management/classes/RemoteBrowser.ts
@@ -9,7 +9,7 @@ import { Socket } from "socket.io";
 import { PlaywrightBlocker } from '@cliqz/adblocker-playwright';
 import fetch from 'cross-fetch';
 import logger from '../../logger';
-import { readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { dirname, join } from "path";
 import { InterpreterSettings } from "../../types";
 import { WorkflowGenerator } from "../../workflow-management/classes/Generator";
@@ -19,6 +19,7 @@ import { getInjectableScript } from 'idcac-playwright';
 import { FingerprintInjector } from "fingerprint-injector";
 import { FingerprintGenerator } from "fingerprint-generator";
 import { connectToRemoteBrowser } from '../browserConnection';
+import { sanitizeBrowserUrl } from '../../sdk/urlPrivacy';
 
 const RRWEB_MASK_TEXT_SELECTOR = [
   '[data-sensitive]',
@@ -444,7 +445,21 @@ export class RemoteBrowser {
       try {
         const rrwebEntryPath = require.resolve('rrweb');
         const rrwebPackageRoot = dirname(dirname(rrwebEntryPath));
-        const rrwebJsPath = join(rrwebPackageRoot, 'umd', 'rrweb.min.js');
+        // rrweb 2.0.0-alpha.4 (the backend image pin) ships its browser
+        // bundle under dist/rrweb.min.js, while newer releases expose a UMD
+        // bundle under umd/. Resolve the installed package layout instead of
+        // assuming the development dependency's file tree.
+        const rrwebCandidates = [
+          join(rrwebPackageRoot, 'umd', 'rrweb.min.js'),
+          join(rrwebPackageRoot, 'dist', 'rrweb.umd.min.cjs'),
+          join(rrwebPackageRoot, 'dist', 'rrweb-all.min.js'),
+          join(rrwebPackageRoot, 'dist', 'rrweb.min.js'),
+          join(rrwebPackageRoot, 'dist', 'rrweb.js'),
+        ];
+        const rrwebJsPath = rrwebCandidates.find(existsSync);
+        if (!rrwebJsPath) {
+          throw new Error(`Unable to locate a browser rrweb bundle under ${rrwebPackageRoot}`);
+        }
         const rrwebScriptContent = readFileSync(rrwebJsPath, 'utf8');
         const navigationState = this.getPageNavigationState(page);
         const navigationVersion = navigationState.version;
@@ -776,6 +791,13 @@ export class RemoteBrowser {
       if (!this.currentPage || this.currentPage.isClosed()) {
         throw new Error('No active page available');
       }
+      const sensitiveLocators = [
+        this.currentPage.locator('input'),
+        this.currentPage.locator('textarea'),
+        this.currentPage.locator('[contenteditable="true"]'),
+        this.currentPage.locator('iframe'),
+        this.currentPage.locator('[data-sensitive], [data-private], .rr-mask'),
+      ];
       return this.currentPage.screenshot({
         fullPage: settings.fullPage,
         type: settings.type || 'png',
@@ -783,6 +805,8 @@ export class RemoteBrowser {
         animations: settings.animations || 'allow',
         caret: settings.caret || 'hide',
         scale: settings.scale || 'device',
+        mask: sensitiveLocators,
+        maskColor: '#000000',
       });
     };
 
@@ -1056,10 +1080,9 @@ export class RemoteBrowser {
       if (!page || page.isClosed()) throw new Error('Browser page is unavailable');
       if (signal.aborted) throw new Error('Control command cancelled before dispatch');
 
-      const abortInterpreter = () => {
-        void this.interpreter.stopInterpretation().catch(() => undefined);
+      const throwIfAborted = () => {
+        if (signal.aborted) throw new Error('Control command cancelled');
       };
-      signal.addEventListener('abort', abortInterpreter, { once: true });
       let recorded = false;
       try {
         switch (command.kind) {
@@ -1068,6 +1091,7 @@ export class RemoteBrowser {
             if (!coordinates || !Number.isFinite(coordinates.x) || !Number.isFinite(coordinates.y)) {
               throw new Error('click requires finite coordinates');
             }
+            throwIfAborted();
             await page.mouse.click(coordinates.x, coordinates.y);
             if (command.mode === 'record') {
               await this.generator.onClick(coordinates, page);
@@ -1078,12 +1102,13 @@ export class RemoteBrowser {
           case 'key': {
             const key = typeof command.key === 'string' ? command.key.trim() : '';
             if (!key || key.length > 100) throw new Error('key must be a non-empty short string');
+            throwIfAborted();
             await page.keyboard.press(key);
             if (command.mode === 'record' && command.selector) {
               await this.generator.onDOMKeyboardAction(page, {
                 selector: command.selector,
                 key,
-                url: page.url(),
+                url: sanitizeBrowserUrl(page.url()) ?? '',
                 userId: this.userId,
               });
               recorded = true;
@@ -1093,6 +1118,7 @@ export class RemoteBrowser {
           case 'type': {
             if (command.mode !== 'assist') throw new Error('text entry is transient assist-only work');
             if (typeof command.text !== 'string' || command.text.length > 16_384) throw new Error('text is invalid');
+            throwIfAborted();
             await page.keyboard.insertText(command.text);
             break;
           }
@@ -1101,9 +1127,10 @@ export class RemoteBrowser {
             const target = new URL(command.url);
             if (target.protocol !== 'http:' && target.protocol !== 'https:') throw new Error('Only http(s) URLs are allowed');
             if (command.mode === 'record') {
-              await this.generator.onChangeUrl(target.toString(), page);
+              await this.generator.onChangeUrl(sanitizeBrowserUrl(target.toString()) ?? target.origin + target.pathname, page);
               recorded = true;
             }
+            throwIfAborted();
             await this.navigateTo(page, target.toString(), { waitUntil: 'domcontentloaded', timeout: 30_000 });
             break;
           }
@@ -1111,22 +1138,28 @@ export class RemoteBrowser {
             const x = Number(command.coordinates?.x ?? 0);
             const y = Number(command.coordinates?.y ?? 0);
             if (!Number.isFinite(x) || !Number.isFinite(y)) throw new Error('scroll requires finite deltas');
+            throwIfAborted();
             await page.mouse.wheel(x, y);
             break;
           }
           case 'refresh':
+            throwIfAborted();
             await page.reload({ waitUntil: 'domcontentloaded', timeout: 30_000 });
             break;
           case 'pause':
+            throwIfAborted();
             this.interpreter.pauseInterpretation();
             break;
           case 'resume':
+            throwIfAborted();
             this.interpreter.resumeInterpretation();
             break;
           case 'step':
+            throwIfAborted();
             this.interpreter.stepInterpretation();
             break;
           case 'abort':
+            throwIfAborted();
             await this.interpreter.stopInterpretation();
             break;
           default:
@@ -1137,10 +1170,9 @@ export class RemoteBrowser {
           applied: true,
           recorded,
           browserStatus: 'active',
-          currentUrl: page.url() || null,
+          currentUrl: sanitizeBrowserUrl(page.url()),
         };
       } finally {
-        signal.removeEventListener('abort', abortInterpreter);
       }
     };
 

--- a/server/src/browser-management/controller.ts
+++ b/server/src/browser-management/controller.ts
@@ -17,6 +17,7 @@ import {
   normalizeControlCommand,
 } from '../sdk/browserControl';
 import logger from "../logger";
+import { sanitizeBrowserUrl } from '../sdk/urlPrivacy';
 
 const RECORDING_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const recordingTimeouts = new Map<string, NodeJS.Timeout>();
@@ -291,7 +292,7 @@ export const canCreateBrowserInState = (userId: string, state?: "recording" | "r
  * @category  BrowserManagement-Controller
  */
 export const getRemoteBrowserCurrentUrl = (id: string, userId: string): string | undefined => {
-  return browserPool.getRemoteBrowser(id)?.getCurrentPage()?.url();
+  return sanitizeBrowserUrl(browserPool.getRemoteBrowser(id)?.getCurrentPage()?.url()) ?? undefined;
 };
 
 /** Return the process-local browser slot status for an authenticated owner. */
@@ -480,7 +481,15 @@ const initializeBrowserAsync = async (id: string, userId: string, enableLiveStre
         }
         const streamCapability = socket.data.maxunStreamCapability as { browserId?: string } | undefined;
         const controlCapability = socket.data.maxunControlCapability as { browserId?: string } | undefined;
-        if ((streamCapability && streamCapability.browserId !== id) || (controlCapability && controlCapability.browserId !== id)) {
+        const internalRunCapability = socket.data.maxunInternalRunCapability as { browserId?: string } | undefined;
+        if (enableLiveStream && !streamCapability && !controlCapability) {
+          logger.log('warn', `Rejected generic mutating socket ${socket.id} for Harness browser ${id}`);
+          socket.disconnect(true);
+          return;
+        }
+        if ((streamCapability && streamCapability.browserId !== id)
+          || (controlCapability && controlCapability.browserId !== id)
+          || (internalRunCapability && internalRunCapability.browserId !== id)) {
           logger.log('warn', `Rejected browser socket ${socket.id}: capability does not match browser ${id}`);
           socket.disconnect(true);
           return;

--- a/server/src/browser-management/controller.ts
+++ b/server/src/browser-management/controller.ts
@@ -6,9 +6,16 @@ import { Socket } from "socket.io";
 import { v4 as uuid } from "uuid";
 import { Page } from "playwright-core";
 import { createSocketConnection, createSocketConnectionForRun } from "../socket-connection/connection";
+import { socketOwns } from "../socket-connection/socketAuth";
 import { io, browserPool } from "../server";
 import { RemoteBrowser } from "./classes/RemoteBrowser";
 import { RemoteBrowserOptions } from "../types";
+import { ControlLeaseError, heartbeatControl, releaseControl, type ControlActor } from '../sdk/controlLease';
+import {
+  cancelBrowserControlCommands,
+  executeBrowserControlCommand,
+  normalizeControlCommand,
+} from '../sdk/browserControl';
 import logger from "../logger";
 
 const RECORDING_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
@@ -111,7 +118,7 @@ export const initializeRemoteBrowserForRecording = (userId: string, mode: string
  * @returns string Browser ID
  * @category BrowserManagement-Controller
  */
-export const createRemoteBrowserForRun = (userId: string): string => {
+export const createRemoteBrowserForRun = (userId: string, enableLiveStream: boolean = false): string => {
   if (!userId) {
     logger.log('error', 'createRemoteBrowserForRun: Missing required parameter userId');
     throw new Error('userId is required');
@@ -127,7 +134,7 @@ export const createRemoteBrowserForRun = (userId: string): string => {
 
   logger.log('info', `createRemoteBrowserForRun: Reserved slot ${id} for user ${userId}`);
 
-  initializeBrowserAsync(id, userId)
+  initializeBrowserAsync(id, userId, enableLiveStream)
     .catch((error: any) => {
       logger.log('error', `Unhandled error in initializeBrowserAsync for browser ${id}: ${error.message}`);
       browserPool.failBrowserSlot(id);
@@ -153,6 +160,11 @@ export const clearRecordingTimeout = (id: string): void => {
 };
 
 export const destroyRemoteBrowser = async (id: string, userId: string): Promise<boolean> => {
+  const owner = browserPool.getUserForBrowser(id);
+  if (owner && owner !== String(userId)) {
+    logger.log('warn', `Refusing to destroy browser ${id} for non-owner user ${userId}`);
+    return false;
+  }
   clearRecordingTimeout(id);
 
   const DESTROY_TIMEOUT = 30000;
@@ -161,7 +173,13 @@ export const destroyRemoteBrowser = async (id: string, userId: string): Promise<
     try {
       const browserSession = browserPool.getRemoteBrowser(id);
       if (!browserSession) {
-        logger.log('info', `Browser with id: ${id} not found, may have already been destroyed`);
+        // Reserved and failed slots intentionally have no RemoteBrowser object;
+        // release them from the pool as well so an explicit owner release cannot
+        // leave an orphaned reconnect target until the stale-slot sweeper runs.
+        const deleted = browserPool.deleteRemoteBrowser(id);
+        logger.log('info', deleted
+          ? `Removed browser slot ${id} without an initialized session`
+          : `Browser with id: ${id} not found, may have already been destroyed`);
         return true;
       }
 
@@ -276,6 +294,20 @@ export const getRemoteBrowserCurrentUrl = (id: string, userId: string): string |
   return browserPool.getRemoteBrowser(id)?.getCurrentPage()?.url();
 };
 
+/** Return the process-local browser slot status for an authenticated owner. */
+export const getRemoteBrowserStatus = (id: string): 'reserved' | 'initializing' | 'ready' | 'failed' | null => (
+  browserPool.getBrowserStatus(id)
+);
+
+/** Return the process-local owner of a browser slot, or null when it is gone. */
+export const getRemoteBrowserOwner = (id: string): string | null => browserPool.getUserForBrowser(id);
+
+/** Return a remote browser only to its authenticated owner. */
+export const getRemoteBrowser = (id: string, userId: string): RemoteBrowser | undefined => {
+  if (getRemoteBrowserOwner(id) !== String(userId)) return undefined;
+  return browserPool.getRemoteBrowser(id);
+};
+
 /**
  * Returns the array of tab strings from a remote browser if exists in the browser pool.
  * @param id instance id of the remote browser
@@ -330,23 +362,142 @@ export const stopRunningInterpretation = async (userId: string) => {
   }
 };
 
-const initializeBrowserAsync = async (id: string, userId: string) => {
+const attachControlSocket = (browserSession: RemoteBrowser, socket: Socket, userId: string, browserId: string): void => {
+  const activeControllers = new Map<string, AbortController>();
+  socket.removeAllListeners('control-command');
+  socket.removeAllListeners('control-cancel');
+  socket.removeAllListeners('control-heartbeat');
+  socket.removeAllListeners('control-release');
+
+  const capability = () => socket.data.maxunControlCapability as {
+    browserId?: string;
+    ownerSessionId?: string;
+    controlEpoch?: number;
+    actor?: ControlActor;
+  } | undefined;
+
+  socket.on('control-command', async (payload: any) => {
+    const current = capability();
+    const commandId = typeof payload?.commandId === 'string' ? payload.commandId.trim() : '';
+    const controlEpoch = current?.controlEpoch;
+    if (!current || current.browserId !== browserId || !current.ownerSessionId || !Number.isSafeInteger(controlEpoch) || !current.actor || !commandId) {
+      socket.emit('control-result', { commandId, success: false, code: 'stale_control' });
+      return;
+    }
+    if (commandId.length > 255) {
+      socket.emit('control-result', { commandId, success: false, code: 'invalid_control' });
+      return;
+    }
+    try {
+      const command = normalizeControlCommand(payload);
+      const abort = new AbortController();
+      activeControllers.set(commandId, abort);
+      const result = await executeBrowserControlCommand(Number(userId), browserSession, {
+        browserSessionId: browserId,
+        ownerSessionId: current.ownerSessionId,
+        actor: current.actor,
+        controlEpoch: controlEpoch as number,
+        commandId,
+        commandType: command.kind,
+        mode: command.mode,
+      }, command, abort.signal);
+      socket.emit('control-result', { commandId, success: true, data: result });
+    } catch (error: unknown) {
+      if (error instanceof ControlLeaseError) {
+        socket.emit('control-result', { commandId, success: false, code: error.code });
+      } else {
+        socket.emit('control-result', { commandId, success: false, code: 'control_command_failed' });
+      }
+    } finally {
+      activeControllers.delete(commandId);
+    }
+  });
+
+  socket.on('control-cancel', (payload: { commandId?: string }) => {
+    const commandId = typeof payload?.commandId === 'string' ? payload.commandId : '';
+    activeControllers.get(commandId)?.abort(new Error('control command cancelled'));
+  });
+
+  socket.on('control-heartbeat', async () => {
+    const current = capability();
+    if (!current?.ownerSessionId || !current.actor || !Number.isSafeInteger(current.controlEpoch)) {
+      socket.emit('control-status', { success: false, code: 'stale_control' });
+      return;
+    }
+    try {
+      const lease = await heartbeatControl(Number(userId), {
+        browserSessionId: browserId,
+        ownerSessionId: current.ownerSessionId,
+        actor: current.actor,
+        controlEpoch: current.controlEpoch,
+      });
+      socket.emit('control-status', { success: true, data: lease });
+    } catch (error: unknown) {
+      socket.emit('control-status', { success: false, code: error instanceof ControlLeaseError ? error.code : 'control_internal_error' });
+    }
+  });
+
+  socket.on('control-release', async () => {
+    const current = capability();
+    if (!current?.ownerSessionId || !current.actor || !Number.isSafeInteger(current.controlEpoch)) {
+      socket.emit('control-status', { success: false, code: 'stale_control' });
+      return;
+    }
+    try {
+      const released = await releaseControl(Number(userId), {
+        browserSessionId: browserId,
+        ownerSessionId: current.ownerSessionId,
+        actor: current.actor,
+        controlEpoch: current.controlEpoch,
+      });
+      cancelBrowserControlCommands(Number(userId), browserId);
+      socket.emit('control-status', { success: true, data: released });
+    } catch (error: unknown) {
+      socket.emit('control-status', { success: false, code: error instanceof ControlLeaseError ? error.code : 'control_internal_error' });
+    }
+  });
+
+  socket.on('disconnect', () => {
+    for (const controller of activeControllers.values()) controller.abort(new Error('control socket disconnected'));
+    cancelBrowserControlCommands(Number(userId), browserId);
+  });
+};
+
+const initializeBrowserAsync = async (id: string, userId: string, enableLiveStream: boolean = false) => {
   try {
     const namespace = io.of(id);
     let clientConnected = false;
     let connectionTimeout: NodeJS.Timeout;
-    
+    let browserSession: RemoteBrowser | undefined;
+
     const waitForConnection = new Promise<Socket | null>((resolve) => {
       let initialResolved = false;
       namespace.on('connection', (socket: Socket) => {
+        if (!socketOwns(socket, userId)) {
+          logger.log('warn', `Rejected socket ${socket.id}: does not own browser ${id}`);
+          socket.disconnect(true);
+          return;
+        }
+        const streamCapability = socket.data.maxunStreamCapability as { browserId?: string } | undefined;
+        const controlCapability = socket.data.maxunControlCapability as { browserId?: string } | undefined;
+        if ((streamCapability && streamCapability.browserId !== id) || (controlCapability && controlCapability.browserId !== id)) {
+          logger.log('warn', `Rejected browser socket ${socket.id}: capability does not match browser ${id}`);
+          socket.disconnect(true);
+          return;
+        }
         if (!initialResolved) {
           initialResolved = true;
           clientConnected = true;
           clearTimeout(connectionTimeout);
           logger.log('info', `Frontend connected to browser ${id} via socket ${socket.id}`);
           resolve(socket);
-        } else {
+        } else if (browserSession) {
+          if (streamCapability) browserSession.updateStreamSocket(socket);
+          else if (controlCapability) attachControlSocket(browserSession, socket, userId, id);
+          else browserSession.updateSocket(socket);
           logger.log('debug', `Additional frontend socket ${socket.id} joined browser ${id} namespace (shared connection)`);
+        } else {
+          logger.log('debug', `Additional frontend socket ${socket.id} joined browser ${id} namespace before initialization`);
         }
       });
       
@@ -391,11 +542,9 @@ const initializeBrowserAsync = async (id: string, userId: string) => {
     const socket = await connectWithRetry(3);
     
     try {
-      let browserSession: RemoteBrowser;
-      
       if (socket) {
         logger.log('info', `Using real socket for browser ${id}`);
-        browserSession = new RemoteBrowser(socket, userId, id);
+        browserSession = new RemoteBrowser(socket, userId, id, enableLiveStream);
       } else {
         logger.log('info', `Using dummy socket for browser ${id}`);
         const dummySocket = {
@@ -403,6 +552,8 @@ const initializeBrowserAsync = async (id: string, userId: string) => {
             logger.log('debug', `Browser ${id} dummy socket emitted ${event}:`, data);
           },
           on: () => {},
+          off: () => {},
+          removeAllListeners: () => {},
           id: `dummy-${id}`,
           nsp: {
             emit: (event: string, ...args: any[]) => {
@@ -411,7 +562,7 @@ const initializeBrowserAsync = async (id: string, userId: string) => {
           },
         } as any;
         
-        browserSession = new RemoteBrowser(dummySocket, userId, id);
+        browserSession = new RemoteBrowser(dummySocket, userId, id, enableLiveStream);
       }
 
       logger.log('debug', `Starting browser initialization for ${id}`);
@@ -450,6 +601,9 @@ const initializeBrowserAsync = async (id: string, userId: string) => {
       await new Promise(resolve => setTimeout(resolve, 500));
       
       if (socket) {
+        const initialControl = socket.data.maxunControlCapability as { browserId?: string } | undefined;
+        if (initialControl) attachControlSocket(browserSession, socket, userId, id);
+        else if (enableLiveStream) browserSession.updateStreamSocket(socket);
         socket.emit('ready-for-run');
       } else {
         setTimeout(async () => {

--- a/server/src/browser-management/controller.ts
+++ b/server/src/browser-management/controller.ts
@@ -162,7 +162,7 @@ export const clearRecordingTimeout = (id: string): void => {
 
 export const destroyRemoteBrowser = async (id: string, userId: string): Promise<boolean> => {
   const owner = browserPool.getUserForBrowser(id);
-  if (owner && owner !== String(userId)) {
+  if (owner && String(owner) !== String(userId)) {
     logger.log('warn', `Refusing to destroy browser ${id} for non-owner user ${userId}`);
     return false;
   }

--- a/server/src/db/migrations/20250527105655-add-webhooks.js
+++ b/server/src/db/migrations/20250527105655-add-webhooks.js
@@ -2,26 +2,32 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addColumn('robot', 'webhooks', {
-      type: Sequelize.JSONB,
-      allowNull: true,
-      defaultValue: null,
-      comment: 'Webhook configurations for the robot'
-    });
+    const tableInfo = await queryInterface.describeTable('robot');
+    if (!tableInfo.webhooks) {
+      await queryInterface.addColumn('robot', 'webhooks', {
+        type: Sequelize.JSONB,
+        allowNull: true,
+        defaultValue: null,
+        comment: 'Webhook configurations for the robot'
+      });
+    }
 
-    // Optional: Add an index for better query performance if you plan to search within webhook data
-    await queryInterface.addIndex('robot', {
-      fields: ['webhooks'],
-      using: 'gin', // GIN index for JSONB columns
-      name: 'robot_webhooks_gin_idx'
-    });
+    const indexes = await queryInterface.showIndex('robot');
+    if (!indexes.some(index => index.name === 'robot_webhooks_gin_idx')) {
+      await queryInterface.addIndex('robot', {
+        fields: ['webhooks'],
+        using: 'gin',
+        name: 'robot_webhooks_gin_idx'
+      });
+    }
   },
 
-  async down(queryInterface, Sequelize) {
-    // Remove the index first
-    await queryInterface.removeIndex('robot', 'robot_webhooks_gin_idx');
-    
-    // Then remove the column
-    await queryInterface.removeColumn('robot', 'webhooks');
+  async down(queryInterface) {
+    const indexes = await queryInterface.showIndex('robot');
+    if (indexes.some(index => index.name === 'robot_webhooks_gin_idx')) {
+      await queryInterface.removeIndex('robot', 'robot_webhooks_gin_idx');
+    }
+    const tableInfo = await queryInterface.describeTable('robot');
+    if (tableInfo.webhooks) await queryInterface.removeColumn('robot', 'webhooks');
   }
 };

--- a/server/src/db/migrations/20260707173443-add-run-is-partial.js
+++ b/server/src/db/migrations/20260707173443-add-run-is-partial.js
@@ -2,15 +2,18 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addColumn('run', 'isPartial', {
-      type: Sequelize.BOOLEAN,
-      allowNull: true,
-      defaultValue: false,
-      comment: 'True when a failed/aborted run still has partial serializableOutput/binaryOutput worth surfacing'
-    });
+    const tableInfo = await queryInterface.describeTable('run');
+    if (!tableInfo.isPartial) {
+      await queryInterface.addColumn('run', 'isPartial', {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+      });
+    }
   },
 
-  async down(queryInterface, Sequelize) {
-    await queryInterface.removeColumn('run', 'isPartial');
-  }
+  async down(queryInterface) {
+    const tableInfo = await queryInterface.describeTable('run');
+    if (tableInfo.isPartial) await queryInterface.removeColumn('run', 'isPartial');
+  },
 };

--- a/server/src/db/migrations/20260818185000-create-recorder-drafts.js
+++ b/server/src/db/migrations/20260818185000-create-recorder-drafts.js
@@ -1,0 +1,63 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('recorder_draft', {
+      id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      url: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      name: {
+        type: Sequelize.STRING(200),
+        allowNull: false,
+      },
+      description: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      status: {
+        type: Sequelize.STRING(32),
+        allowNull: false,
+        defaultValue: 'discovered',
+      },
+      state: {
+        type: Sequelize.JSONB,
+        allowNull: false,
+      },
+      compiledRobotId: {
+        type: Sequelize.UUID,
+        allowNull: true,
+      },
+      lastError: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn('NOW'),
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn('NOW'),
+      },
+    });
+
+    await queryInterface.addIndex('recorder_draft', ['userId']);
+    await queryInterface.addIndex('recorder_draft', ['userId', 'updatedAt']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('recorder_draft');
+  },
+};

--- a/server/src/db/migrations/20260818185000-create-recorder-drafts.js
+++ b/server/src/db/migrations/20260818185000-create-recorder-drafts.js
@@ -2,62 +2,33 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable('recorder_draft', {
-      id: {
-        type: Sequelize.UUID,
-        allowNull: false,
-        primaryKey: true,
-      },
-      userId: {
-        type: Sequelize.INTEGER,
-        allowNull: false,
-      },
-      url: {
-        type: Sequelize.TEXT,
-        allowNull: false,
-      },
-      name: {
-        type: Sequelize.STRING(200),
-        allowNull: false,
-      },
-      description: {
-        type: Sequelize.TEXT,
-        allowNull: true,
-      },
-      status: {
-        type: Sequelize.STRING(32),
-        allowNull: false,
-        defaultValue: 'discovered',
-      },
-      state: {
-        type: Sequelize.JSONB,
-        allowNull: false,
-      },
-      compiledRobotId: {
-        type: Sequelize.UUID,
-        allowNull: true,
-      },
-      lastError: {
-        type: Sequelize.TEXT,
-        allowNull: true,
-      },
-      createdAt: {
-        type: Sequelize.DATE,
-        allowNull: false,
-        defaultValue: Sequelize.fn('NOW'),
-      },
-      updatedAt: {
-        type: Sequelize.DATE,
-        allowNull: false,
-        defaultValue: Sequelize.fn('NOW'),
-      },
-    });
-
-    await queryInterface.addIndex('recorder_draft', ['userId']);
-    await queryInterface.addIndex('recorder_draft', ['userId', 'updatedAt']);
+    const tables = await queryInterface.showAllTables();
+    if (!tables.includes('recorder_draft')) {
+      await queryInterface.createTable('recorder_draft', {
+        id: { type: Sequelize.UUID, allowNull: false, primaryKey: true },
+        userId: { type: Sequelize.INTEGER, allowNull: false },
+        url: { type: Sequelize.TEXT, allowNull: false },
+        name: { type: Sequelize.STRING(200), allowNull: false },
+        description: { type: Sequelize.TEXT, allowNull: true },
+        status: { type: Sequelize.STRING(32), allowNull: false, defaultValue: 'discovered' },
+        state: { type: Sequelize.JSONB, allowNull: false },
+        compiledRobotId: { type: Sequelize.UUID, allowNull: true },
+        lastError: { type: Sequelize.TEXT, allowNull: true },
+        createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+        updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+      });
+    }
+    const indexes = await queryInterface.showIndex('recorder_draft');
+    if (!indexes.some(index => index.fields?.map(field => field.attribute).join(',') === 'userId')) {
+      await queryInterface.addIndex('recorder_draft', ['userId']);
+    }
+    if (!indexes.some(index => index.fields?.map(field => field.attribute).join(',') === 'userId,updatedAt')) {
+      await queryInterface.addIndex('recorder_draft', ['userId', 'updatedAt']);
+    }
   },
 
   async down(queryInterface) {
-    await queryInterface.dropTable('recorder_draft');
+    const tables = await queryInterface.showAllTables();
+    if (tables.includes('recorder_draft')) await queryInterface.dropTable('recorder_draft');
   },
 };

--- a/server/src/db/migrations/20260818210000-create-maxun-resource-claims.js
+++ b/server/src/db/migrations/20260818210000-create-maxun-resource-claims.js
@@ -1,0 +1,59 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('maxun_resource_claim', {
+      id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        primaryKey: true,
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      resourceType: {
+        type: Sequelize.STRING(32),
+        allowNull: false,
+      },
+      resourceId: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+      ownerSessionId: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+      epoch: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 1,
+      },
+      active: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: true,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn('NOW'),
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn('NOW'),
+      },
+    });
+
+    await queryInterface.addIndex('maxun_resource_claim', ['userId', 'resourceType', 'resourceId'], {
+      unique: true,
+      name: 'maxun_resource_claim_owner_unique',
+    });
+    await queryInterface.addIndex('maxun_resource_claim', ['userId', 'ownerSessionId']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('maxun_resource_claim');
+  },
+};

--- a/server/src/db/migrations/20260818210000-create-maxun-resource-claims.js
+++ b/server/src/db/migrations/20260818210000-create-maxun-resource-claims.js
@@ -2,58 +2,34 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable('maxun_resource_claim', {
-      id: {
-        type: Sequelize.UUID,
-        allowNull: false,
-        primaryKey: true,
-      },
-      userId: {
-        type: Sequelize.INTEGER,
-        allowNull: false,
-      },
-      resourceType: {
-        type: Sequelize.STRING(32),
-        allowNull: false,
-      },
-      resourceId: {
-        type: Sequelize.STRING(255),
-        allowNull: false,
-      },
-      ownerSessionId: {
-        type: Sequelize.STRING(255),
-        allowNull: false,
-      },
-      epoch: {
-        type: Sequelize.INTEGER,
-        allowNull: false,
-        defaultValue: 1,
-      },
-      active: {
-        type: Sequelize.BOOLEAN,
-        allowNull: false,
-        defaultValue: true,
-      },
-      createdAt: {
-        type: Sequelize.DATE,
-        allowNull: false,
-        defaultValue: Sequelize.fn('NOW'),
-      },
-      updatedAt: {
-        type: Sequelize.DATE,
-        allowNull: false,
-        defaultValue: Sequelize.fn('NOW'),
-      },
-    });
-
-    await queryInterface.addIndex('maxun_resource_claim', ['userId', 'resourceType', 'resourceId'], {
-      unique: true,
-      name: 'maxun_resource_claim_owner_unique',
-    });
-    await queryInterface.addIndex('maxun_resource_claim', ['userId', 'ownerSessionId']);
+    const tables = await queryInterface.showAllTables();
+    if (!tables.includes('maxun_resource_claim')) {
+      await queryInterface.createTable('maxun_resource_claim', {
+        id: { type: Sequelize.UUID, allowNull: false, primaryKey: true },
+        userId: { type: Sequelize.INTEGER, allowNull: false },
+        resourceType: { type: Sequelize.STRING(32), allowNull: false },
+        resourceId: { type: Sequelize.STRING(255), allowNull: false },
+        ownerSessionId: { type: Sequelize.STRING(255), allowNull: false },
+        epoch: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 1 },
+        active: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+        createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+        updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+      });
+    }
+    const indexes = await queryInterface.showIndex('maxun_resource_claim');
+    if (!indexes.some(index => index.name === 'maxun_resource_claim_owner_unique')) {
+      await queryInterface.addIndex('maxun_resource_claim', ['userId', 'resourceType', 'resourceId'], {
+        unique: true,
+        name: 'maxun_resource_claim_owner_unique',
+      });
+    }
+    if (!indexes.some(index => index.fields?.map(field => field.attribute).join(',') === 'userId,ownerSessionId')) {
+      await queryInterface.addIndex('maxun_resource_claim', ['userId', 'ownerSessionId']);
+    }
   },
 
   async down(queryInterface) {
-    await queryInterface.dropTable('maxun_resource_claim');
+    const tables = await queryInterface.showAllTables();
+    if (tables.includes('maxun_resource_claim')) await queryInterface.dropTable('maxun_resource_claim');
   },
 };

--- a/server/src/db/migrations/20260819010000-create-maxun-control-leases.js
+++ b/server/src/db/migrations/20260819010000-create-maxun-control-leases.js
@@ -1,0 +1,52 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('maxun_control_lease', {
+      id: { type: Sequelize.UUID, allowNull: false, primaryKey: true },
+      userId: { type: Sequelize.INTEGER, allowNull: false },
+      browserSessionId: { type: Sequelize.STRING(255), allowNull: false },
+      ownerSessionId: { type: Sequelize.STRING(255), allowNull: false },
+      actor: { type: Sequelize.STRING(16), allowNull: false },
+      controlEpoch: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 1 },
+      active: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+      expiresAt: { type: Sequelize.DATE, allowNull: false },
+      heartbeatAt: { type: Sequelize.DATE, allowNull: false },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+    });
+
+    await queryInterface.addIndex('maxun_control_lease', ['userId', 'browserSessionId'], {
+      unique: true,
+      name: 'maxun_control_lease_browser_unique',
+    });
+    await queryInterface.addIndex('maxun_control_lease', ['userId', 'ownerSessionId']);
+
+    await queryInterface.createTable('maxun_control_command', {
+      id: { type: Sequelize.UUID, allowNull: false, primaryKey: true },
+      userId: { type: Sequelize.INTEGER, allowNull: false },
+      browserSessionId: { type: Sequelize.STRING(255), allowNull: false },
+      ownerSessionId: { type: Sequelize.STRING(255), allowNull: false },
+      actor: { type: Sequelize.STRING(16), allowNull: false },
+      controlEpoch: { type: Sequelize.INTEGER, allowNull: false },
+      commandId: { type: Sequelize.STRING(255), allowNull: false },
+      commandType: { type: Sequelize.STRING(32), allowNull: false },
+      mode: { type: Sequelize.STRING(16), allowNull: false },
+      status: { type: Sequelize.STRING(16), allowNull: false },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+      finishedAt: { type: Sequelize.DATE, allowNull: true },
+    });
+
+    await queryInterface.addIndex('maxun_control_command', ['userId', 'browserSessionId', 'commandId'], {
+      unique: true,
+      name: 'maxun_control_command_replay_unique',
+    });
+    await queryInterface.addIndex('maxun_control_command', ['userId', 'browserSessionId', 'controlEpoch']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('maxun_control_command');
+    await queryInterface.dropTable('maxun_control_lease');
+  },
+};

--- a/server/src/db/migrations/20260819010000-create-maxun-control-leases.js
+++ b/server/src/db/migrations/20260819010000-create-maxun-control-leases.js
@@ -2,51 +2,70 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable('maxun_control_lease', {
-      id: { type: Sequelize.UUID, allowNull: false, primaryKey: true },
-      userId: { type: Sequelize.INTEGER, allowNull: false },
-      browserSessionId: { type: Sequelize.STRING(255), allowNull: false },
-      ownerSessionId: { type: Sequelize.STRING(255), allowNull: false },
-      actor: { type: Sequelize.STRING(16), allowNull: false },
-      controlEpoch: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 1 },
-      active: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
-      expiresAt: { type: Sequelize.DATE, allowNull: false },
-      heartbeatAt: { type: Sequelize.DATE, allowNull: false },
-      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
-      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
-    });
+    const tables = await queryInterface.showAllTables();
+    if (!tables.includes('maxun_control_lease')) {
+      await queryInterface.createTable('maxun_control_lease', {
+        id: { type: Sequelize.UUID, allowNull: false, primaryKey: true },
+        userId: { type: Sequelize.INTEGER, allowNull: false },
+        browserSessionId: { type: Sequelize.STRING(255), allowNull: false },
+        ownerSessionId: { type: Sequelize.STRING(255), allowNull: false },
+        actor: { type: Sequelize.STRING(16), allowNull: false },
+        controlEpoch: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 1 },
+        active: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+        expiresAt: { type: Sequelize.DATE, allowNull: false },
+        heartbeatAt: { type: Sequelize.DATE, allowNull: false },
+        createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+        updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+      });
+    }
+    let indexes = await queryInterface.showIndex('maxun_control_lease');
+    if (!indexes.some(index => index.name === 'maxun_control_lease_browser_unique')) {
+      await queryInterface.addIndex('maxun_control_lease', ['userId', 'browserSessionId'], {
+        unique: true,
+        name: 'maxun_control_lease_browser_unique',
+      });
+    }
+    indexes = await queryInterface.showIndex('maxun_control_lease');
+    if (!indexes.some(index => index.name === 'maxun_control_lease_owner_idx')) {
+      await queryInterface.addIndex('maxun_control_lease', ['userId', 'ownerSessionId'], {
+        name: 'maxun_control_lease_owner_idx',
+      });
+    }
 
-    await queryInterface.addIndex('maxun_control_lease', ['userId', 'browserSessionId'], {
-      unique: true,
-      name: 'maxun_control_lease_browser_unique',
-    });
-    await queryInterface.addIndex('maxun_control_lease', ['userId', 'ownerSessionId']);
-
-    await queryInterface.createTable('maxun_control_command', {
-      id: { type: Sequelize.UUID, allowNull: false, primaryKey: true },
-      userId: { type: Sequelize.INTEGER, allowNull: false },
-      browserSessionId: { type: Sequelize.STRING(255), allowNull: false },
-      ownerSessionId: { type: Sequelize.STRING(255), allowNull: false },
-      actor: { type: Sequelize.STRING(16), allowNull: false },
-      controlEpoch: { type: Sequelize.INTEGER, allowNull: false },
-      commandId: { type: Sequelize.STRING(255), allowNull: false },
-      commandType: { type: Sequelize.STRING(32), allowNull: false },
-      mode: { type: Sequelize.STRING(16), allowNull: false },
-      status: { type: Sequelize.STRING(16), allowNull: false },
-      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
-      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
-      finishedAt: { type: Sequelize.DATE, allowNull: true },
-    });
-
-    await queryInterface.addIndex('maxun_control_command', ['userId', 'browserSessionId', 'commandId'], {
-      unique: true,
-      name: 'maxun_control_command_replay_unique',
-    });
-    await queryInterface.addIndex('maxun_control_command', ['userId', 'browserSessionId', 'controlEpoch']);
+    if (!tables.includes('maxun_control_command')) {
+      await queryInterface.createTable('maxun_control_command', {
+        id: { type: Sequelize.UUID, allowNull: false, primaryKey: true },
+        userId: { type: Sequelize.INTEGER, allowNull: false },
+        browserSessionId: { type: Sequelize.STRING(255), allowNull: false },
+        ownerSessionId: { type: Sequelize.STRING(255), allowNull: false },
+        actor: { type: Sequelize.STRING(16), allowNull: false },
+        controlEpoch: { type: Sequelize.INTEGER, allowNull: false },
+        commandId: { type: Sequelize.STRING(255), allowNull: false },
+        commandType: { type: Sequelize.STRING(32), allowNull: false },
+        mode: { type: Sequelize.STRING(16), allowNull: false },
+        status: { type: Sequelize.STRING(16), allowNull: false },
+        createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+        updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.fn('NOW') },
+        finishedAt: { type: Sequelize.DATE, allowNull: true },
+      });
+    }
+    indexes = await queryInterface.showIndex('maxun_control_command');
+    if (!indexes.some(index => index.name === 'maxun_control_command_replay_unique')) {
+      await queryInterface.addIndex('maxun_control_command', ['userId', 'browserSessionId', 'commandId'], {
+        unique: true,
+        name: 'maxun_control_command_replay_unique',
+      });
+    }
+    if (!indexes.some(index => index.name === 'maxun_control_command_epoch_idx')) {
+      await queryInterface.addIndex('maxun_control_command', ['userId', 'browserSessionId', 'controlEpoch'], {
+        name: 'maxun_control_command_epoch_idx',
+      });
+    }
   },
 
   async down(queryInterface) {
-    await queryInterface.dropTable('maxun_control_command');
-    await queryInterface.dropTable('maxun_control_lease');
+    const tables = await queryInterface.showAllTables();
+    if (tables.includes('maxun_control_command')) await queryInterface.dropTable('maxun_control_command');
+    if (tables.includes('maxun_control_lease')) await queryInterface.dropTable('maxun_control_lease');
   },
 };

--- a/server/src/db/migrations/20260819020000-add-control-observation-ready.js
+++ b/server/src/db/migrations/20260819020000-add-control-observation-ready.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('maxun_control_lease', 'observationReady', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('maxun_control_lease', 'observationReady');
+  },
+};

--- a/server/src/db/migrations/20260819020000-add-control-observation-ready.js
+++ b/server/src/db/migrations/20260819020000-add-control-observation-ready.js
@@ -2,14 +2,18 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addColumn('maxun_control_lease', 'observationReady', {
-      type: Sequelize.BOOLEAN,
-      allowNull: false,
-      defaultValue: true,
-    });
+    const tableInfo = await queryInterface.describeTable('maxun_control_lease');
+    if (!tableInfo.observationReady) {
+      await queryInterface.addColumn('maxun_control_lease', 'observationReady', {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: true,
+      });
+    }
   },
 
   async down(queryInterface) {
-    await queryInterface.removeColumn('maxun_control_lease', 'observationReady');
+    const tableInfo = await queryInterface.describeTable('maxun_control_lease');
+    if (tableInfo.observationReady) await queryInterface.removeColumn('maxun_control_lease', 'observationReady');
   },
 };

--- a/server/src/db/prepareSchema.ts
+++ b/server/src/db/prepareSchema.ts
@@ -1,0 +1,26 @@
+import sequelize from '../storage/db';
+import '../models/User';
+import '../models/Robot';
+import '../models/Run';
+import '../models/RecorderDraft';
+import '../models/ResourceClaim';
+import '../models/ControlLease';
+import '../models/ControlCommand';
+
+/**
+ * Establishes the model baseline before legacy migrations run. Maxun's
+ * historical migration chain starts from an existing core schema rather than
+ * a blank database; this step makes a truly fresh container deterministic.
+ */
+async function main(): Promise<void> {
+  await sequelize.authenticate();
+  await sequelize.sync({ force: false, alter: false });
+  await sequelize.close();
+  console.log('Base model schema prepared successfully.');
+}
+
+void main().catch(async error => {
+  console.error('Failed to prepare base model schema:', error);
+  await sequelize.close().catch(() => undefined);
+  process.exitCode = 1;
+});

--- a/server/src/models/ControlCommand.ts
+++ b/server/src/models/ControlCommand.ts
@@ -1,0 +1,64 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize from '../storage/db';
+
+export type ControlCommandStatus = 'running' | 'completed' | 'cancelled' | 'unknown';
+export type ControlCommandMode = 'assist' | 'record';
+
+export interface ControlCommandAttributes {
+  id: string;
+  userId: number;
+  browserSessionId: string;
+  ownerSessionId: string;
+  actor: 'agent' | 'human';
+  controlEpoch: number;
+  commandId: string;
+  commandType: string;
+  mode: ControlCommandMode;
+  status: ControlCommandStatus;
+  createdAt: Date;
+  updatedAt: Date;
+  finishedAt?: Date | null;
+}
+
+type ControlCommandCreationAttributes = Optional<ControlCommandAttributes, 'id' | 'createdAt' | 'updatedAt' | 'finishedAt'>;
+
+class ControlCommand extends Model<ControlCommandAttributes, ControlCommandCreationAttributes> implements ControlCommandAttributes {
+  public id!: string;
+  public userId!: number;
+  public browserSessionId!: string;
+  public ownerSessionId!: string;
+  public actor!: 'agent' | 'human';
+  public controlEpoch!: number;
+  public commandId!: string;
+  public commandType!: string;
+  public mode!: ControlCommandMode;
+  public status!: ControlCommandStatus;
+  public createdAt!: Date;
+  public updatedAt!: Date;
+  public finishedAt!: Date | null;
+}
+
+ControlCommand.init(
+  {
+    id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+    userId: { type: DataTypes.INTEGER, allowNull: false },
+    browserSessionId: { type: DataTypes.STRING(255), allowNull: false },
+    ownerSessionId: { type: DataTypes.STRING(255), allowNull: false },
+    actor: { type: DataTypes.STRING(16), allowNull: false },
+    controlEpoch: { type: DataTypes.INTEGER, allowNull: false },
+    commandId: { type: DataTypes.STRING(255), allowNull: false },
+    commandType: { type: DataTypes.STRING(32), allowNull: false },
+    mode: { type: DataTypes.STRING(16), allowNull: false },
+    status: { type: DataTypes.STRING(16), allowNull: false },
+    createdAt: { type: DataTypes.DATE, allowNull: false },
+    updatedAt: { type: DataTypes.DATE, allowNull: false },
+    finishedAt: { type: DataTypes.DATE, allowNull: true },
+  },
+  {
+    sequelize,
+    tableName: 'maxun_control_command',
+    timestamps: true,
+  },
+);
+
+export default ControlCommand;

--- a/server/src/models/ControlCommand.ts
+++ b/server/src/models/ControlCommand.ts
@@ -57,6 +57,10 @@ ControlCommand.init(
   {
     sequelize,
     tableName: 'maxun_control_command',
+    indexes: [
+      { unique: true, fields: ['userId', 'browserSessionId', 'commandId'], name: 'maxun_control_command_replay_unique' },
+      { fields: ['userId', 'browserSessionId', 'controlEpoch'], name: 'maxun_control_command_epoch_idx' },
+    ],
     timestamps: true,
   },
 );

--- a/server/src/models/ControlLease.ts
+++ b/server/src/models/ControlLease.ts
@@ -1,0 +1,57 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize from '../storage/db';
+
+export type ControlActor = 'agent' | 'human';
+
+export interface ControlLeaseAttributes {
+  id: string;
+  userId: number;
+  browserSessionId: string;
+  ownerSessionId: string;
+  actor: ControlActor;
+  controlEpoch: number;
+  active: boolean;
+  expiresAt: Date;
+  heartbeatAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+type ControlLeaseCreationAttributes = Optional<ControlLeaseAttributes, 'id' | 'createdAt' | 'updatedAt'>;
+
+class ControlLease extends Model<ControlLeaseAttributes, ControlLeaseCreationAttributes> implements ControlLeaseAttributes {
+  public id!: string;
+  public userId!: number;
+  public browserSessionId!: string;
+  public ownerSessionId!: string;
+  public actor!: ControlActor;
+  public controlEpoch!: number;
+  public active!: boolean;
+  public expiresAt!: Date;
+  public heartbeatAt!: Date;
+  public createdAt!: Date;
+  public updatedAt!: Date;
+}
+
+ControlLease.init(
+  {
+    id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+    userId: { type: DataTypes.INTEGER, allowNull: false },
+    browserSessionId: { type: DataTypes.STRING(255), allowNull: false },
+    ownerSessionId: { type: DataTypes.STRING(255), allowNull: false },
+    actor: { type: DataTypes.STRING(16), allowNull: false },
+    controlEpoch: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 1 },
+    active: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    expiresAt: { type: DataTypes.DATE, allowNull: false },
+    heartbeatAt: { type: DataTypes.DATE, allowNull: false },
+    createdAt: { type: DataTypes.DATE, allowNull: false },
+    updatedAt: { type: DataTypes.DATE, allowNull: false },
+  },
+  {
+    sequelize,
+    tableName: 'maxun_control_lease',
+    timestamps: true,
+  },
+);
+
+export default ControlLease;

--- a/server/src/models/ControlLease.ts
+++ b/server/src/models/ControlLease.ts
@@ -11,6 +11,7 @@ export interface ControlLeaseAttributes {
   actor: ControlActor;
   controlEpoch: number;
   active: boolean;
+  observationReady: boolean;
   expiresAt: Date;
   heartbeatAt: Date;
   createdAt: Date;
@@ -27,6 +28,7 @@ class ControlLease extends Model<ControlLeaseAttributes, ControlLeaseCreationAtt
   public actor!: ControlActor;
   public controlEpoch!: number;
   public active!: boolean;
+  public observationReady!: boolean;
   public expiresAt!: Date;
   public heartbeatAt!: Date;
   public createdAt!: Date;
@@ -42,6 +44,7 @@ ControlLease.init(
     actor: { type: DataTypes.STRING(16), allowNull: false },
     controlEpoch: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 1 },
     active: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    observationReady: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
     expiresAt: { type: DataTypes.DATE, allowNull: false },
     heartbeatAt: { type: DataTypes.DATE, allowNull: false },
     createdAt: { type: DataTypes.DATE, allowNull: false },
@@ -50,6 +53,10 @@ ControlLease.init(
   {
     sequelize,
     tableName: 'maxun_control_lease',
+    indexes: [
+      { unique: true, fields: ['userId', 'browserSessionId'], name: 'maxun_control_lease_browser_unique' },
+      { fields: ['userId', 'ownerSessionId'], name: 'maxun_control_lease_owner_idx' },
+    ],
     timestamps: true,
   },
 );

--- a/server/src/models/RecorderDraft.ts
+++ b/server/src/models/RecorderDraft.ts
@@ -1,0 +1,135 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize from '../storage/db';
+
+export type RecorderDraftStatus = 'discovered' | 'compiled' | 'failed';
+
+export interface DraftFieldState {
+  id: string;
+  sourceLabel: string;
+  label: string;
+  selector: string;
+  attribute: string;
+  tag: string;
+  isShadow: boolean;
+  samples: string[];
+  included: boolean;
+}
+
+export interface DraftListState {
+  id: string;
+  selector: string;
+  tag: string;
+  count: number;
+  semanticParent: string;
+  sampleTexts: string[];
+  attributes: string[];
+  fields: DraftFieldState[];
+  pagination: {
+    type: string;
+    selector: string;
+    tested: boolean;
+  };
+}
+
+export interface RecorderDraftState {
+  lists: DraftListState[];
+  selectedListId?: string;
+  limit?: number | null;
+}
+
+export interface RecorderDraftAttributes {
+  id: string;
+  userId: number;
+  url: string;
+  name: string;
+  description?: string | null;
+  status: RecorderDraftStatus;
+  state: RecorderDraftState;
+  compiledRobotId?: string | null;
+  lastError?: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+type RecorderDraftCreationAttributes = Optional<
+  RecorderDraftAttributes,
+  'id' | 'description' | 'compiledRobotId' | 'lastError' | 'createdAt' | 'updatedAt'
+>;
+
+class RecorderDraft extends Model<RecorderDraftAttributes, RecorderDraftCreationAttributes> implements RecorderDraftAttributes {
+  public id!: string;
+  public userId!: number;
+  public url!: string;
+  public name!: string;
+  public description!: string | null;
+  public status!: RecorderDraftStatus;
+  public state!: RecorderDraftState;
+  public compiledRobotId!: string | null;
+  public lastError!: string | null;
+  public createdAt!: Date;
+  public updatedAt!: Date;
+}
+
+RecorderDraft.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    url: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING(200),
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    status: {
+      type: DataTypes.STRING(32),
+      allowNull: false,
+      defaultValue: 'discovered',
+    },
+    state: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+    },
+    compiledRobotId: {
+      type: DataTypes.UUID,
+      allowNull: true,
+    },
+    lastError: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize,
+    tableName: 'recorder_draft',
+    timestamps: false,
+    indexes: [
+      { fields: ['userId'] },
+      { fields: ['userId', 'updatedAt'] },
+    ],
+  },
+);
+
+export default RecorderDraft;

--- a/server/src/models/ResourceClaim.ts
+++ b/server/src/models/ResourceClaim.ts
@@ -1,0 +1,51 @@
+import { DataTypes, Model, Optional } from 'sequelize';
+import sequelize from '../storage/db';
+
+export type ResourceClaimType = 'draft' | 'browser';
+
+export interface ResourceClaimAttributes {
+  id: string;
+  userId: number;
+  resourceType: ResourceClaimType;
+  resourceId: string;
+  ownerSessionId: string;
+  epoch: number;
+  active: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+type ResourceClaimCreationAttributes = Optional<ResourceClaimAttributes, 'id' | 'createdAt' | 'updatedAt'>;
+
+class ResourceClaim extends Model<ResourceClaimAttributes, ResourceClaimCreationAttributes> implements ResourceClaimAttributes {
+  public id!: string;
+  public userId!: number;
+  public resourceType!: ResourceClaimType;
+  public resourceId!: string;
+  public ownerSessionId!: string;
+  public epoch!: number;
+  public active!: boolean;
+  public createdAt!: Date;
+  public updatedAt!: Date;
+}
+
+ResourceClaim.init(
+  {
+    id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+    userId: { type: DataTypes.INTEGER, allowNull: false },
+    resourceType: { type: DataTypes.STRING(32), allowNull: false },
+    resourceId: { type: DataTypes.STRING(255), allowNull: false },
+    ownerSessionId: { type: DataTypes.STRING(255), allowNull: false },
+    epoch: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 1 },
+    active: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+    createdAt: { type: DataTypes.DATE, allowNull: false },
+    updatedAt: { type: DataTypes.DATE, allowNull: false },
+  },
+  {
+    sequelize,
+    tableName: 'maxun_resource_claim',
+    timestamps: true,
+  },
+);
+
+export default ResourceClaim;

--- a/server/src/models/Robot.ts
+++ b/server/src/models/Robot.ts
@@ -9,6 +9,7 @@ interface RobotMeta {
   createdAt: string;
   pairs: number;
   updatedAt: string;
+  description?: string;
   params: any[];
   type?: 'extract' | 'scrape' | 'crawl' | 'search' | 'doc-extract' | 'doc-parse';
   url?: string;

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -1748,7 +1748,9 @@ export async function recoverStuckRunningRuns() {
             CASE
               WHEN "startedAt" ~ '^[0-9]{4}-'
               THEN "startedAt"::timestamptz
-              ELSE to_timestamp("startedAt", 'FMMM/FMDD/YYYY, FMHH12:MI:SS AM')
+              WHEN "startedAt" ~ 'AM|PM'
+              THEN to_timestamp("startedAt", 'FMMM/FMDD/YYYY, FMHH12:MI:SS AM')
+              ELSE to_timestamp("startedAt", 'DD.MM.YYYY, HH24:MI:SS')
             END < now() - interval '${STUCK_RUNNING_THRESHOLD_MINUTES} minutes'
           `),
         ],

--- a/server/src/routes/storage.ts
+++ b/server/src/routes/storage.ts
@@ -17,6 +17,7 @@ import { addJob } from '../storage/graphileWorker';
 import { QUEUE_NAMES } from '../task-runner';
 import { io as serverIo, recentRecoveries } from '../server';
 import { WorkflowEnricher } from '../sdk/workflowEnricher';
+import { createLlmRobot, LlmRobotError } from '../sdk/llmRobot';
 import sequelizeInstance from '../storage/db';
 import { Op, literal } from 'sequelize';
 import {
@@ -759,6 +760,38 @@ router.post('/recordings/llm', requireSignIn, async (req: AuthenticatedRequest, 
     const finalRobotName = (typeof robotName === 'string' ? robotName.trim() : '') || `LLM Extract: ${prompt.substring(0, 50)}`;
     if (!finalRobotName) {
       return res.status(400).json({ error: 'Robot name cannot be empty.' });
+    }
+
+    if (url) {
+      const llmConfig = {
+        provider: llmProvider || 'ollama',
+        model: llmModel,
+        apiKey: llmApiKey,
+        baseUrl: llmBaseUrl,
+      };
+      const llmValidationError = validateRequiredLlmConfig(llmConfig, 'Creating an LLM extract robot');
+      if (llmValidationError) return res.status(400).json(llmValidationError);
+
+      try {
+        const result = await createLlmRobot({
+          url,
+          prompt,
+          userId: req.user.id,
+          robotName: finalRobotName,
+          llmConfig,
+        });
+        const robot = sanitizeRobotMeta(result.robot);
+        return res.status(result.existing ? 200 : 201).json({
+          message: result.existing ? 'Existing LLM robot returned.' : 'LLM robot created successfully.',
+          robot,
+        });
+      } catch (error: unknown) {
+        if (error instanceof LlmRobotError) {
+          const status = error.code === 'robot_name_conflict' ? 409 : error.code === 'invalid_url' ? 400 : 422;
+          return res.status(status).json({ error: error.message, code: error.code, details: error.details });
+        }
+        throw error;
+      }
     }
 
     if (await isRobotNameTaken(finalRobotName, req.user.id)) {

--- a/server/src/sdk/browserControl.ts
+++ b/server/src/sdk/browserControl.ts
@@ -1,0 +1,159 @@
+import type { Request } from 'express';
+import type { ControlActor } from '../models/ControlLease';
+import type { RemoteBrowser, RemoteBrowserControlCommand, RemoteBrowserControlResult, ControlCommandKind, ControlCommandMode } from '../browser-management/classes/RemoteBrowser';
+import { ControlLeaseError } from './controlLease';
+import {
+  beginControlCommand,
+  finishControlCommand,
+  requireControlLease,
+  type ControlLeaseResult,
+  type ControlCommandInput,
+} from './controlLease';
+
+export interface BrowserControlExecution extends RemoteBrowserControlResult {
+  readonly commandId: string;
+  readonly controlEpoch: number;
+  readonly observationEpoch: number;
+  readonly observedAt: number;
+}
+
+const queues = new Map<string, Promise<unknown>>();
+const CONTROL_COMMANDS: readonly ControlCommandKind[] = ['click', 'key', 'type', 'navigate', 'scroll', 'refresh', 'pause', 'resume', 'step', 'abort'];
+const CONTROL_MODES: readonly ControlCommandMode[] = ['assist', 'record'];
+
+export function normalizeControlCommand(body: any): RemoteBrowserControlCommand {
+  const source = body?.command && typeof body.command === 'object' ? body.command : body;
+  const kind = source?.kind;
+  const mode = source?.mode ?? 'assist';
+  if (!CONTROL_COMMANDS.includes(kind) || !CONTROL_MODES.includes(mode)) {
+    throw new ControlLeaseError('invalid_control', 'Unsupported control command or mode');
+  }
+  const output: any = { kind, mode };
+  if (source.coordinates !== undefined) {
+    const x = Number(source.coordinates?.x);
+    const y = Number(source.coordinates?.y);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) throw new ControlLeaseError('invalid_control', 'coordinates must be finite');
+    output.coordinates = { x, y };
+  }
+  if (source.key !== undefined) output.key = String(source.key);
+  if (source.text !== undefined) output.text = String(source.text);
+  if (source.url !== undefined) output.url = String(source.url);
+  if (source.selector !== undefined) output.selector = String(source.selector);
+  return output;
+}
+const activeCommands = new Map<string, AbortController>();
+
+const queueKey = (userId: number, browserSessionId: string): string => `${userId}:${browserSessionId}`;
+const commandKey = (userId: number, browserSessionId: string, commandId: string): string => `${queueKey(userId, browserSessionId)}:${commandId}`;
+
+/**
+ * Serialize mutating commands per browser. The lease is rechecked after a
+ * queued command reaches the head, so a handoff cannot release a stale queued
+ * click/type/navigation into Playwright.
+ */
+export async function executeBrowserControlCommand(
+  userId: number,
+  browser: RemoteBrowser,
+  input: ControlCommandInput,
+  command: RemoteBrowserControlCommand,
+  signal: AbortSignal,
+): Promise<BrowserControlExecution> {
+  const key = queueKey(userId, input.browserSessionId);
+  const previous = queues.get(key) ?? Promise.resolve();
+  let run!: Promise<BrowserControlExecution>;
+  run = previous.catch(() => undefined).then(async () => {
+    if (signal.aborted) throw new Error('Control command cancelled before queue admission');
+    await beginControlCommand(userId, input);
+    const controller = new AbortController();
+    const combinedController = new AbortController();
+    const forwardAbort = () => combinedController.abort(signal.reason);
+    const forwardInternalAbort = () => combinedController.abort(controller.signal.reason);
+    signal.addEventListener('abort', forwardAbort, { once: true });
+    controller.signal.addEventListener('abort', forwardInternalAbort, { once: true });
+    const combined = combinedController.signal;
+    const activeKey = commandKey(userId, input.browserSessionId, input.commandId);
+    activeCommands.set(activeKey, controller);
+    try {
+      const result = await browser.executeControlCommand(command, combined);
+      await finishControlCommand(userId, input.browserSessionId, input.commandId, 'completed');
+      return {
+        ...result,
+        commandId: input.commandId,
+        controlEpoch: input.controlEpoch,
+        observationEpoch: input.controlEpoch,
+        observedAt: Date.now(),
+      };
+    } catch (error) {
+      // A cancellation after dispatch cannot know whether Playwright applied the
+      // action before the abort reached the browser, so durable status is unknown.
+      await finishControlCommand(userId, input.browserSessionId, input.commandId, 'unknown');
+      throw error;
+    } finally {
+      signal.removeEventListener('abort', forwardAbort);
+      controller.signal.removeEventListener('abort', forwardInternalAbort);
+      activeCommands.delete(activeKey);
+    }
+  });
+  queues.set(key, run);
+  try {
+    return await run;
+  } finally {
+    if (queues.get(key) === run) queues.delete(key);
+  }
+}
+
+export function cancelBrowserControlCommand(userId: number, browserSessionId: string, commandId: string): boolean {
+  const controller = activeCommands.get(commandKey(userId, browserSessionId, commandId));
+  if (!controller) return false;
+  controller.abort(new Error('control command cancelled'));
+  return true;
+}
+
+export function cancelBrowserControlCommands(userId: number, browserSessionId: string): number {
+  const prefix = `${queueKey(userId, browserSessionId)}:`;
+  let cancelled = 0;
+  for (const [key, controller] of activeCommands) {
+    if (!key.startsWith(prefix)) continue;
+    controller.abort(new Error('browser control ownership changed'));
+    cancelled += 1;
+  }
+  return cancelled;
+}
+
+/** Compact observation returned after a control transition; no page payload. */
+export function controlObservation(
+  browserSessionId: string,
+  lease: ControlLeaseResult,
+  browserStatus: 'active' | 'gone',
+  currentUrl: string | null,
+): Record<string, string | number | boolean | null> {
+  return {
+    browserSessionId,
+    browserStatus,
+    currentUrl,
+    controlActor: lease.actor,
+    controlEpoch: lease.controlEpoch,
+    observedAt: Date.now(),
+  };
+}
+
+/** Abort an in-flight command if its HTTP caller disappears. */
+export function abortWhenRequestCloses(req: Request, controller: AbortController, responseEnded: () => boolean): () => void {
+  const onAborted = () => controller.abort(new Error('control request cancelled'));
+  const onClose = () => {
+    if (!responseEnded()) controller.abort(new Error('control request disconnected'));
+  };
+  req.once('aborted', onAborted);
+  req.once('close', onClose);
+  return () => {
+    req.off('aborted', onAborted);
+    req.off('close', onClose);
+  };
+}
+
+export async function requireActorControl(
+  userId: number,
+  input: { browserSessionId: string; ownerSessionId: string; actor: ControlActor; controlEpoch: number },
+): Promise<ControlLeaseResult> {
+  return requireControlLease(userId, input);
+}

--- a/server/src/sdk/browserControl.ts
+++ b/server/src/sdk/browserControl.ts
@@ -9,6 +9,7 @@ import {
   type ControlLeaseResult,
   type ControlCommandInput,
 } from './controlLease';
+import { sanitizeBrowserUrl } from './urlPrivacy';
 
 export interface BrowserControlExecution extends RemoteBrowserControlResult {
   readonly commandId: string;
@@ -47,9 +48,9 @@ const queueKey = (userId: number, browserSessionId: string): string => `${userId
 const commandKey = (userId: number, browserSessionId: string, commandId: string): string => `${queueKey(userId, browserSessionId)}:${commandId}`;
 
 /**
- * Serialize mutating commands per browser. The lease is rechecked after a
- * queued command reaches the head, so a handoff cannot release a stale queued
- * click/type/navigation into Playwright.
+ * Serialize mutating commands per browser. A command is registered as
+ * cancellable before lease admission and the lease is fenced again immediately
+ * before dispatch, so handoff can abort an admitted command before Playwright.
  */
 export async function executeBrowserControlCommand(
   userId: number,
@@ -63,18 +64,23 @@ export async function executeBrowserControlCommand(
   let run!: Promise<BrowserControlExecution>;
   run = previous.catch(() => undefined).then(async () => {
     if (signal.aborted) throw new Error('Control command cancelled before queue admission');
-    await beginControlCommand(userId, input);
     const controller = new AbortController();
     const combinedController = new AbortController();
     const forwardAbort = () => combinedController.abort(signal.reason);
     const forwardInternalAbort = () => combinedController.abort(controller.signal.reason);
+    const activeKey = commandKey(userId, input.browserSessionId, input.commandId);
     signal.addEventListener('abort', forwardAbort, { once: true });
     controller.signal.addEventListener('abort', forwardInternalAbort, { once: true });
-    const combined = combinedController.signal;
-    const activeKey = commandKey(userId, input.browserSessionId, input.commandId);
     activeCommands.set(activeKey, controller);
+    let admitted = false;
     try {
-      const result = await browser.executeControlCommand(command, combined);
+      await beginControlCommand(userId, input);
+      admitted = true;
+      // This is the dispatch fence. Handoff/release locks and advances the
+      // lease epoch; no await occurs between this check and the browser call.
+      await requireControlLease(userId, input);
+      if (combinedController.signal.aborted) throw new Error('Control command cancelled before dispatch');
+      const result = await browser.executeControlCommand(command, combinedController.signal);
       await finishControlCommand(userId, input.browserSessionId, input.commandId, 'completed');
       return {
         ...result,
@@ -84,9 +90,9 @@ export async function executeBrowserControlCommand(
         observedAt: Date.now(),
       };
     } catch (error) {
-      // A cancellation after dispatch cannot know whether Playwright applied the
-      // action before the abort reached the browser, so durable status is unknown.
-      await finishControlCommand(userId, input.browserSessionId, input.commandId, 'unknown');
+      // A cancellation after admission cannot know whether Playwright applied
+      // the action before the abort reached the browser, so status is unknown.
+      if (admitted) await finishControlCommand(userId, input.browserSessionId, input.commandId, 'unknown');
       throw error;
     } finally {
       signal.removeEventListener('abort', forwardAbort);
@@ -130,7 +136,7 @@ export function controlObservation(
   return {
     browserSessionId,
     browserStatus,
-    currentUrl,
+    currentUrl: sanitizeBrowserUrl(currentUrl),
     controlActor: lease.actor,
     controlEpoch: lease.controlEpoch,
     observedAt: Date.now(),

--- a/server/src/sdk/controlLease.ts
+++ b/server/src/sdk/controlLease.ts
@@ -13,6 +13,7 @@ export type ControlErrorCode =
   | 'control_expired'
   | 'stale_control'
   | 'command_replay'
+  | 'observation_required'
   | 'invalid_control';
 
 export class ControlLeaseError extends Error {
@@ -35,6 +36,8 @@ export interface ControlLeaseResult {
   readonly expiresAt: string;
   readonly heartbeatAt: string;
   readonly existing: boolean;
+  readonly observationEpoch: number;
+  readonly observationReady: boolean;
 }
 
 export interface ControlCommandInput {
@@ -75,6 +78,8 @@ function leaseResult(lease: ControlLease, existing: boolean): ControlLeaseResult
     expiresAt: lease.expiresAt.toISOString(),
     heartbeatAt: lease.heartbeatAt.toISOString(),
     existing,
+    observationEpoch: lease.controlEpoch,
+    observationReady: lease.observationReady,
   };
 }
 
@@ -121,6 +126,7 @@ export async function acquireControl(
         expiresAt,
         heartbeatAt: now,
         active: true,
+        observationReady: normalized.actor === 'agent' ? false : true,
       }, { transaction });
       return leaseResult(current, false);
     }
@@ -133,6 +139,7 @@ export async function acquireControl(
         expiresAt,
         heartbeatAt: now,
         active: true,
+        observationReady: normalized.actor === 'agent' ? false : true,
       }, { transaction });
       return leaseResult(current, false);
     }
@@ -145,6 +152,7 @@ export async function acquireControl(
       actor: normalized.actor,
       controlEpoch: 1,
       active: true,
+      observationReady: true,
       expiresAt,
       heartbeatAt: now,
     }, { transaction });
@@ -178,7 +186,43 @@ export async function requireControlLease(
       actor: current.actor,
     });
   }
+  if (normalized.actor === 'agent' && !current.observationReady) {
+    throw new ControlLeaseError('observation_required', 'A fresh browser observation is required before agent control resumes', {
+      controlEpoch: current.controlEpoch,
+      actor: current.actor,
+    });
+  }
   return leaseResult(current, true);
+}
+
+/** Mark the post-handoff full snapshot as the current agent observation. */
+export async function acknowledgeControlObservation(
+  userId: number,
+  input: { browserSessionId: unknown; ownerSessionId: unknown; actor: unknown; controlEpoch: unknown },
+): Promise<ControlLeaseResult> {
+  const normalized = normalizeLeaseInput(input);
+  const controlEpoch = assertEpoch(input.controlEpoch);
+  if (normalized.actor !== 'agent') throw new ControlLeaseError('invalid_control', 'Only agent control can acknowledge an observation');
+  await requireResourceClaim(userId, {
+    resourceType: 'browser',
+    resourceId: normalized.browserSessionId,
+    ownerSessionId: normalized.ownerSessionId,
+  });
+  return sequelize.transaction(async transaction => {
+    const lease = await ControlLease.findOne({
+      where: { userId, browserSessionId: normalized.browserSessionId },
+      transaction,
+      lock: transaction.LOCK.UPDATE,
+    });
+    if (!lease || !lease.active || lease.ownerSessionId !== normalized.ownerSessionId || lease.actor !== 'agent' || lease.controlEpoch !== controlEpoch) {
+      throw new ControlLeaseError('stale_control', 'Control observation acknowledgement is stale', {
+        controlEpoch: lease?.controlEpoch,
+        actor: lease?.actor,
+      });
+    }
+    await lease.update({ observationReady: true }, { transaction });
+    return leaseResult(lease, true);
+  });
 }
 
 /** Extend a live lease without changing its epoch. */

--- a/server/src/sdk/controlLease.ts
+++ b/server/src/sdk/controlLease.ts
@@ -1,0 +1,295 @@
+import { UniqueConstraintError } from 'sequelize';
+import { v4 as uuid } from 'uuid';
+import sequelize from '../storage/db';
+import ControlCommand, { type ControlCommandMode, type ControlCommandStatus } from '../models/ControlCommand';
+import ControlLease, { type ControlActor } from '../models/ControlLease';
+import { requireResourceClaim } from './resourceClaims';
+
+export type { ControlActor } from '../models/ControlLease';
+
+export type ControlErrorCode =
+  | 'control_conflict'
+  | 'control_not_found'
+  | 'control_expired'
+  | 'stale_control'
+  | 'command_replay'
+  | 'invalid_control';
+
+export class ControlLeaseError extends Error {
+  public constructor(
+    public readonly code: ControlErrorCode,
+    message: string,
+    public readonly details?: { controlEpoch?: number; actor?: ControlActor; commandId?: string },
+  ) {
+    super(message);
+    this.name = 'ControlLeaseError';
+  }
+}
+
+export interface ControlLeaseResult {
+  readonly browserSessionId: string;
+  readonly ownerSessionId: string;
+  readonly actor: ControlActor;
+  readonly controlEpoch: number;
+  readonly active: boolean;
+  readonly expiresAt: string;
+  readonly heartbeatAt: string;
+  readonly existing: boolean;
+}
+
+export interface ControlCommandInput {
+  readonly browserSessionId: string;
+  readonly ownerSessionId: string;
+  readonly actor: ControlActor;
+  readonly controlEpoch: number;
+  readonly commandId: string;
+  readonly commandType: string;
+  readonly mode: ControlCommandMode;
+}
+
+const CONTROL_LEASE_TTL_MS = 10 * 60 * 1000;
+
+const validActor = (value: unknown): value is ControlActor => value === 'agent' || value === 'human';
+const validMode = (value: unknown): value is ControlCommandMode => value === 'assist' || value === 'record';
+
+function normalizeLeaseInput(input: {
+  browserSessionId: unknown;
+  ownerSessionId: unknown;
+  actor: unknown;
+}): { browserSessionId: string; ownerSessionId: string; actor: ControlActor } {
+  const browserSessionId = typeof input.browserSessionId === 'string' ? input.browserSessionId.trim() : '';
+  const ownerSessionId = typeof input.ownerSessionId === 'string' ? input.ownerSessionId.trim() : '';
+  if (!browserSessionId || !ownerSessionId || !validActor(input.actor)) {
+    throw new ControlLeaseError('invalid_control', 'browserSessionId, ownerSessionId, and actor are required');
+  }
+  return { browserSessionId, ownerSessionId, actor: input.actor };
+}
+
+function leaseResult(lease: ControlLease, existing: boolean): ControlLeaseResult {
+  return {
+    browserSessionId: lease.browserSessionId,
+    ownerSessionId: lease.ownerSessionId,
+    actor: lease.actor,
+    controlEpoch: lease.controlEpoch,
+    active: lease.active,
+    expiresAt: lease.expiresAt.toISOString(),
+    heartbeatAt: lease.heartbeatAt.toISOString(),
+    existing,
+  };
+}
+
+function assertEpoch(epoch: unknown): number {
+  if (!Number.isSafeInteger(epoch) || Number(epoch) < 1) {
+    throw new ControlLeaseError('invalid_control', 'controlEpoch must be a positive integer');
+  }
+  return Number(epoch);
+}
+
+/** Acquire or transition the control lease. Resource ownership is checked first. */
+export async function acquireControl(
+  userId: number,
+  input: { browserSessionId: unknown; ownerSessionId: unknown; actor: unknown },
+): Promise<ControlLeaseResult> {
+  const normalized = normalizeLeaseInput(input);
+  await requireResourceClaim(userId, {
+    resourceType: 'browser',
+    resourceId: normalized.browserSessionId,
+    ownerSessionId: normalized.ownerSessionId,
+  });
+
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + CONTROL_LEASE_TTL_MS);
+  return sequelize.transaction(async transaction => {
+    const current = await ControlLease.findOne({
+      where: { userId, browserSessionId: normalized.browserSessionId },
+      transaction,
+      lock: transaction.LOCK.UPDATE,
+    });
+
+    if (current?.active && current.expiresAt.getTime() > now.getTime()) {
+      if (current.ownerSessionId !== normalized.ownerSessionId) {
+        throw new ControlLeaseError('control_conflict', 'Maxun browser control is owned by another Harness session', {
+          controlEpoch: current.controlEpoch,
+          actor: current.actor,
+        });
+      }
+      if (current.actor === normalized.actor) return leaseResult(current, true);
+
+      await current.update({
+        actor: normalized.actor,
+        controlEpoch: current.controlEpoch + 1,
+        expiresAt,
+        heartbeatAt: now,
+        active: true,
+      }, { transaction });
+      return leaseResult(current, false);
+    }
+
+    if (current) {
+      await current.update({
+        ownerSessionId: normalized.ownerSessionId,
+        actor: normalized.actor,
+        controlEpoch: current.controlEpoch + 1,
+        expiresAt,
+        heartbeatAt: now,
+        active: true,
+      }, { transaction });
+      return leaseResult(current, false);
+    }
+
+    const created = await ControlLease.create({
+      id: uuid(),
+      userId,
+      browserSessionId: normalized.browserSessionId,
+      ownerSessionId: normalized.ownerSessionId,
+      actor: normalized.actor,
+      controlEpoch: 1,
+      active: true,
+      expiresAt,
+      heartbeatAt: now,
+    }, { transaction });
+    return leaseResult(created, false);
+  });
+}
+
+/** Require the currently active actor and epoch, failing closed on expiry. */
+export async function requireControlLease(
+  userId: number,
+  input: { browserSessionId: unknown; ownerSessionId: unknown; actor: unknown; controlEpoch: unknown },
+): Promise<ControlLeaseResult> {
+  const normalized = normalizeLeaseInput(input);
+  const controlEpoch = assertEpoch(input.controlEpoch);
+  await requireResourceClaim(userId, {
+    resourceType: 'browser',
+    resourceId: normalized.browserSessionId,
+    ownerSessionId: normalized.ownerSessionId,
+  });
+  const current = await ControlLease.findOne({ where: { userId, browserSessionId: normalized.browserSessionId } });
+  if (!current || !current.active) {
+    throw new ControlLeaseError('control_not_found', 'Maxun browser has no active control lease');
+  }
+  if (current.expiresAt.getTime() <= Date.now()) {
+    await current.update({ active: false, controlEpoch: current.controlEpoch + 1 });
+    throw new ControlLeaseError('control_expired', 'Maxun browser control lease has expired', { controlEpoch: current.controlEpoch });
+  }
+  if (current.ownerSessionId !== normalized.ownerSessionId || current.actor !== normalized.actor || current.controlEpoch !== controlEpoch) {
+    throw new ControlLeaseError('stale_control', 'Maxun browser control lease is stale or owned by another actor', {
+      controlEpoch: current.controlEpoch,
+      actor: current.actor,
+    });
+  }
+  return leaseResult(current, true);
+}
+
+/** Extend a live lease without changing its epoch. */
+export async function heartbeatControl(
+  userId: number,
+  input: { browserSessionId: unknown; ownerSessionId: unknown; actor: unknown; controlEpoch: unknown },
+): Promise<ControlLeaseResult> {
+  const normalized = normalizeLeaseInput(input);
+  const controlEpoch = assertEpoch(input.controlEpoch);
+  await requireResourceClaim(userId, {
+    resourceType: 'browser',
+    resourceId: normalized.browserSessionId,
+    ownerSessionId: normalized.ownerSessionId,
+  });
+  const now = new Date();
+  const lease = await ControlLease.findOne({ where: { userId, browserSessionId: normalized.browserSessionId } });
+  if (!lease || !lease.active || lease.ownerSessionId !== normalized.ownerSessionId || lease.actor !== normalized.actor || lease.controlEpoch !== controlEpoch) {
+    throw new ControlLeaseError('stale_control', 'Maxun browser control lease is stale or owned by another actor', {
+      controlEpoch: lease?.controlEpoch,
+      actor: lease?.actor,
+    });
+  }
+  if (lease.expiresAt.getTime() <= now.getTime()) {
+    await lease.update({ active: false, controlEpoch: lease.controlEpoch + 1 });
+    throw new ControlLeaseError('control_expired', 'Maxun browser control lease has expired', { controlEpoch: lease.controlEpoch });
+  }
+  await lease.update({ heartbeatAt: now, expiresAt: new Date(now.getTime() + CONTROL_LEASE_TTL_MS) });
+  return leaseResult(lease, true);
+}
+
+/** Release a lease and advance its epoch so queued commands cannot apply. */
+export async function releaseControl(
+  userId: number,
+  input: { browserSessionId: unknown; ownerSessionId: unknown; actor: unknown; controlEpoch: unknown },
+): Promise<{ controlEpoch: number }> {
+  const normalized = normalizeLeaseInput(input);
+  const controlEpoch = assertEpoch(input.controlEpoch);
+  return sequelize.transaction(async transaction => {
+    const lease = await ControlLease.findOne({
+      where: { userId, browserSessionId: normalized.browserSessionId },
+      transaction,
+      lock: transaction.LOCK.UPDATE,
+    });
+    if (!lease || !lease.active) return { controlEpoch: lease?.controlEpoch ?? controlEpoch + 1 };
+    if (lease.ownerSessionId !== normalized.ownerSessionId || lease.actor !== normalized.actor || lease.controlEpoch !== controlEpoch) {
+      throw new ControlLeaseError('stale_control', 'Maxun browser control lease is stale or owned by another actor', {
+        controlEpoch: lease.controlEpoch,
+        actor: lease.actor,
+      });
+    }
+    const nextEpoch = lease.controlEpoch + 1;
+    await lease.update({ active: false, controlEpoch: nextEpoch, heartbeatAt: new Date() }, { transaction });
+    return { controlEpoch: nextEpoch };
+  });
+}
+
+/** Record one command identity before executing it, rejecting replays atomically. */
+export async function beginControlCommand(userId: number, input: ControlCommandInput): Promise<void> {
+  if (!input.commandId.trim() || !input.commandType.trim() || !validMode(input.mode)) {
+    throw new ControlLeaseError('invalid_control', 'commandId, commandType, and mode are required');
+  }
+  await requireControlLease(userId, input);
+  try {
+    await ControlCommand.create({
+      id: uuid(),
+      userId,
+      browserSessionId: input.browserSessionId,
+      ownerSessionId: input.ownerSessionId,
+      actor: input.actor,
+      controlEpoch: input.controlEpoch,
+      commandId: input.commandId.trim(),
+      commandType: input.commandType.trim(),
+      mode: input.mode,
+      status: 'running',
+    });
+  } catch (error) {
+    if (error instanceof UniqueConstraintError) {
+      throw new ControlLeaseError('command_replay', 'This control command has already been accepted', { commandId: input.commandId });
+    }
+    throw error;
+  }
+}
+
+export async function getControlCommandStatus(
+  userId: number,
+  input: { browserSessionId: string; ownerSessionId: string; actor: ControlActor; controlEpoch: number; commandId: string },
+): Promise<{ commandId: string; status: ControlCommandStatus; controlEpoch: number; commandType: string } | null> {
+  await requireControlLease(userId, input);
+  const command = await ControlCommand.findOne({ where: {
+    userId,
+    browserSessionId: input.browserSessionId,
+    commandId: input.commandId,
+  } });
+  if (!command) return null;
+  return {
+    commandId: command.commandId,
+    status: command.status,
+    controlEpoch: command.controlEpoch,
+    commandType: command.commandType,
+  };
+}
+
+export async function finishControlCommand(
+  userId: number,
+  browserSessionId: string,
+  commandId: string,
+  status: Exclude<ControlCommandStatus, 'running'>,
+): Promise<void> {
+  const command = await ControlCommand.findOne({ where: { userId, browserSessionId, commandId } });
+  if (!command) return;
+  await command.update({ status, finishedAt: new Date() });
+}
+
+export const CONTROL_LEASE_TTL_SECONDS = CONTROL_LEASE_TTL_MS / 1000;

--- a/server/src/sdk/llmRobot.ts
+++ b/server/src/sdk/llmRobot.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from 'uuid';
-import { Op } from 'sequelize';
+import { Op, type Transaction } from 'sequelize';
 import Robot from '../models/Robot';
 import sequelizeInstance from '../storage/db';
 import logger from '../logger';
@@ -119,7 +119,7 @@ export const normalizeWorkflowUrls = (workflow: any[] = []): any[] =>
       : pair?.what,
   }));
 
-export const findExistingRobotByName = async (name: string, userId: number | string): Promise<Robot | null> => Robot.findOne({
+export const findExistingRobotByName = async (name: string, userId: number | string, transaction?: Transaction): Promise<Robot | null> => Robot.findOne({
   where: {
     userId,
     [Op.and]: sequelizeInstance.where(
@@ -127,6 +127,7 @@ export const findExistingRobotByName = async (name: string, userId: number | str
       name.trim(),
     ),
   } as any,
+  ...(transaction ? { transaction } : {}),
 });
 
 const getListAction = (workflow: any[]): any | null => workflow
@@ -154,6 +155,7 @@ export interface PersistNativeRobotOptions {
   workflow: any[];
   isLLM?: boolean;
   prompt?: string;
+  transaction?: Transaction;
 }
 
 /**
@@ -166,7 +168,7 @@ export async function persistNativeRobot(options: PersistNativeRobotOptions): Pr
   const workflow = normalizeWorkflowUrls(options.workflow);
   const description = options.description?.trim() || undefined;
   const name = options.robotName?.trim() || 'Recorder Draft';
-  const existingRobot = await findExistingRobotByName(name, options.userId);
+  const existingRobot = await findExistingRobotByName(name, options.userId, options.transaction);
 
   if (existingRobot) {
     const meta = existingRobot.recording_meta;
@@ -182,7 +184,7 @@ export async function persistNativeRobot(options: PersistNativeRobotOptions): Pr
           pairs: workflow.length,
           updatedAt: now,
         },
-      });
+      }, options.transaction ? { transaction: options.transaction } : undefined);
       return {
         robot: existingRobot,
         workflow,
@@ -210,7 +212,7 @@ export async function persistNativeRobot(options: PersistNativeRobotOptions): Pr
       status: 'ready',
     },
     recording: { workflow },
-  });
+  }, options.transaction ? { transaction: options.transaction } : undefined);
 
   logger.info(`[SDK] Persistent native robot created: ${metaId}`);
   capture(options.isLLM ? 'maxun-oss-llm-robot-created' : 'maxun-oss-recorder-draft-compiled', {

--- a/server/src/sdk/llmRobot.ts
+++ b/server/src/sdk/llmRobot.ts
@@ -173,9 +173,19 @@ export async function persistNativeRobot(options: PersistNativeRobotOptions): Pr
     const sameDescription = description === undefined || (meta as any).description === description;
     const sameUrl = normalizeUrl(meta.url || '') === normalizeUrl(url);
     if (sameDescription && sameUrl) {
+      const now = new Date().toISOString();
+      await existingRobot.update({
+        recording: { workflow },
+        recording_meta: {
+          ...meta,
+          name,
+          pairs: workflow.length,
+          updatedAt: now,
+        },
+      });
       return {
         robot: existingRobot,
-        workflow: existingRobot.recording?.workflow || [],
+        workflow,
         existing: true,
       };
     }

--- a/server/src/sdk/llmRobot.ts
+++ b/server/src/sdk/llmRobot.ts
@@ -1,0 +1,250 @@
+import { v4 as uuid } from 'uuid';
+import { Op } from 'sequelize';
+import Robot from '../models/Robot';
+import sequelizeInstance from '../storage/db';
+import logger from '../logger';
+import { capture } from '../utils/analytics';
+import { LLMConfig } from './browserAgent';
+import { WorkflowEnricher } from './workflowEnricher';
+
+export type LlmRobotErrorCode =
+  | 'invalid_url'
+  | 'workflow_generation_failed'
+  | 'robot_name_conflict';
+
+export class LlmRobotError extends Error {
+  public constructor(
+    public readonly code: LlmRobotErrorCode,
+    message: string,
+    public readonly details?: string[],
+  ) {
+    super(message);
+    this.name = 'LlmRobotError';
+  }
+}
+
+export interface CreateLlmRobotOptions {
+  url: string;
+  prompt: string;
+  userId: number | string;
+  robotName?: string;
+  llmConfig: LLMConfig;
+}
+
+export interface CreatedLlmRobot {
+  robot: Robot;
+  workflow: any[];
+  existing: boolean;
+}
+
+export interface ListWorkflowSummary {
+  fields: string[];
+  pagination: Record<string, unknown> | null;
+  limit: number | null;
+}
+
+const normalizeUrl = (raw: string): string => {
+  try {
+    const url = new URL(raw);
+    url.search = url.searchParams.toString();
+    return `${url.protocol}//${url.host.toLowerCase()}${url.pathname.replace(/\/$/, '')}${url.search}`;
+  } catch {
+    return raw.toLowerCase().trim();
+  }
+};
+
+export const normalizeRobotUrl = (rawUrl: string): string => {
+  let url: URL;
+  try {
+    url = new URL(rawUrl.trim());
+  } catch {
+    throw new LlmRobotError('invalid_url', 'Invalid URL format');
+  }
+
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new LlmRobotError('invalid_url', 'Only http and https URLs are supported');
+  }
+
+  const hostname = url.hostname;
+  const isPlausibleHost = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(hostname)
+    || hostname === 'localhost'
+    || /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)
+    || /^\[[0-9a-f:]+\]$/i.test(hostname);
+  if (!isPlausibleHost) {
+    throw new LlmRobotError('invalid_url', 'URL hostname is not reachable');
+  }
+
+  url.search = url.searchParams.toString();
+  return url.toString();
+};
+
+export const normalizeWorkflowUrls = (workflow: any[] = []): any[] =>
+  workflow.map((pair: any) => ({
+    ...pair,
+    where: pair?.where
+      ? {
+          ...pair.where,
+          ...(typeof pair.where.url === 'string' && pair.where.url !== 'about:blank'
+            ? { url: normalizeRobotUrl(pair.where.url) }
+            : {}),
+        }
+      : pair?.where,
+    what: Array.isArray(pair?.what)
+      ? pair.what.map((action: any) => {
+          if (
+            action.action === 'goto'
+            && Array.isArray(action.args)
+            && typeof action.args[0] === 'string'
+            && action.args[0] !== 'about:blank'
+          ) {
+            return { ...action, args: [normalizeRobotUrl(action.args[0]), ...action.args.slice(1)] };
+          }
+
+          if (
+            (action.action === 'scrape' || action.action === 'crawl')
+            && Array.isArray(action.args)
+            && action.args[0]
+            && typeof action.args[0] === 'object'
+            && typeof action.args[0].url === 'string'
+            && action.args[0].url !== 'about:blank'
+          ) {
+            return {
+              ...action,
+              args: [{ ...action.args[0], url: normalizeRobotUrl(action.args[0].url) }, ...action.args.slice(1)],
+            };
+          }
+
+          return action;
+        })
+      : pair?.what,
+  }));
+
+export const findExistingRobotByName = async (name: string, userId: number | string): Promise<Robot | null> => Robot.findOne({
+  where: {
+    userId,
+    [Op.and]: sequelizeInstance.where(
+      sequelizeInstance.fn('trim', sequelizeInstance.literal("recording_meta->>'name'")),
+      name.trim(),
+    ),
+  } as any,
+});
+
+const getListAction = (workflow: any[]): any | null => workflow
+  .flatMap(pair => pair?.what || [])
+  .find(action => action?.action === 'scrapeList') || null;
+
+export const summarizeListWorkflow = (workflow: any[]): ListWorkflowSummary => {
+  const listAction = getListAction(workflow);
+  const config = listAction?.args?.[0];
+  const fields = config?.fields && typeof config.fields === 'object'
+    ? Object.keys(config.fields)
+    : [];
+  const pagination = config?.pagination && typeof config.pagination === 'object'
+    ? config.pagination as Record<string, unknown>
+    : null;
+  const limit = typeof config?.limit === 'number' ? config.limit : null;
+  return { fields, pagination, limit };
+};
+
+export interface PersistNativeRobotOptions {
+  url: string;
+  userId: number | string;
+  robotName?: string;
+  description?: string;
+  workflow: any[];
+  isLLM?: boolean;
+  prompt?: string;
+}
+
+/**
+ * Persist a workflow using Maxun's normal native robot record shape.
+ * Both the Goal-1 one-shot seam and the semantic Recorder Draft compiler use
+ * this helper so persistence stays in one server-owned path.
+ */
+export async function persistNativeRobot(options: PersistNativeRobotOptions): Promise<CreatedLlmRobot> {
+  const url = normalizeRobotUrl(options.url);
+  const workflow = normalizeWorkflowUrls(options.workflow);
+  const description = options.description?.trim() || undefined;
+  const name = options.robotName?.trim() || 'Recorder Draft';
+  const existingRobot = await findExistingRobotByName(name, options.userId);
+
+  if (existingRobot) {
+    const meta = existingRobot.recording_meta;
+    const sameDescription = description === undefined || (meta as any).description === description;
+    const sameUrl = normalizeUrl(meta.url || '') === normalizeUrl(url);
+    if (sameDescription && sameUrl) {
+      return {
+        robot: existingRobot,
+        workflow: existingRobot.recording?.workflow || [],
+        existing: true,
+      };
+    }
+    throw new LlmRobotError('robot_name_conflict', `A robot named "${name}" already exists with a different configuration`);
+  }
+
+  const metaId = uuid();
+  const robot = await Robot.create({
+    id: uuid(),
+    userId: Number(options.userId),
+    recording_meta: {
+      name,
+      id: metaId,
+      ...(description ? { description } : {}),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      pairs: workflow.length,
+      params: [],
+      type: 'extract',
+      url,
+      isLLM: options.isLLM ?? false,
+      status: 'ready',
+    },
+    recording: { workflow },
+  });
+
+  logger.info(`[SDK] Persistent native robot created: ${metaId}`);
+  capture(options.isLLM ? 'maxun-oss-llm-robot-created' : 'maxun-oss-recorder-draft-compiled', {
+    robot_meta: robot.recording_meta,
+    recording: robot.recording,
+    ...(options.prompt ? { prompt: options.prompt } : {}),
+  });
+
+  return { robot, workflow, existing: false };
+}
+
+export async function createLlmRobot(options: CreateLlmRobotOptions): Promise<CreatedLlmRobot> {
+  const url = normalizeRobotUrl(options.url);
+  const prompt = options.prompt.trim();
+  const name = options.robotName?.trim() || `LLM Extract: ${prompt.substring(0, 50)}`;
+
+  const workflowResult = await WorkflowEnricher.generateWorkflowFromPrompt(
+    url,
+    prompt,
+    String(options.userId),
+    options.llmConfig,
+  );
+  if (!workflowResult.success || !workflowResult.workflow) {
+    throw new LlmRobotError(
+      'workflow_generation_failed',
+      'Failed to generate workflow from prompt',
+      workflowResult.errors,
+    );
+  }
+
+  return persistNativeRobot({
+    url,
+    userId: options.userId,
+    robotName: name,
+    description: prompt,
+    workflow: workflowResult.workflow,
+    isLLM: true,
+    prompt,
+  });
+}
+
+export const getTrustedAgentLlmConfig = (): LLMConfig => ({
+  provider: (process.env.MAXUN_AGENT_LLM_PROVIDER || 'openai') as LLMConfig['provider'],
+  model: process.env.MAXUN_AGENT_LLM_MODEL,
+  apiKey: process.env.MAXUN_AGENT_LLM_API_KEY || process.env.OPENCODE_API_KEY || process.env.OPENAI_API_KEY,
+  baseUrl: process.env.MAXUN_AGENT_LLM_BASE_URL || process.env.OPENAI_BASE_URL,
+});

--- a/server/src/sdk/recorderDraft.ts
+++ b/server/src/sdk/recorderDraft.ts
@@ -1,0 +1,544 @@
+import { Page } from 'playwright-core';
+import { v4 as uuid } from 'uuid';
+import RecorderDraft, {
+  DraftFieldState,
+  DraftListState,
+  RecorderDraftState,
+} from '../models/RecorderDraft';
+import Robot from '../models/Robot';
+import { createRemoteBrowserForValidation, destroyRemoteBrowser } from '../browser-management/controller';
+import { SelectorValidator } from './selectorValidator';
+import { normalizeRobotUrl, persistNativeRobot } from './llmRobot';
+import logger from '../logger';
+
+const MAX_DISCOVERY_LISTS = 12;
+const MAX_PREVIEW_PAGES = 10;
+const DEFAULT_PREVIEW_LIMIT = 100;
+const MIN_FIELD_COVERAGE = 0.8;
+
+type ValidationScope = 'current-page' | 'multi-page';
+type FieldOperation = 'include' | 'exclude' | 'rename';
+
+export type RecorderDraftErrorCode =
+  | 'draft_not_found'
+  | 'invalid_request'
+  | 'list_not_selected'
+  | 'candidate_not_found'
+  | 'field_not_found'
+  | 'validation_failed'
+  | 'robot_name_conflict';
+
+export class RecorderDraftError extends Error {
+  public constructor(
+    public readonly code: RecorderDraftErrorCode,
+    message: string,
+    public readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = 'RecorderDraftError';
+  }
+}
+
+interface DiscoveredGroup {
+  xpath?: string;
+  count?: number;
+  sampleTexts?: string[];
+  semanticParent?: string;
+  fingerprint?: { tagName?: string; attributes?: string };
+  isNavOrFooter?: boolean;
+  ariaRole?: string | null;
+}
+
+interface PreviewResult {
+  rows: Record<string, string>[];
+  diagnostics: Array<Record<string, unknown>>;
+  pagesVisited: number;
+  truncated: boolean;
+}
+
+interface DraftValidationResult {
+  valid: boolean;
+  scope: ValidationScope;
+  diagnostics: Array<Record<string, unknown>>;
+  coverage: Record<string, number>;
+  pagesVisited: number;
+}
+
+const cloneState = (state: RecorderDraftState): RecorderDraftState => JSON.parse(JSON.stringify(state));
+
+const normalizeAttributes = (raw: string | undefined): string[] => (raw || '')
+  .split('|')
+  .map(value => value.trim())
+  .filter(Boolean)
+  .slice(0, 20);
+
+const textValue = (element: Element | null, attribute: string): string => {
+  if (!element) return '';
+  if (attribute !== 'innerText' && attribute !== 'textContent') return element.getAttribute(attribute) || '';
+  return ((element as HTMLElement).innerText || element.textContent || '').trim();
+};
+
+/** Extract list rows while keeping selectors inside this server-side operation. */
+const extractRows = async (
+  page: Page,
+  listSelector: string,
+  fields: DraftFieldState[],
+  limit: number,
+): Promise<Record<string, string>[]> => page.evaluate(({ listSelector: listSel, fields: fieldDefs, limit: rowLimit }) => {
+  const evaluateSelector = (selector: string, context: Document | Element = document): Element[] => {
+    try {
+      const isXPath = selector.startsWith('//') || selector.startsWith('(//') || selector.startsWith('/');
+      if (isXPath) {
+        const result = document.evaluate(selector, context, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+        return Array.from({ length: result.snapshotLength }, (_, index) => result.snapshotItem(index) as Element).filter(Boolean);
+      }
+      return Array.from(context.querySelectorAll(selector));
+    } catch {
+      return [];
+    }
+  };
+
+  const readValue = (element: Element | null, attribute: string): string => {
+    if (!element) return '';
+    if (attribute !== 'innerText' && attribute !== 'textContent') return element.getAttribute(attribute) || '';
+    return (((element as HTMLElement).innerText || element.textContent || '') as string).trim();
+  };
+
+  const items = evaluateSelector(listSel).slice(0, rowLimit);
+  const rows: Record<string, string>[] = [];
+  for (let index = 0; index < items.length; index++) {
+    const row: Record<string, string> = {};
+    for (const field of fieldDefs) {
+      const isXPath = field.selector.startsWith('//') || field.selector.startsWith('(//') || field.selector.startsWith('/');
+      const matches = isXPath ? evaluateSelector(field.selector) : evaluateSelector(field.selector, items[index]);
+      row[field.label] = readValue(matches[index] || matches[0] || null, field.attribute);
+    }
+    rows.push(row);
+  }
+  return rows;
+}, { listSelector, fields, limit });
+
+const withValidationPage = async <T>(
+  userId: string,
+  url: string,
+  operation: (page: Page, validator: SelectorValidator) => Promise<T>,
+): Promise<T> => {
+  let browserId: string | null = null;
+  const validator = new SelectorValidator();
+  try {
+    const created = await createRemoteBrowserForValidation(userId);
+    browserId = created.browserId;
+    await validator.initialize(created.page, url);
+    return await operation(created.page, validator);
+  } finally {
+    await validator.close();
+    if (browserId) {
+      try {
+        await destroyRemoteBrowser(browserId, userId);
+      } catch (error: any) {
+        logger.warn(`[RecorderDraft] Failed to clean up validation browser: ${error.message}`);
+      }
+    }
+  }
+};
+
+const getListState = (state: RecorderDraftState): DraftListState => {
+  const list = state.lists.find(candidate => candidate.id === state.selectedListId);
+  if (!list) throw new RecorderDraftError('list_not_selected', 'Select a list candidate before continuing');
+  return list;
+};
+
+const includedFields = (list: DraftListState): DraftFieldState[] => list.fields.filter(field => field.included);
+
+const publicField = (field: DraftFieldState) => ({
+  id: field.id,
+  sourceLabel: field.sourceLabel,
+  label: field.label,
+  attribute: field.attribute,
+  tag: field.tag,
+  isShadow: field.isShadow,
+  samples: field.samples,
+  included: field.included,
+});
+
+const publicList = (list: DraftListState, selected: boolean) => ({
+  id: list.id,
+  tag: list.tag,
+  count: list.count,
+  semanticParent: list.semanticParent,
+  sampleTexts: list.sampleTexts,
+  attributes: list.attributes,
+  fields: list.fields.map(publicField),
+  pagination: {
+    type: list.pagination.type || 'none',
+    tested: list.pagination.tested,
+  },
+  selected,
+});
+
+export const serializeRecorderDraft = (draft: RecorderDraft) => {
+  const state = draft.state;
+  return {
+    id: draft.id,
+    name: draft.name,
+    description: draft.description,
+    url: draft.url,
+    status: draft.status,
+    selectedListId: state.selectedListId || null,
+    limit: state.limit ?? null,
+    compiledRobotId: draft.compiledRobotId,
+    lists: state.lists.map(list => publicList(list, list.id === state.selectedListId)),
+    createdAt: draft.createdAt,
+    updatedAt: draft.updatedAt,
+    lastError: draft.lastError,
+  };
+};
+
+const findDraft = async (id: string, userId: number | string): Promise<RecorderDraft> => {
+  const draft = await RecorderDraft.findOne({ where: { id, userId: Number(userId) } });
+  if (!draft) throw new RecorderDraftError('draft_not_found', 'Recorder draft not found');
+  return draft;
+};
+
+const makeFieldSamples = async (page: Page, listSelector: string, fields: DraftFieldState[]): Promise<void> => {
+  const samples = await extractRows(page, listSelector, fields, 3);
+  for (const field of fields) {
+    field.samples = samples.map(row => row[field.label] || '').filter(Boolean).slice(0, 3);
+  }
+};
+
+export async function createRecorderDraft(options: {
+  url: string;
+  userId: number | string;
+  name?: string;
+  description?: string;
+}): Promise<RecorderDraft> {
+  const url = normalizeRobotUrl(options.url);
+  const name = options.name?.trim() || 'Semantic Recorder Draft';
+
+  const state = await withValidationPage(String(options.userId), url, async (page, validator): Promise<RecorderDraftState> => {
+    const groups = (await validator.analyzeElementGroups())
+      .filter((group: DiscoveredGroup) => group.xpath && (group.count || 0) >= 2 && !group.isNavOrFooter)
+      .slice(0, MAX_DISCOVERY_LISTS);
+    const lists: DraftListState[] = [];
+
+    for (const group of groups) {
+      const detected = await validator.autoDetectListFields(group.xpath!);
+      if (!detected.success || !detected.fields || !detected.listSelector) continue;
+
+      const fields: DraftFieldState[] = Object.entries(detected.fields).map(([sourceLabel, value]: [string, any]) => ({
+        id: uuid(),
+        sourceLabel,
+        label: sourceLabel,
+        selector: value.selector,
+        attribute: value.attribute || 'innerText',
+        tag: value.tag || 'UNKNOWN',
+        isShadow: Boolean(value.isShadow),
+        samples: [],
+        included: true,
+      }));
+      if (fields.length === 0) continue;
+
+      await makeFieldSamples(page, detected.listSelector, fields);
+      const pagination = await validator.autoDetectPagination(detected.listSelector);
+      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 100000 }).catch(() => undefined);
+
+      lists.push({
+        id: uuid(),
+        selector: detected.listSelector,
+        tag: group.fingerprint?.tagName || 'unknown',
+        count: group.count || 0,
+        semanticParent: group.semanticParent || 'unknown',
+        sampleTexts: (group.sampleTexts || []).slice(0, 3),
+        attributes: normalizeAttributes(group.fingerprint?.attributes),
+        fields,
+        pagination: {
+          type: pagination.success ? pagination.type || 'none' : 'none',
+          selector: pagination.selector || '',
+          // clickNext detection only confirms that a control exists; preview must
+          // successfully advance a page before the draft reports it as tested.
+          tested: pagination.success && pagination.type !== 'clickNext',
+        },
+      });
+    }
+
+    if (lists.length === 0) {
+      throw new RecorderDraftError('validation_failed', 'No repeated list candidates with extractable fields were found');
+    }
+    return { lists, limit: null };
+  });
+
+  return RecorderDraft.create({
+    userId: Number(options.userId),
+    url,
+    name,
+    description: options.description?.trim() || null,
+    status: 'discovered',
+    state,
+  });
+}
+
+export async function selectRecorderDraftList(id: string, userId: number | string, listCandidateId: string, limit?: number | null): Promise<RecorderDraft> {
+  const draft = await findDraft(id, userId);
+  const state = cloneState(draft.state);
+  if (!state.lists.some(list => list.id === listCandidateId)) {
+    throw new RecorderDraftError('candidate_not_found', 'List candidate not found');
+  }
+  if (limit !== undefined && limit !== null && (!Number.isInteger(limit) || limit < 1 || limit > 10000)) {
+    throw new RecorderDraftError('invalid_request', 'limit must be an integer between 1 and 10000');
+  }
+  state.selectedListId = listCandidateId;
+  if (limit !== undefined) state.limit = limit;
+  await draft.update({ state, status: 'discovered', updatedAt: new Date() });
+  return draft;
+}
+
+export async function updateRecorderDraftField(
+  id: string,
+  userId: number | string,
+  operation: { fieldId: string; action: FieldOperation; name?: string },
+): Promise<RecorderDraft> {
+  const draft = await findDraft(id, userId);
+  const state = cloneState(draft.state);
+  const list = getListState(state);
+  const field = list.fields.find(candidate => candidate.id === operation.fieldId);
+  if (!field) throw new RecorderDraftError('field_not_found', 'Field candidate not found');
+
+  if (operation.action === 'include') field.included = true;
+  else if (operation.action === 'exclude') field.included = false;
+  else {
+    const label = operation.name?.trim();
+    if (!label || label.length > 100) throw new RecorderDraftError('invalid_request', 'A field rename must be 1-100 characters');
+    if (list.fields.some(candidate => candidate.id !== field.id && candidate.label.toLowerCase() === label.toLowerCase())) {
+      throw new RecorderDraftError('invalid_request', `A field named "${label}" already exists`);
+    }
+    field.label = label;
+  }
+
+  if (includedFields(list).length === 0) {
+    throw new RecorderDraftError('invalid_request', 'At least one field must remain included');
+  }
+  await draft.update({ state, status: 'discovered', updatedAt: new Date() });
+  return draft;
+}
+
+export async function updateRecorderDraftOptions(
+  id: string,
+  userId: number | string,
+  options: { limit?: number | null },
+): Promise<RecorderDraft> {
+  const draft = await findDraft(id, userId);
+  if (options.limit !== undefined && options.limit !== null && (!Number.isInteger(options.limit) || options.limit < 1 || options.limit > 10000)) {
+    throw new RecorderDraftError('invalid_request', 'limit must be an integer between 1 and 10000');
+  }
+  const state = cloneState(draft.state);
+  state.limit = options.limit ?? null;
+  await draft.update({ state, updatedAt: new Date() });
+  return draft;
+}
+
+const clickPagination = async (page: Page, list: DraftListState): Promise<boolean> => {
+  if (!list.pagination.type || list.pagination.type === 'none') return false;
+  if (list.pagination.type === 'scrollDown' || list.pagination.type === 'scrollUp') {
+    await page.evaluate((direction) => window.scrollTo(0, direction === 'scrollUp' ? 0 : document.documentElement.scrollHeight), list.pagination.type);
+    await page.waitForTimeout(750);
+    return true;
+  }
+  if (!list.pagination.selector) return false;
+  try {
+    await page.locator(list.pagination.selector).first().click({ timeout: 3000 });
+    await page.waitForLoadState('domcontentloaded', { timeout: 5000 }).catch(() => undefined);
+    await page.waitForTimeout(500);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export async function previewRecorderDraft(
+  id: string,
+  userId: number | string,
+  options: { followPagination?: boolean; limit?: number | null } = {},
+): Promise<PreviewResult> {
+  const draft = await findDraft(id, userId);
+  const list = getListState(draft.state);
+  const fields = includedFields(list);
+  const limit = options.limit ?? draft.state.limit ?? DEFAULT_PREVIEW_LIMIT;
+
+  return withValidationPage(String(userId), draft.url, async page => {
+    const rows: Record<string, string>[] = [];
+    const diagnostics: Array<Record<string, unknown>> = [];
+    const seenStates = new Set<string>();
+    let pagesVisited = 0;
+    let truncated = false;
+    const followPagination = options.followPagination ?? true;
+
+    for (let pageIndex = 0; pageIndex < MAX_PREVIEW_PAGES && rows.length < limit; pageIndex++) {
+      pagesVisited++;
+      const pageRows = await extractRows(page, list.selector, fields, Math.min(limit - rows.length, 100));
+      const signature = JSON.stringify({ url: page.url(), first: pageRows[0], count: pageRows.length });
+      if (seenStates.has(signature)) {
+        diagnostics.push({ code: 'pagination_loop', severity: 'warning', message: 'Pagination returned a page already seen' });
+        break;
+      }
+      seenStates.add(signature);
+      rows.push(...pageRows);
+      if (!followPagination || rows.length >= limit || list.pagination.type === 'none') break;
+      if (!(await clickPagination(page, list))) {
+        diagnostics.push({ code: 'pagination_not_actionable', severity: 'error', message: 'Detected pagination could not be activated' });
+        break;
+      }
+    }
+
+    if (rows.length > limit) {
+      rows.length = limit;
+      truncated = true;
+    }
+    if (pagesVisited >= 2 && list.pagination.type !== 'none' && !list.pagination.tested) {
+      const state = cloneState(draft.state);
+      const selectedList = state.lists.find(candidate => candidate.id === state.selectedListId);
+      if (selectedList) {
+        selectedList.pagination.tested = true;
+        await draft.update({ state, updatedAt: new Date() });
+      }
+    }
+    if (pagesVisited >= MAX_PREVIEW_PAGES && rows.length < limit) {
+      diagnostics.push({ code: 'pagination_page_cap', severity: 'warning', message: `Preview stopped after ${MAX_PREVIEW_PAGES} pages` });
+    }
+    return { rows, diagnostics, pagesVisited, truncated };
+  });
+}
+
+export async function validateRecorderDraft(
+  id: string,
+  userId: number | string,
+  scope: ValidationScope = 'current-page',
+): Promise<DraftValidationResult> {
+  const draft = await findDraft(id, userId);
+  const list = getListState(draft.state);
+  const fields = includedFields(list);
+  if (fields.length === 0) throw new RecorderDraftError('invalid_request', 'At least one field must be included');
+
+  return withValidationPage(String(userId), draft.url, async (page, validator) => {
+    const diagnostics: Array<Record<string, unknown>> = [];
+    const fieldMap = Object.fromEntries(fields.map(field => [field.label, {
+      selector: field.selector,
+      attribute: field.attribute,
+    }]));
+    const selectorResult = await validator.validateListFields({ itemSelector: list.selector, fields: fieldMap });
+    if (!selectorResult.valid) {
+      diagnostics.push({
+        code: 'selector_invalid',
+        severity: 'error',
+        message: 'One or more server-owned selectors no longer match the page',
+        failedFields: selectorResult.errors?.length || 0,
+      });
+    }
+
+    const labelCoverage = await validator.validateFieldFillRates(fieldMap, list.selector);
+    const coverage = Object.fromEntries(fields.map(field => [field.id, labelCoverage[field.label] ?? 0]));
+    for (const field of fields) {
+      const rate = coverage[field.id] ?? 0;
+      if (rate < MIN_FIELD_COVERAGE) {
+        diagnostics.push({ code: 'field_low_coverage', severity: rate === 0 ? 'error' : 'warning', fieldId: field.id, field: field.label, coverage: rate, message: `${field.label} is populated on only ${Math.round(rate * 100)}% of sampled rows` });
+      }
+    }
+
+    if (!list.pagination.tested) {
+      diagnostics.push({ code: 'pagination_not_tested', severity: 'warning', message: 'Pagination detection has not been successfully tested' });
+    }
+
+    let pagesVisited = 1;
+    if (scope === 'multi-page') {
+      const preview = await previewRecorderDraft(id, userId, { followPagination: true, limit: Math.min(draft.state.limit || DEFAULT_PREVIEW_LIMIT, 100) });
+      pagesVisited = preview.pagesVisited;
+      diagnostics.push(...preview.diagnostics);
+      if (list.pagination.type !== 'none' && pagesVisited < 2) {
+        diagnostics.push({ code: 'pagination_not_observed', severity: 'error', message: 'Multi-page validation did not observe a second page' });
+      }
+    }
+
+    const hasErrors = diagnostics.some(diagnostic => diagnostic.severity === 'error');
+    return { valid: !hasErrors, scope, diagnostics, coverage, pagesVisited };
+  });
+}
+
+const compileWorkflow = (draft: RecorderDraft): any[] => {
+  const list = getListState(draft.state);
+  const fields = includedFields(list);
+  if (fields.length === 0) throw new RecorderDraftError('invalid_request', 'At least one field must be included');
+  return [{
+    where: { url: draft.url },
+    what: [
+      { action: 'goto', args: [draft.url] },
+      { action: 'waitForLoadState', args: ['networkidle'] },
+      {
+        action: 'scrapeList',
+        actionId: `draft-${draft.id}-list-${list.id}`,
+        name: list.fields.find(field => field.included)?.label || 'List',
+        args: [{
+          fields: Object.fromEntries(fields.map(field => [field.label, {
+            selector: field.selector,
+            attribute: field.attribute,
+            tag: field.tag,
+            isShadow: field.isShadow,
+          }])),
+          listSelector: list.selector,
+          pagination: {
+            type: list.pagination.type || 'none',
+            selector: list.pagination.selector || '',
+          },
+          limit: draft.state.limit ?? DEFAULT_PREVIEW_LIMIT,
+        }],
+      },
+      { action: 'waitForLoadState', args: ['networkidle'] },
+    ],
+  }];
+};
+
+export async function compileRecorderDraft(
+  id: string,
+  userId: number | string,
+  options: { robotName?: string } = {},
+): Promise<{ draft: RecorderDraft; robot: Robot; workflow: any[]; existing: boolean }> {
+  const draft = await findDraft(id, userId);
+  const validation = await validateRecorderDraft(id, userId, 'current-page');
+  if (!validation.valid) throw new RecorderDraftError('validation_failed', 'Draft validation failed', validation.diagnostics);
+  const workflow = compileWorkflow(draft);
+  const robotName = options.robotName?.trim() || draft.name;
+  let robot: Robot;
+  let existing = false;
+
+  if (draft.compiledRobotId) {
+    const existingRobot = await Robot.findOne({ where: { userId: Number(userId), 'recording_meta.id': draft.compiledRobotId } });
+    if (existingRobot) {
+      await existingRobot.update({
+        recording: { workflow },
+        recording_meta: {
+          ...existingRobot.recording_meta,
+          name: robotName,
+          pairs: workflow.length,
+          updatedAt: new Date().toISOString(),
+        },
+      });
+      robot = existingRobot;
+      existing = true;
+    } else {
+      draft.compiledRobotId = null;
+      await draft.save();
+      const persisted = await persistNativeRobot({ url: draft.url, userId, robotName, description: `Recorder Draft ${draft.id}`, workflow });
+      robot = persisted.robot;
+      existing = persisted.existing;
+    }
+  } else {
+    const persisted = await persistNativeRobot({ url: draft.url, userId, robotName, description: `Recorder Draft ${draft.id}`, workflow });
+    robot = persisted.robot;
+    existing = persisted.existing;
+  }
+
+  draft.compiledRobotId = robot.recording_meta.id;
+  draft.status = 'compiled';
+  draft.lastError = null;
+  await draft.save();
+  return { draft, robot, workflow, existing };
+}

--- a/server/src/sdk/recorderDraft.ts
+++ b/server/src/sdk/recorderDraft.ts
@@ -1,5 +1,6 @@
 import { Page } from 'playwright-core';
 import { v4 as uuid } from 'uuid';
+import sequelize from '../storage/db';
 import RecorderDraft, {
   DraftFieldState,
   DraftListState,
@@ -506,39 +507,60 @@ export async function compileRecorderDraft(
   if (!validation.valid) throw new RecorderDraftError('validation_failed', 'Draft validation failed', validation.diagnostics);
   const workflow = compileWorkflow(draft);
   const robotName = options.robotName?.trim() || draft.name;
-  let robot: Robot;
-  let existing = false;
+  return sequelize.transaction(async transaction => {
+    await draft.reload({ transaction, lock: transaction.LOCK.UPDATE });
+    let robot: Robot;
+    let existing = false;
 
-  if (draft.compiledRobotId) {
-    const existingRobot = await Robot.findOne({ where: { userId: Number(userId), 'recording_meta.id': draft.compiledRobotId } });
-    if (existingRobot) {
-      await existingRobot.update({
-        recording: { workflow },
-        recording_meta: {
-          ...existingRobot.recording_meta,
-          name: robotName,
-          pairs: workflow.length,
-          updatedAt: new Date().toISOString(),
-        },
+    if (draft.compiledRobotId) {
+      const existingRobot = await Robot.findOne({
+        where: { userId: Number(userId), 'recording_meta.id': draft.compiledRobotId },
+        transaction,
+        lock: transaction.LOCK.UPDATE,
       });
-      robot = existingRobot;
-      existing = true;
+      if (existingRobot) {
+        await existingRobot.update({
+          recording: { workflow },
+          recording_meta: {
+            ...existingRobot.recording_meta,
+            name: robotName,
+            pairs: workflow.length,
+            updatedAt: new Date().toISOString(),
+          },
+        }, { transaction });
+        robot = existingRobot;
+        existing = true;
+      } else {
+        draft.compiledRobotId = null;
+        await draft.save({ transaction });
+        const persisted = await persistNativeRobot({
+          url: draft.url,
+          userId,
+          robotName,
+          description: `Recorder Draft ${draft.id}`,
+          workflow,
+          transaction,
+        });
+        robot = persisted.robot;
+        existing = persisted.existing;
+      }
     } else {
-      draft.compiledRobotId = null;
-      await draft.save();
-      const persisted = await persistNativeRobot({ url: draft.url, userId, robotName, description: `Recorder Draft ${draft.id}`, workflow });
+      const persisted = await persistNativeRobot({
+        url: draft.url,
+        userId,
+        robotName,
+        description: `Recorder Draft ${draft.id}`,
+        workflow,
+        transaction,
+      });
       robot = persisted.robot;
       existing = persisted.existing;
     }
-  } else {
-    const persisted = await persistNativeRobot({ url: draft.url, userId, robotName, description: `Recorder Draft ${draft.id}`, workflow });
-    robot = persisted.robot;
-    existing = persisted.existing;
-  }
 
-  draft.compiledRobotId = robot.recording_meta.id;
-  draft.status = 'compiled';
-  draft.lastError = null;
-  await draft.save();
-  return { draft, robot, workflow, existing };
+    draft.compiledRobotId = robot.recording_meta.id;
+    draft.status = 'compiled';
+    draft.lastError = null;
+    await draft.save({ transaction });
+    return { draft, robot, workflow, existing };
+  });
 }

--- a/server/src/sdk/resourceClaims.ts
+++ b/server/src/sdk/resourceClaims.ts
@@ -84,7 +84,7 @@ export async function claimResource(
 /** Release is idempotent for an already released row but rejects stale epochs. */
 export async function requireResourceClaim(
   userId: number,
-  input: { resourceType: unknown; resourceId: unknown; ownerSessionId: unknown },
+  input: { resourceType: unknown; resourceId: unknown; ownerSessionId: unknown; epoch?: unknown },
 ): Promise<{ epoch: number }> {
   const normalized = normalizeInput(input);
   const current = await ResourceClaim.findOne({
@@ -92,6 +92,15 @@ export async function requireResourceClaim(
   });
   if (!current || !current.active || current.ownerSessionId !== normalized.ownerSessionId) {
     throw new ResourceClaimError('claim_conflict', 'Maxun resource requires an explicit claim by this Harness session');
+  }
+  if (input.epoch !== undefined && (typeof input.epoch !== 'number' || !Number.isSafeInteger(input.epoch) || input.epoch < 1)) {
+    throw new ResourceClaimError('invalid_claim', 'epoch must be a positive integer');
+  }
+  if (input.epoch !== undefined && current.epoch !== input.epoch) {
+    throw new ResourceClaimError('claim_conflict', 'Maxun resource claim epoch is stale', {
+      ownerSessionId: current.ownerSessionId,
+      epoch: current.epoch,
+    });
   }
   return { epoch: current.epoch };
 }

--- a/server/src/sdk/resourceClaims.ts
+++ b/server/src/sdk/resourceClaims.ts
@@ -1,0 +1,112 @@
+import { UniqueConstraintError } from 'sequelize';
+import { v4 as uuid } from 'uuid';
+import ResourceClaim, { type ResourceClaimType } from '../models/ResourceClaim';
+
+export type ResourceClaimErrorCode = 'claim_conflict' | 'claim_not_found' | 'invalid_claim';
+
+export class ResourceClaimError extends Error {
+  public constructor(
+    public readonly code: ResourceClaimErrorCode,
+    message: string,
+    public readonly details?: { ownerSessionId?: string; epoch?: number },
+  ) {
+    super(message);
+    this.name = 'ResourceClaimError';
+  }
+}
+
+const validType = (value: unknown): value is ResourceClaimType => value === 'draft' || value === 'browser';
+
+const normalizeInput = (input: {
+  resourceType: unknown;
+  resourceId: unknown;
+  ownerSessionId: unknown;
+}): { resourceType: ResourceClaimType; resourceId: string; ownerSessionId: string } => {
+  if (!validType(input.resourceType)) throw new ResourceClaimError('invalid_claim', 'resourceType must be draft or browser');
+  const resourceId = typeof input.resourceId === 'string' ? input.resourceId.trim() : '';
+  const ownerSessionId = typeof input.ownerSessionId === 'string' ? input.ownerSessionId.trim() : '';
+  if (!resourceId || !ownerSessionId) throw new ResourceClaimError('invalid_claim', 'resourceId and ownerSessionId are required');
+  return { resourceType: input.resourceType, resourceId, ownerSessionId };
+};
+
+type ClaimResult = {
+  resourceType: ResourceClaimType;
+  resourceId: string;
+  ownerSessionId: string;
+  epoch: number;
+  existing: boolean;
+};
+
+/**
+ * Claim one resource with an epoch that increases after every release. The
+ * unique resource index serializes competing sessions; the conditional update
+ * prevents a stale owner from reclaiming an inactive row during a race.
+ */
+export async function claimResource(
+  userId: number,
+  input: { resourceType: unknown; resourceId: unknown; ownerSessionId: unknown },
+): Promise<ClaimResult> {
+  const normalized = normalizeInput(input);
+  const where = { userId, resourceType: normalized.resourceType, resourceId: normalized.resourceId };
+  const current = await ResourceClaim.findOne({ where });
+  if (current?.active) {
+    if (current.ownerSessionId !== normalized.ownerSessionId) {
+      throw new ResourceClaimError('claim_conflict', 'Maxun resource is already claimed by another Harness session');
+    }
+    return { ...normalized, epoch: current.epoch, existing: true };
+  }
+
+  if (current) {
+    const nextEpoch = current.epoch + 1;
+    const [updated] = await ResourceClaim.update(
+      { ownerSessionId: normalized.ownerSessionId, active: true, epoch: nextEpoch },
+      { where: { id: current.id, active: false, epoch: current.epoch } },
+    );
+    if (updated === 0) return claimResource(userId, input);
+    return { ...normalized, epoch: nextEpoch, existing: false };
+  }
+
+  try {
+    const created = await ResourceClaim.create({
+      id: uuid(),
+      ...where,
+      ownerSessionId: normalized.ownerSessionId,
+      epoch: 1,
+      active: true,
+    });
+    return { ...normalized, epoch: created.epoch, existing: false };
+  } catch (error) {
+    if (!(error instanceof UniqueConstraintError)) throw error;
+    return claimResource(userId, input);
+  }
+}
+
+/** Release is idempotent for an already released row but rejects stale epochs. */
+export async function requireResourceClaim(
+  userId: number,
+  input: { resourceType: unknown; resourceId: unknown; ownerSessionId: unknown },
+): Promise<{ epoch: number }> {
+  const normalized = normalizeInput(input);
+  const current = await ResourceClaim.findOne({
+    where: { userId, resourceType: normalized.resourceType, resourceId: normalized.resourceId },
+  });
+  if (!current || !current.active || current.ownerSessionId !== normalized.ownerSessionId) {
+    throw new ResourceClaimError('claim_conflict', 'Maxun resource requires an explicit claim by this Harness session');
+  }
+  return { epoch: current.epoch };
+}
+
+export async function releaseResource(
+  userId: number,
+  input: { resourceType: unknown; resourceId: unknown; ownerSessionId: unknown; epoch: unknown },
+): Promise<void> {
+  const normalized = normalizeInput(input);
+  const epoch = typeof input.epoch === 'number' ? input.epoch : NaN;
+  if (!Number.isSafeInteger(epoch) || epoch < 1) throw new ResourceClaimError('invalid_claim', 'epoch must be a positive integer');
+  const current = await ResourceClaim.findOne({ where: { userId, resourceType: normalized.resourceType, resourceId: normalized.resourceId } });
+  if (!current || !current.active) return;
+  if (current.ownerSessionId !== normalized.ownerSessionId || current.epoch !== epoch) {
+    throw new ResourceClaimError('claim_conflict', 'Maxun resource claim is owned by another session or epoch');
+  }
+  await current.update({ active: false, ownerSessionId: '' });
+}

--- a/server/src/sdk/selectorValidator.ts
+++ b/server/src/sdk/selectorValidator.ts
@@ -224,6 +224,46 @@ export class SelectorValidator {
   }
 
   /**
+   * Load Maxun's browser-side semantic analyzer into the active page once.
+   * The analyzer owns selector discovery; callers receive metadata and keep
+   * selectors server-side rather than asking an agent to author them.
+   */
+  private async loadPageAnalyzer(): Promise<void> {
+    if (!this.page) throw new Error('Browser not initialized');
+    const fs = require('fs');
+    const path = require('path');
+    const scriptPath = path.join(__dirname, 'browserSide/pageAnalyzer.js');
+    const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+
+    await this.page.evaluate((script) => {
+      const win = window as any;
+      if (typeof win.analyzeElementGroups === 'function' && typeof win.autoDetectListFields === 'function') return;
+      eval(script);
+    }, scriptContent);
+  }
+
+  /**
+   * Discover repeated semantic element groups on the current page.
+   * Selectors are intentionally retained only inside Maxun's server-side
+   * draft state; the returned group metadata is safe for an agent to inspect.
+   */
+  async analyzeElementGroups(): Promise<any[]> {
+    if (!this.page) return [];
+    try {
+      await this.loadPageAnalyzer();
+      return await this.page.evaluate(() => {
+        const win = window as any;
+        return typeof win.analyzeElementGroups === 'function'
+          ? win.analyzeElementGroups()
+          : [];
+      });
+    } catch (error: any) {
+      logger.error('Element-group analysis failed:', error.message);
+      return [];
+    }
+  }
+
+  /**
    * Auto-detect fields from list selector
    */
   async autoDetectListFields(listSelector: string): Promise<{
@@ -237,14 +277,7 @@ export class SelectorValidator {
     }
 
     try {
-      const fs = require('fs');
-      const path = require('path');
-      const scriptPath = path.join(__dirname, 'browserSide/pageAnalyzer.js');
-      const scriptContent = fs.readFileSync(scriptPath, 'utf8');
-
-      await this.page.evaluate((script) => {
-        eval(script);
-      }, scriptContent);
+      await this.loadPageAnalyzer();
 
       const result = await this.page.evaluate((selector) => {
         const win = window as any;
@@ -302,14 +335,7 @@ export class SelectorValidator {
     }
 
     try {
-      const fs = require('fs');
-      const path = require('path');
-      const scriptPath = path.join(__dirname, 'browserSide/pageAnalyzer.js');
-      const scriptContent = fs.readFileSync(scriptPath, 'utf8');
-
-      await this.page.evaluate((script) => {
-        eval(script);
-      }, scriptContent);
+      await this.loadPageAnalyzer();
 
       const buttonResult = await this.page.evaluate((selector) => {
         const win = window as any;

--- a/server/src/sdk/serviceIdentity.ts
+++ b/server/src/sdk/serviceIdentity.ts
@@ -1,0 +1,6 @@
+/** Stable operator-defined identity for this Maxun service instance. */
+export const getServiceInstanceId = (): string => (
+  process.env.MAXUN_SERVICE_INSTANCE_ID?.trim()
+  || process.env.HOSTNAME?.trim()
+  || 'maxun-local'
+);

--- a/server/src/sdk/urlPrivacy.ts
+++ b/server/src/sdk/urlPrivacy.ts
@@ -1,0 +1,18 @@
+/**
+ * Remove credential-bearing URL components before a URL crosses a model or
+ * durable-correlation boundary. The browser may still display the live URL in
+ * the ephemeral visual stream, but API observations and session state do not.
+ */
+export function sanitizeBrowserUrl(value: string | null | undefined): string | null {
+  if (typeof value !== 'string' || !value) return null;
+  try {
+    const url = new URL(value);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return null;
+  }
+}

--- a/server/src/sdk/workflowEnricher.ts
+++ b/server/src/sdk/workflowEnricher.ts
@@ -359,30 +359,7 @@ export class WorkflowEnricher {
    * Analyze page groups using browser-side script
    */
   private static async analyzePageGroups(validator: SelectorValidator): Promise<any[]> {
-    try {
-      const page = (validator as any).page;
-      const fs = require('fs');
-      const path = require('path');
-      const scriptPath = path.join(__dirname, 'browserSide/pageAnalyzer.js');
-      const scriptContent = fs.readFileSync(scriptPath, 'utf8');
-
-      await page.evaluate((script: string) => {
-        eval(script);
-      }, scriptContent);
-
-      const groups = await page.evaluate(() => {
-        const win = window as any;
-        if (typeof win.analyzeElementGroups === 'function') {
-          return win.analyzeElementGroups();
-        }
-        return [];
-      });
-
-      return groups;
-    } catch (error: any) {
-      logger.error('Error analyzing page groups:', error);
-      return [];
-    }
+    return validator.analyzeElementGroups();
   }
 
   /**
@@ -486,7 +463,8 @@ export class WorkflowEnricher {
       if (objectMatch) jsonStr = objectMatch[0];
 
       const decision = JSON.parse(this.sanitizeJsonString(jsonStr));
-      const limit = decision.limit || this.extractLimitFromPrompt(prompt) || null;
+      const promptLimit = this.extractLimitFromPrompt(prompt);
+      const limit = promptLimit || decision.limit || null;
       const parsed = WorkflowEnricher.parseGroupCandidates(decision, elementGroups, limit);
       return WorkflowEnricher.buildDecisionFromCandidates(parsed.candidates, parsed.reasoning, limit);
 
@@ -502,7 +480,7 @@ export class WorkflowEnricher {
    */
   private static extractLimitFromPrompt(prompt: string): number | null {
     const verbBoundNumber = prompt.match(
-      /\b(?:scrape|extract|get|fetch|pull|grab|collect|need|want|find|return|give\s+me|show\s+me)\s+(\d+)\b/i
+      /\b(?:scrape|extract|get|fetch|pull|grab|collect|need|want|find|return|give\s+me|show\s+me)\s+(?:(?:the\s+)?(?:first|top|last)\s+)?(\d+)\b/i
     );
     if (verbBoundNumber && verbBoundNumber[1]) {
       const limit = parseInt(verbBoundNumber[1], 10);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -152,6 +152,7 @@ app.get('/', function (req, res) {
 });
 
 if (require.main === module) {
+  if (!process.env.JWT_SECRET) throw new Error('JWT_SECRET is required for authenticated Maxun socket capabilities');
   const serverIntervals: NodeJS.Timeout[] = [];
 
   const processQueuedRunsInterval = setInterval(async () => {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -25,6 +25,8 @@ import { startScheduleWorker, stopScheduleWorker } from './schedule-worker';
 import Run from './models/Run';
 import { authenticateSocket } from './socket-connection/socketAuth';
 
+const WORKERS_ENABLED = process.env.MAXUN_DISABLE_WORKERS !== 'true';
+
 const normalizeOrigin = (urlString?: string): string => {
   if (!urlString) return 'http://localhost:5173';
   try {
@@ -155,28 +157,32 @@ if (require.main === module) {
   if (!process.env.JWT_SECRET) throw new Error('JWT_SECRET is required for authenticated Maxun socket capabilities');
   const serverIntervals: NodeJS.Timeout[] = [];
 
-  const processQueuedRunsInterval = setInterval(async () => {
-    try {
-      await processQueuedRuns();
-    } catch (error: any) {
-      logger.log('error', `Error in processQueuedRuns interval: ${error.message}`);
-    }
-  }, 5000);
-  serverIntervals.push(processQueuedRunsInterval);
+  if (WORKERS_ENABLED) {
+    const processQueuedRunsInterval = setInterval(async () => {
+      try {
+        await processQueuedRuns();
+      } catch (error: any) {
+        logger.log('error', `Error in processQueuedRuns interval: ${error.message}`);
+      }
+    }, 5000);
+    serverIntervals.push(processQueuedRunsInterval);
+
+    const stuckRunningRunsInterval = setInterval(async () => {
+      try {
+        await recoverStuckRunningRuns();
+      } catch (error: any) {
+        logger.log('error', `Error in recoverStuckRunningRuns interval: ${error.message}`);
+      }
+    }, 5 * 60 * 1000);
+    serverIntervals.push(stuckRunningRunsInterval);
+  } else {
+    logger.log('info', 'Graphile and scheduled run workers are disabled for this Maxun instance');
+  }
 
   const browserPoolCleanupInterval = setInterval(() => {
     browserPool.cleanupStaleBrowserSlots();
   }, 60000);
   serverIntervals.push(browserPoolCleanupInterval);
-
-  const stuckRunningRunsInterval = setInterval(async () => {
-    try {
-      await recoverStuckRunningRuns();
-    } catch (error: any) {
-      logger.log('error', `Error in recoverStuckRunningRuns interval: ${error.message}`);
-    }
-  }, 5 * 60 * 1000);
-  serverIntervals.push(stuckRunningRunsInterval);
 
   server.listen(SERVER_PORT, '0.0.0.0', async () => {
     try {
@@ -186,11 +192,14 @@ if (require.main === module) {
       logger.log('info', 'Cleaning up stale browser slots...');
       browserPool.cleanupStaleBrowserSlots();
 
-      await recoverOrphanedRuns();
-
-      await startGraphileWorkerUtils();
-      await startWorkers();
-      await startScheduleWorker();
+      if (WORKERS_ENABLED) {
+        await recoverOrphanedRuns();
+        await startGraphileWorkerUtils();
+        await startWorkers();
+        await startScheduleWorker();
+      } else {
+        logger.log('info', 'Skipping orphaned-run recovery and worker startup because workers are disabled');
+      }
 
       io.of('/queued-run').on('connection', (socket) => {
         const userId = socket.data.userId as string;
@@ -217,7 +226,9 @@ if (require.main === module) {
         }
       });
 
-      logger.log('info', 'All workers started in main process');
+      logger.log('info', WORKERS_ENABLED
+        ? 'All workers started in main process'
+        : 'Maxun started in API/browser-only mode');
 
       logger.log('info', `Server listening on port ${SERVER_PORT}`);
     } catch (error: any) {

--- a/server/src/socket-connection/socketAuth.ts
+++ b/server/src/socket-connection/socketAuth.ts
@@ -1,5 +1,20 @@
-import { verify } from 'jsonwebtoken';
+import { verify, type JwtPayload } from 'jsonwebtoken';
 import { Socket } from 'socket.io';
+import { requireResourceClaim } from '../sdk/resourceClaims';
+import { requireControlLease, type ControlActor } from '../sdk/controlLease';
+
+export interface MaxunStreamCapability {
+  readonly browserId: string;
+  readonly ownerSessionId: string;
+  readonly epoch: number;
+}
+
+export interface MaxunControlCapability {
+  readonly browserId: string;
+  readonly ownerSessionId: string;
+  readonly controlEpoch: number;
+  readonly actor: ControlActor;
+}
 
 /**
  * Reads the session JWT from the handshake cookie header.
@@ -38,7 +53,7 @@ const readTokenFromCookieHeader = (cookieHeader?: string): string | null => {
  * The verified id is stored on `socket.data.userId`; nothing downstream should
  * take a user id from client-supplied handshake data.
  */
-export const authenticateSocket = (socket: Socket, next: (err?: Error) => void): void => {
+export const authenticateSocket = async (socket: Socket, next: (err?: Error) => void): Promise<void> => {
   const suppliedToken = socket.handshake.auth && (socket.handshake.auth as any).token;
   const token = suppliedToken || readTokenFromCookieHeader(socket.handshake.headers.cookie);
 
@@ -54,12 +69,65 @@ export const authenticateSocket = (socket: Socket, next: (err?: Error) => void):
   }
 
   try {
-    const decoded = verify(token, secret) as any;
-    const userId = decoded && (decoded.id ?? decoded.userId);
+    const decoded = verify(token, secret) as JwtPayload & Record<string, unknown>;
+    const userId = decoded && (decoded.id ?? decoded.userId ?? decoded.sub);
 
     if (userId === undefined || userId === null || userId === '') {
       next(new Error('Unauthorized'));
       return;
+    }
+
+    if (decoded.purpose !== undefined) {
+      const browserId = typeof decoded.browserId === 'string' ? decoded.browserId : '';
+      const ownerSessionId = typeof decoded.ownerSessionId === 'string' ? decoded.ownerSessionId : '';
+      const namespaceBrowserId = socket.nsp.name.replace(/^\//, '');
+      if (!browserId || !ownerSessionId || namespaceBrowserId !== browserId) {
+        next(new Error('Unauthorized'));
+        return;
+      }
+
+      if (decoded.purpose === 'maxun-browser-stream') {
+        const epoch = typeof decoded.epoch === 'number' ? decoded.epoch : NaN;
+        if (!Number.isSafeInteger(epoch) || epoch < 1) {
+          next(new Error('Unauthorized'));
+          return;
+        }
+        try {
+          const claim = await requireResourceClaim(Number(userId), {
+            resourceType: 'browser', resourceId: browserId, ownerSessionId,
+          });
+          if (claim.epoch !== epoch) {
+            next(new Error('Unauthorized'));
+            return;
+          }
+        } catch {
+          next(new Error('Unauthorized'));
+          return;
+        }
+        socket.data.maxunStreamCapability = { browserId, ownerSessionId, epoch } satisfies MaxunStreamCapability;
+      } else if (decoded.purpose === 'maxun-browser-control') {
+        const controlEpoch = typeof decoded.controlEpoch === 'number' ? decoded.controlEpoch : NaN;
+        const actor = decoded.actor === 'agent' || decoded.actor === 'human' ? decoded.actor : null;
+        if (!actor || !Number.isSafeInteger(controlEpoch) || controlEpoch < 1) {
+          next(new Error('Unauthorized'));
+          return;
+        }
+        try {
+          await requireControlLease(Number(userId), {
+            browserSessionId: browserId,
+            ownerSessionId,
+            actor,
+            controlEpoch,
+          });
+        } catch {
+          next(new Error('Unauthorized'));
+          return;
+        }
+        socket.data.maxunControlCapability = { browserId, ownerSessionId, controlEpoch, actor } satisfies MaxunControlCapability;
+      } else {
+        next(new Error('Unauthorized'));
+        return;
+      }
     }
 
     socket.data.userId = String(userId);

--- a/server/src/socket-connection/socketAuth.ts
+++ b/server/src/socket-connection/socketAuth.ts
@@ -83,14 +83,18 @@ export const authenticateSocket = async (socket: Socket, next: (err?: Error) => 
 
     if (decoded.purpose !== undefined) {
       const browserId = typeof decoded.browserId === 'string' ? decoded.browserId : '';
-      const ownerSessionId = typeof decoded.ownerSessionId === 'string' ? decoded.ownerSessionId : '';
       const namespaceBrowserId = socket.nsp.name.replace(/^\//, '');
-      if (!browserId || !ownerSessionId || namespaceBrowserId !== browserId) {
+      if (!browserId || namespaceBrowserId !== browserId) {
         next(new Error('Unauthorized'));
         return;
       }
 
       if (decoded.purpose === 'maxun-browser-stream') {
+        const ownerSessionId = typeof decoded.ownerSessionId === 'string' ? decoded.ownerSessionId : '';
+        if (!ownerSessionId) {
+          next(new Error('Unauthorized'));
+          return;
+        }
         const epoch = typeof decoded.epoch === 'number' ? decoded.epoch : NaN;
         if (!Number.isSafeInteger(epoch) || epoch < 1) {
           next(new Error('Unauthorized'));
@@ -116,6 +120,11 @@ export const authenticateSocket = async (socket: Socket, next: (err?: Error) => 
         }
         socket.data.maxunInternalRunCapability = { browserId: decoded.browserId } satisfies MaxunInternalRunCapability;
       } else if (decoded.purpose === 'maxun-browser-control') {
+        const ownerSessionId = typeof decoded.ownerSessionId === 'string' ? decoded.ownerSessionId : '';
+        if (!ownerSessionId) {
+          next(new Error('Unauthorized'));
+          return;
+        }
         const controlEpoch = typeof decoded.controlEpoch === 'number' ? decoded.controlEpoch : NaN;
         const actor = decoded.actor === 'agent' || decoded.actor === 'human' ? decoded.actor : null;
         if (!actor || !Number.isSafeInteger(controlEpoch) || controlEpoch < 1) {

--- a/server/src/socket-connection/socketAuth.ts
+++ b/server/src/socket-connection/socketAuth.ts
@@ -16,6 +16,10 @@ export interface MaxunControlCapability {
   readonly actor: ControlActor;
 }
 
+export interface MaxunInternalRunCapability {
+  readonly browserId: string;
+}
+
 /**
  * Reads the session JWT from the handshake cookie header.
  *
@@ -105,6 +109,12 @@ export const authenticateSocket = async (socket: Socket, next: (err?: Error) => 
           return;
         }
         socket.data.maxunStreamCapability = { browserId, ownerSessionId, epoch } satisfies MaxunStreamCapability;
+      } else if (decoded.purpose === 'maxun-internal-run') {
+        if (typeof decoded.browserId !== 'string' || decoded.browserId !== namespaceBrowserId) {
+          next(new Error('Unauthorized'));
+          return;
+        }
+        socket.data.maxunInternalRunCapability = { browserId: decoded.browserId } satisfies MaxunInternalRunCapability;
       } else if (decoded.purpose === 'maxun-browser-control') {
         const controlEpoch = typeof decoded.controlEpoch === 'number' ? decoded.controlEpoch : NaN;
         const actor = decoded.actor === 'agent' || decoded.actor === 'human' ? decoded.actor : null;

--- a/server/src/storage/db.ts
+++ b/server/src/storage/db.ts
@@ -41,15 +41,16 @@ export const connectDB = async () => {
 
 export const syncDB = async () => {
     try {
-        //setupAssociations();
+        // Production schema is owned by Sequelize migrations. Running sync there
+        // would let a fresh deployment silently create a weaker schema when a
+        // migration job was omitted, especially for unique lease/replay indexes.
         const isDevelopment = process.env.NODE_ENV === 'development';
-        // force: true will drop and recreate tables on every run
-        // Use `alter: true` only in development mode
-        await sequelize.sync({ 
-            force: false, 
-            alter: isDevelopment 
-        }); 
-        console.log('Database synced successfully!');
+        if (!isDevelopment) {
+            console.log('Production schema is migration-managed; skipping sequelize.sync().');
+            return;
+        }
+        await sequelize.sync({ force: false, alter: true });
+        console.log('Development database synced successfully!');
     } catch (error) {
         console.error('Failed to sync database:', error);
     }

--- a/server/src/task-runner.ts
+++ b/server/src/task-runner.ts
@@ -690,7 +690,7 @@ export async function startWorkers(): Promise<void> {
       pgPool: runnerPool,
       concurrency: TOTAL_CONCURRENCY,
       noHandleSignals: true,
-      pollInterval: 3600000,
+      pollInterval: 1000,
       taskList,
     });
 

--- a/server/src/workflow-management/classes/Interpreter.ts
+++ b/server/src/workflow-management/classes/Interpreter.ts
@@ -382,6 +382,23 @@ export class WorkflowInterpreter {
    * Stops the current process of the interpretation of the workflow.
    * @returns {Promise<void>}
    */
+  /** Server-authorized pause used by the Goal 5 control plane. */
+  public pauseInterpretation = (): void => {
+    this.interpretationIsPaused = true;
+  };
+
+  /** Server-authorized resume used by the Goal 5 control plane. */
+  public resumeInterpretation = (): void => {
+    this.interpretationIsPaused = false;
+    this.interpretationResume?.();
+  };
+
+  /** Resume exactly one interpreter step, preserving the paused state contract. */
+  public stepInterpretation = (): void => {
+    this.interpretationResume?.();
+    this.interpretationIsPaused = true;
+  };
+
   public stopInterpretation = async () => {
     if (this.interpreter) {
       logger.log('info', 'Stopping the interpretation.');


### PR DESCRIPTION
## Summary

Adds the Maxun-side integration seams for the five-goal Harness project:

- semantic Recorder Draft, resource-claim, service-identity, and LLM SDK boundaries;
- durable control leases and command ledger;
- claim/actor/epoch/expiry/replay-fenced browser control;
- authenticated control capabilities and Socket.IO command handling;
- cancellation propagation and interpreter/browser pause/resume/step/abort reuse;
- fresh observation and workflow provenance support.

The companion Harness integration is in the `Fatih0234/deepseek-harness` fork branch `pi/maxun-harness-integration`.

## Baseline

- Base: `6ef14c7c89fac18b5ba771a1228ee064e1d7810f`
- Head: `6e0ec876f5e194598402ea6879df297bf2a23f76`

## Validation

- `npm run build:server`
- Goal 1–5 live/evidence verification from the companion integration workspace
- Source pins and `git diff --check`

Please review authorization ordering, migration behavior on fresh/existing databases, command cancellation/quiescence, and browser side-effect fencing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Recorder Draft workflows for discovering, editing, previewing, validating, and compiling robots.
  * Added AI-assisted list robot creation and browser session controls for screenshots, streaming, commands, and health.
  * Added pause, resume, and step controls for workflow runs.
* **Security**
  * Added authenticated browser connections, ownership leases, capability controls, takeover safeguards, and sensitive-data masking.
  * Sanitized browser URLs to protect private information.
* **Improvements**
  * Improved browser control, element detection, pagination detection, capacity recovery, and database startup reliability.
  * Improved prompt-based extraction limit handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->