### PR TITLE
fix(server): authenticate the sockets the backend opens to itself

### DIFF
--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -18,6 +18,7 @@ import { addAirtableUpdateTask, processAirtableUpdates } from "../workflow-manag
 import { sendWebhook } from "../routes/webhook";
 import { convertPageToHTML, convertPageToLinks, convertPageToMarkdown, convertPageToScreenshot, convertPageToText } from '../markdownify/scrape';
 import { safeDecrypt } from '../utils/auth';
+import { mintInternalSocketToken } from '../socket-connection/socketAuth';
 import { executeBrowserAgent } from '../sdk/browserAgent';
 import { OutputFormats } from '../constants/output-formats';
 import { processRobotOutputFormats } from '../utils/output-post-processor';
@@ -1415,6 +1416,10 @@ export async function handleRunRecording(id: string, userId: string, runSource: 
             transports: ['websocket'],
             rejectUnauthorized: false,
             timeout: CONNECTION_TIMEOUT,
+            // This connection carries no cookie, so it must present a token or
+            // the namespace middleware refuses it and the run waits forever for
+            // a `ready-for-run` that never comes.
+            auth: { token: mintInternalSocketToken(userId) },
         });
 
         const readyHandler = () => readyForRunHandler(browserId, newRunId, userId, socket!);

--- a/server/src/socket-connection/socketAuth.ts
+++ b/server/src/socket-connection/socketAuth.ts
@@ -1,4 +1,4 @@
-import { verify } from 'jsonwebtoken';
+import { sign, verify } from 'jsonwebtoken';
 import { Socket } from 'socket.io';
 
 /**
@@ -28,6 +28,41 @@ const readTokenFromCookieHeader = (cookieHeader?: string): string | null => {
   }
 
   return null;
+};
+
+/**
+ * Lifetime of a server-minted socket token.
+ *
+ * It is used once, immediately, by a connection opened in the same tick. A
+ * login token is deliberately long-lived because it backs a session; this backs
+ * a handshake, so it expires almost at once.
+ */
+const INTERNAL_SOCKET_TOKEN_TTL_SECONDS = 60;
+
+/**
+ * Mint a token for a socket connection the backend opens to itself.
+ *
+ * The backend joins its own namespace as a client whenever a run is started by
+ * something other than a browser: API, SDK and scheduled runs all take that
+ * path. Those connections carry no cookie, so once `authenticateSocket` was
+ * applied to every namespace they were refused - and because the refusal
+ * surfaces as `connect_error` rather than as a failed run, the run simply
+ * waited for a `ready-for-run` that could never arrive.
+ *
+ * Signed with the same secret and the same `id` claim the HTTP login issues, so
+ * the gate needs no special case and `socketOwns` keeps working unchanged: the
+ * connection authenticates as the user the run already belongs to, rather than
+ * as a privileged internal caller.
+ */
+export const mintInternalSocketToken = (userId: string | number): string => {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET is not set, so an internal socket connection cannot authenticate.');
+  }
+
+  return sign({ id: String(userId) }, secret, {
+    expiresIn: INTERNAL_SOCKET_TOKEN_TTL_SECONDS,
+  });
 };
 
 /**

--- a/server/src/workflow-management/scheduler/index.ts
+++ b/server/src/workflow-management/scheduler/index.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from "uuid";
 import { io, Socket } from "socket.io-client";
+import { mintInternalSocketToken } from '../../socket-connection/socketAuth';
 import { createRemoteBrowserForRun, destroyRemoteBrowser } from '../../browser-management/controller';
 import logger from '../../logger';
 import { browserPool, io as serverIo } from "../../server";
@@ -903,6 +904,9 @@ export async function handleRunRecording(id: string, userId: string) {
       transports: ['websocket'],
       rejectUnauthorized: false,
       timeout: CONNECTION_TIMEOUT,
+      // Same reason as the API path: no cookie on a server-opened socket, so
+      // the namespace middleware needs an explicit token.
+      auth: { token: mintInternalSocketToken(userId) },
     });
 
     const readyHandler = () => readyForRunHandler(browserId, newRunId, userId, socket!);


### PR DESCRIPTION
API, SDK and scheduled runs hang. This is why.

## The cause

`authenticateSocket` is applied to every namespace through `io.on('new_namespace')` and requires a token in `handshake.auth` or a `token` cookie.

The backend also joins its own `/<browserId>` namespace **as a socket.io client** whenever a run is started by something other than a browser:

- `server/src/api/record.ts:1414` — API and SDK runs
- `server/src/workflow-management/scheduler/index.ts:902` — scheduled runs

Neither passes a cookie or a token, so both handshakes are refused. Browser clients are unaffected because they carry the httpOnly cookie — which is why this looks like an API-only problem and why the UI keeps working.

## Why it hangs instead of failing

`connect_error` is logged and the socket cleaned up, but the run is never marked failed. The browser then falls back to a dummy socket and `ready-for-run` never reaches the caller:

```
Socket connection error for API run ...: Unauthorized
Cleaned up socket connection for browserId ...
No client connected to browser ... within timeout, proceeding with dummy socket
Using dummy socket for browser ...
[SDK] Error executing robot: Run not found
```

So it reads as "slow", not as "broken", which is probably why it has been hard to pin down.

## The fix

Mint a short-lived token carrying the same `id` claim the HTTP login issues, and pass it in `auth`. The gate then needs no special case and `socketOwns` is unchanged: the connection authenticates as the user the run already belongs to, rather than as a privileged internal caller.

60-second expiry, because it is used once, immediately — a login token is deliberately long-lived, which is right for a session and wrong for a handshake.

## Verification

A/B on one stack, same database, only the image changing:

| | before | after |
| --- | --- | --- |
| API run | **hangs, 120s deadline exceeded** | **completes, 18.6s** |
| `Socket connection error: Unauthorized` | 1 per run | **0** |
| `dummy socket` fallback | present | **0** |

And the gate on its own, against `/queued-run`:

| connection | result |
| --- | --- |
| no auth (what the backend sends today) | refused, `Unauthorized` |
| minted token (what this PR sends) | connected |
| token signed with the wrong secret | refused |

The third row is the control — it rules out "any token gets in".

`tsc -p server/tsconfig.json` is clean.

## One thing to know before you try to reproduce this

On a database created by an earlier version, you will not see the hang. You will see every run fail in under a second with:

```
Error scheduling run: column "hasChanges" of relation "run" does not exist
```

`d0014e0` added `Run.hasChanges` and `Robot.compareRuns` to the models with no migration, so a fresh database gets the columns from `sequelize.sync()` and an upgraded one never does. That failure happens before any socket is opened, so it masks this one. I have filed it separately; reproducing the hang needs a fresh database.

---

Per CONTRIBUTING §7: this was written with AI assistance (disclosed in the commit's `Co-Authored-By`), reproduced and verified end to end as above rather than generated and submitted unchecked, and I can respond to review feedback on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization for server-initiated real-time connections.
  * Recording runs triggered through supported server workflows now authenticate reliably, including environments without cookies.
  * Added short-lived authentication for internal socket connections to prevent authorization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->