### PR TITLE
fix: empty data run due to page navigation

### DIFF
--- a/server/src/browser-management/inputHandlers.ts
+++ b/server/src/browser-management/inputHandlers.ts
@@ -348,11 +348,6 @@ const handleChangeUrl = async (activeBrowser: RemoteBrowser, page: Page, url: st
         }
 
         if (url) {
-            // Only http(s) URLs are safe to navigate to. Reject any other
-            // scheme (file:, chrome:, about:, data:, javascript:, ftp:, ...)
-            // before touching the workflow generator or Playwright, so that a
-            // malicious recording client cannot read local files or reach
-            // internal services through the shared browser worker.
             const parsed = parseNavigationUrl(url);
             if (!parsed) {
                 logger.log(
@@ -425,7 +420,6 @@ const handleRefresh = async (activeBrowser: RemoteBrowser, page: Page) => {
             timeout: 30000,
         });
 
-        // small stabilization delay like changeUrl
         await page.waitForTimeout(500);
 
         logger.log("debug", `Page refreshed successfully.`);
@@ -515,7 +509,7 @@ const handleClickAction = async (
   page: Page,
   data: {
     selector: string;
-    url: string;
+    url?: string;
     userId: string;
     elementInfo?: any;
     coordinates?: { x: number; y: number };
@@ -528,7 +522,7 @@ const handleClickAction = async (
       return;
     }
 
-    const { selector, url, elementInfo, coordinates, isSPA = false } = data;
+    const { selector, elementInfo, coordinates, isSPA = false } = data;
 
     if (page.isClosed()) {
       logger.log("debug", "Page is closed, cannot remove target attribute");
@@ -589,7 +583,7 @@ const handleClickAction = async (
     }
 
     const generator = activeBrowser.generator;
-    await generator.onDOMClickAction(page, data);
+    await generator.onDOMClickAction(page, { ...data, url: currentUrl });
 
     logger.log("debug", `Click action processed: ${selector}`);
 

--- a/server/src/workflow-management/classes/Generator.ts
+++ b/server/src/workflow-management/classes/Generator.ts
@@ -439,7 +439,7 @@ export class WorkflowGenerator {
 
   public onDOMClickAction = async (page: Page, data: { 
     selector: string, 
-    url: string, 
+    url: string,
     userId: string,
     elementInfo?: any,
     coordinates?: { x: number, y: number }
@@ -448,7 +448,7 @@ export class WorkflowGenerator {
 
     const pair: WhereWhatPair = {
       where: { 
-        url: this.getBestUrl(url),
+        url: this.getBestUrl(url || page.url()),
         selectors: [selector]
       },
       what: [{

--- a/src/components/recorder/DOMBrowserRenderer.tsx
+++ b/src/components/recorder/DOMBrowserRenderer.tsx
@@ -145,7 +145,7 @@ export const DOMBrowserRenderer: React.FC<RRWebDOMBrowserRendererProps> = ({
   } | null>(null);
 
   const { socket } = useSocketStore();
-  const { setLastAction, lastAction } = useGlobalInfoStore();
+  const { setLastAction, lastAction, recordingUrl } = useGlobalInfoStore();
 
   const { state } = useContext(AuthContext);
   const { user } = state;
@@ -448,6 +448,7 @@ export const DOMBrowserRenderer: React.FC<RRWebDOMBrowserRendererProps> = ({
           if (selector && socket) {
             socket.emit("dom:click", {
               selector,
+              url: recordingUrl,
               userId: user?.id || "unknown",
               elementInfo,
               coordinates: undefined,
@@ -569,6 +570,7 @@ export const DOMBrowserRenderer: React.FC<RRWebDOMBrowserRendererProps> = ({
 
             socket.emit("dom:click", {
               selector,
+              url: recordingUrl,
               userId: user?.id || "unknown",
               elementInfo,
               coordinates: { x: relativeX, y: relativeY },
@@ -577,6 +579,7 @@ export const DOMBrowserRenderer: React.FC<RRWebDOMBrowserRendererProps> = ({
           } else if (elementInfo?.tagName !== "SELECT") {
             socket.emit("dom:click", {
               selector,
+              url: recordingUrl,
               userId: user?.id || "unknown",
               elementInfo,
               coordinates: { x: iframeX, y: iframeY },
@@ -783,6 +786,7 @@ export const DOMBrowserRenderer: React.FC<RRWebDOMBrowserRendererProps> = ({
       onElementSelect,
       isInCaptureMode,
       user?.id,
+      recordingUrl,
       onShowDatePicker,
       onShowDropdown,
       onShowTimePicker,


### PR DESCRIPTION
What this PR does?

Fixes the bug that didnt register a click action when a different URL was not provided thereby failing the entire run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Click actions now consistently use the current page URL, improving workflow reliability when recording interactions.
  - Unsupported URL schemes continue to be rejected during navigation.

- **Refactor**
  - Simplified click-action data handling while preserving the existing user-facing workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->