### PR TITLE
fix: centralize run queuing logic

### DIFF
--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -7,7 +7,6 @@ import { v4 as uuid } from "uuid";
 import { createRemoteBrowserForRun, destroyRemoteBrowser } from "../browser-management/controller";
 import logger from "../logger";
 import { browserPool, io as serverIo } from "../server";
-import { io, Socket } from "socket.io-client";
 import { BinaryOutputService } from "../storage/mino";
 import { AuthenticatedRequest } from "../routes/record"
 import {capture} from "../utils/analytics";
@@ -618,12 +617,31 @@ async function createWorkflowAndStoreMetadata(id: string, userId: string, runSou
             logger.log('warn', `Failed to send run-started notification for API run ${plainRun.runId}: ${socketError.message}`);
         }
 
-        if (isDocRobot) {
+        try {
             await addJob(QUEUE_NAMES.EXECUTE_RUN, {
                 userId,
                 runId: plainRun.runId,
                 browserId,
-            }, { maxAttempts: 1 });
+            }, {
+                maxAttempts: 1,
+                jobKey: `${QUEUE_NAMES.EXECUTE_RUN}:${plainRun.runId}`,
+            });
+        } catch (queueError: any) {
+            await run.update({
+                status: 'failed',
+                finishedAt: new Date().toLocaleString(),
+                log: `Failed to queue execution job: ${queueError.message}`,
+            });
+
+            if (!isDocRobot) {
+                try {
+                    await destroyRemoteBrowser(browserId, userId);
+                } catch (cleanupError: any) {
+                    logger.log('warn', `Failed to clean up browser ${browserId} after queue error: ${cleanupError.message}`);
+                }
+            }
+
+            throw queueError;
         }
 
         return {
@@ -676,36 +694,6 @@ async function triggerIntegrationUpdates(runId: string, robotMetaId: string): Pr
   } catch (err: any) {
     logger.log('error', `Failed to update integrations for run: ${runId}: ${err.message}`);
   }
