### PR TITLE
fix: match chip sizes for run status

### DIFF
--- a/src/components/run/ColapsibleRow.tsx
+++ b/src/components/run/ColapsibleRow.tsx
@@ -227,7 +227,6 @@ export const CollapsibleRow = ({ row, handleDelete, isOpen, onToggleExpanded, cu
                         label={t('runs_table.run_diff.changed_chip', { defaultValue: 'Changed' })}
                         color="info"
                         variant="outlined"
-                        size="small"
                         onClick={handleOpenDiff}
                         sx={{ ml: 1, cursor: 'pointer' }}
                       />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the changed-run status chip styling while preserving all other displayed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->