-}
-
-async function readyForRunHandler(browserId: string, id: string, userId: string, socket: Socket) {
-    try {
-        const result = await executeRun(id, userId);
-
-        if (result && result.success) {
-            logger.log('info', `Interpretation of ${id} succeeded`);
-            resetRecordingState(browserId, id);
-            return result.interpretationInfo;
-        } else {
-            logger.log('error', `Interpretation of ${id} failed`);
-            await destroyRemoteBrowser(browserId, userId);
-            resetRecordingState(browserId, id);
-            return null;
-        }
-
-    } catch (error: any) {
-        logger.error(`Error during readyForRunHandler: ${error.message}`);
-        await destroyRemoteBrowser(browserId, userId);
-        return null;
-    } finally {
-        cleanupSocketConnection(socket, browserId, id);
-    }
-}
-
-
-function resetRecordingState(browserId: string, id: string) {
-    browserId = '';
-    id = '';
 }
 
 function AddGeneratedFlags(workflow: WorkflowFile) {
@@ -1390,11 +1378,9 @@ async function executeRun(id: string, userId: string) {
 }
 
 export async function handleRunRecording(id: string, userId: string, runSource: 'api' | 'sdk' | 'mcp' | 'cli' = 'api', requestedFormats?: OutputFormats[], promptInstructions?: string) {
-    let socket: Socket | null = null;
-
     try {
         const result = await createWorkflowAndStoreMetadata(id, userId, runSource, requestedFormats, promptInstructions);
-        const { browserId, runId: newRunId, isDocRobot } = result as any;
+        const { runId: newRunId, isDocRobot } = result as any;
 
         if (!newRunId || !userId) {
             throw new Error('runId or userId is undefined');
@@ -1402,37 +1388,7 @@ export async function handleRunRecording(id: string, userId: string, runSource: 
 
         if (isDocRobot) {
             logger.log('info', `Doc robot run ${newRunId} queued without browser`);
-            return newRunId;
         }
-
-        if (!browserId) {
-            throw new Error('browserId is undefined for non-document robot');
-        }
-
-        const CONNECTION_TIMEOUT = 30000;
-
-        socket = io(`${process.env.BACKEND_URL ? process.env.BACKEND_URL : 'http://localhost:8080'}/${browserId}`, {
-            transports: ['websocket'],
-            rejectUnauthorized: false,
-            timeout: CONNECTION_TIMEOUT,
-        });
-
-        const readyHandler = () => readyForRunHandler(browserId, newRunId, userId, socket!);
-
-        socket.on('ready-for-run', readyHandler);
-
-        socket.on('connect_error', (error: Error) => {
-            logger.error(`Socket connection error for API run ${newRunId}: ${error.message}`);
-            cleanupSocketConnection(socket!, browserId, newRunId);
-        });
-
-        socket.on('error', (error: Error) => {
-            logger.error(`Socket error for API run ${newRunId}: ${error.message}`);
-        });
-
-        socket.on('disconnect', () => {
-            cleanupSocketConnection(socket!, browserId, newRunId);
-        });
 
         logger.log('info', `Running Robot: ${id}`);
 
@@ -1440,31 +1396,6 @@ export async function handleRunRecording(id: string, userId: string, runSource: 
 
     } catch (error: any) {
         logger.error('Error running robot:', error);
-        if (socket) {
-            cleanupSocketConnection(socket, '', '');
-        }
-    }
-}
-
-function cleanupSocketConnection(socket: Socket, browserId: string, id: string) {
-    try {
-        socket.removeAllListeners();
-        socket.disconnect();
-
-        if (browserId) {
-            const namespace = serverIo.of(browserId);
-            namespace.removeAllListeners();
-            namespace.disconnectSockets(true);
-            const nsps = (serverIo as any)._nsps;
-            if (nsps && nsps.has(`/${browserId}`)) {
-                nsps.delete(`/${browserId}`);
-                logger.log('debug', `Deleted namespace /${browserId} from io._nsps Map`);
-            }
-        }
-
-        logger.log('info', `Cleaned up socket connection for browserId: ${browserId}, runId: ${id}`);
-    } catch (error: any) {
-        logger.error(`Error cleaning up socket connection: ${error.message}`);
     }
 }
 

--- a/server/src/api/record.ts
+++ b/server/src/api/record.ts
@@ -628,11 +628,29 @@ async function createWorkflowAndStoreMetadata(id: string, userId: string, runSou
                 jobKey: `${QUEUE_NAMES.EXECUTE_RUN}:${plainRun.runId}`,
             });
         } catch (queueError: any) {
+            const finishedAt = new Date().toLocaleString();
             await run.update({
                 status: 'failed',
-                finishedAt: new Date().toLocaleString(),
+                finishedAt,
                 log: `Failed to queue execution job: ${queueError.message}`,
             });
+
+            try {
+                serverIo.of('/queued-run').to(`user-${userId}`).emit('run-completed', {
+                    runId: plainRun.runId,
+                    robotMetaId: plainRun.robotMetaId,
+                    robotName: plainRun.name,
+                    status: 'failed',
+                    finishedAt,
+                    runByUserId: plainRun.runByUserId,
+                    runByScheduleId: plainRun.runByScheduleId,
+                    runByAPI: plainRun.runByAPI || false,
+                    browserId: plainRun.browserId,
+                    error: `Failed to queue execution job: ${queueError.message}`,
+                });
+            } catch (socketError: any) {
+                logger.log('warn', `Failed to emit queue failure for API run ${plainRun.runId}: ${socketError.message}`);
+            }
 
             if (!isDocRobot) {
                 try {

--- a/server/src/workflow-management/scheduler/index.ts
+++ b/server/src/workflow-management/scheduler/index.ts
@@ -1,5 +1,4 @@
 import { v4 as uuid } from "uuid";
-import { io, Socket } from "socket.io-client";
 import { createRemoteBrowserForRun, destroyRemoteBrowser } from '../../browser-management/controller';
 import logger from '../../logger';
 import { browserPool, io as serverIo } from "../../server";
@@ -114,18 +113,37 @@ async function createWorkflowAndStoreMetadata(id: string, userId: string) {
       logger.log('warn', `Failed to send run-scheduled notification for run ${plainRun.runId}: ${socketError.message}`);
     }
 
-    if (isDocRobot) {
+    try {
       await addJob(QUEUE_NAMES.EXECUTE_RUN, {
         userId,
         runId: plainRun.runId,
         browserId,
-      }, { maxAttempts: 1 });
-      return { browserId, runId: plainRun.runId, isDocRobot: true };
+      }, {
+        maxAttempts: 1,
+        jobKey: `${QUEUE_NAMES.EXECUTE_RUN}:${plainRun.runId}`,
+      });
+    } catch (queueError: any) {
+      await run.update({
+        status: 'failed',
+        finishedAt: new Date().toLocaleString(),
+        log: `Failed to queue scheduled execution job: ${queueError.message}`,
+      });
+
+      if (!isDocRobot) {
+        try {
+          await destroyRemoteBrowser(browserId, userId);
+        } catch (cleanupError: any) {
+          logger.log('warn', `Failed to clean up browser ${browserId} after scheduled queue error: ${cleanupError.message}`);
+        }
+      }
+
+      throw queueError;
     }
 
     return {
       browserId,
       runId: plainRun.runId,
+      isDocRobot,
     }
 
   } catch (e) {
@@ -851,38 +869,10 @@ async function executeRun(id: string, userId: string) {
   }
 }
 
-async function readyForRunHandler(browserId: string, id: string, userId: string, socket: Socket) {
-  try {
-    const interpretation = await executeRun(id, userId);
-
-    if (interpretation) {
-      logger.log('info', `Interpretation of ${id} succeeded`);
-    } else {
-      logger.log('error', `Interpretation of ${id} failed`);
-      await destroyRemoteBrowser(browserId, userId);
-    }
-
-    resetRecordingState(browserId, id);
-
-  } catch (error: any) {
-    logger.error(`Error during readyForRunHandler: ${error.message}`);
-    await destroyRemoteBrowser(browserId, userId);
-  } finally {
-    cleanupSocketConnection(socket, browserId, id);
-  }
-}
-
-function resetRecordingState(browserId: string, id: string) {
-  browserId = '';
-  id = '';
-}
-
 export async function handleRunRecording(id: string, userId: string) {
-  let socket: Socket | null = null;
-  
   try {
     const result = await createWorkflowAndStoreMetadata(id, userId);
-    const { browserId, runId: newRunId, isDocRobot } = result as any;
+    const { runId: newRunId, isDocRobot } = result as any;
 
     if (!newRunId || !userId) {
       throw new Error('runId or userId is undefined');
@@ -890,63 +880,14 @@ export async function handleRunRecording(id: string, userId: string) {
 
     if (isDocRobot) {
       logger.log('info', `Doc robot scheduled run ${newRunId} queued without browser`);
-      return newRunId;
     }
-
-    if (!browserId) {
-      throw new Error('browserId is undefined for non-document robot');
-    }
-
-    const CONNECTION_TIMEOUT = 30000;
-
-    socket = io(`${process.env.BACKEND_URL ? process.env.BACKEND_URL : 'http://localhost:5000'}/${browserId}`, {
-      transports: ['websocket'],
-      rejectUnauthorized: false,
-      timeout: CONNECTION_TIMEOUT,
-    });
-
-    const readyHandler = () => readyForRunHandler(browserId, newRunId, userId, socket!);
-
-    socket.on('ready-for-run', readyHandler);
-
-    socket.on('connect_error', (error: Error) => {
-      logger.error(`Socket connection error for scheduled run ${newRunId}: ${error.message}`);
-      cleanupSocketConnection(socket!, browserId, newRunId);
-    });
-
-    socket.on('disconnect', () => {
-      cleanupSocketConnection(socket!, browserId, newRunId);
-    });
 
     logger.log('info', `Running robot: ${id}`);
 
+    return newRunId;
+
   } catch (error: any) {
     logger.error('Error running recording:', error);
-    if (socket) {
-      cleanupSocketConnection(socket, '', '');
-    }
-  }
-}
-
-function cleanupSocketConnection(socket: Socket, browserId: string, id: string) {
-  try {
-    socket.removeAllListeners();
-    socket.disconnect();
-
-    if (browserId) {
-      const namespace = serverIo.of(browserId);
-      namespace.removeAllListeners();
-      namespace.disconnectSockets(true);
-      const nsps = (serverIo as any)._nsps;
-      if (nsps && nsps.has(`/${browserId}`)) {
-        nsps.delete(`/${browserId}`);
-        logger.log('debug', `Deleted namespace /${browserId} from io._nsps Map`);
-      }
-    }
-
-    logger.log('info', `Cleaned up socket connection for browserId: ${browserId}, runId: ${id}`);
-  } catch (error: any) {
-    logger.error(`Error cleaning up socket connection: ${error.message}`);
   }
 }
 

--- a/server/src/workflow-management/scheduler/index.ts
+++ b/server/src/workflow-management/scheduler/index.ts
@@ -123,11 +123,32 @@ async function createWorkflowAndStoreMetadata(id: string, userId: string) {
         jobKey: `${QUEUE_NAMES.EXECUTE_RUN}:${plainRun.runId}`,
       });
     } catch (queueError: any) {
+      const finishedAt = new Date().toLocaleString();
       await run.update({
         status: 'failed',
-        finishedAt: new Date().toLocaleString(),
+        finishedAt,
         log: `Failed to queue scheduled execution job: ${queueError.message}`,
       });
+
+      const failureSocketData = {
+        runId: plainRun.runId,
+        robotMetaId: plainRun.robotMetaId,
+        robotName: plainRun.name,
+        status: 'failed',
+        finishedAt,
+        runByUserId: plainRun.runByUserId,
+        runByScheduleId: plainRun.runByScheduleId,
+        runByAPI: plainRun.runByAPI || false,
+        browserId: plainRun.browserId,
+        error: `Failed to queue scheduled execution job: ${queueError.message}`,
+      };
+
+      try {
+        serverIo.of(browserId).emit('run-completed', failureSocketData);
+        serverIo.of('/queued-run').to(`user-${userId}`).emit('run-completed', failureSocketData);
+      } catch (socketError: any) {
+        logger.log('warn', `Failed to emit queue failure for scheduled run ${plainRun.runId}: ${socketError.message}`);
+      }
 
       if (!isDocRobot) {
         try {


### PR DESCRIPTION
What this PR does?

It was noticed that for API/SDK and Scheduled runs the execution didnt occur via the graphite worker queuing system. 

1. This PR centralizes the queuing for all run types
2. Gets rid of separate internal socket logic 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Runs are now queued consistently for all robot types.
  - Duplicate run submissions are prevented through improved job handling.
  - Recording requests return a run ID immediately after submission, without waiting for execution readiness.
  - Run completion updates are provided when scheduling fails.

- **Bug Fixes**
  - Failed run scheduling now marks runs as failed and cleans up remote browser sessions when applicable.
  - Improved reliability when execution jobs cannot be queued.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->